### PR TITLE
Implement logic to check previously generated methods to avoid repetition

### DIFF
--- a/packages/cli/src/types/ts-function.ts
+++ b/packages/cli/src/types/ts-function.ts
@@ -42,6 +42,9 @@ export interface TsFunction {
     /** Temporary property, we will try later to resolve the conflicts correctly */
     hasUnresolvedConflict?: boolean
 
+    /** Ignore function */
+    ignore?: boolean
+
     girTypeName: TypeGirFunction
     /**
      * - Functions are usually exported as global functions in typescript, but can also be static functions of a class


### PR DESCRIPTION
Hello,

This is my implementation of a fix for #92, It also includes some other changes:
 - Move functionHasConflict and related functions to utils.ts
 - Break conflict resolver outer loop as soon as unresolved conflicts are detected
 - Improve resolution between class methods and conflicting inherited ones. Only add as overloads inherited methods that are incompatible with the class implementation
 - Add ignore property to TsFunction, differ from hasUnresolvedConflict as no reference to this function will be included in the generated type definition
 - Introduce tracking of generated functions in type-definition-generator.ts's generateFunction to avoid producing redundant entries

I am opening this as a draft for now, because I think this still needs more tests, and I wanted @JumpLink's input about whether he agrees with this solution, as it has a (minor) performance impact.

Another thing I wanted to discuss is if the case of overlapping input/return types in overloads should be dealt by these changes, or if it should be a separated issue (IMO I think so). This seems to be somewhat common, especially with optional and nullable types and sometimes with overlapping union types
Example (notice the optional for the cancellable argument is the only difference between both `init` definitions):
![image](https://user-images.githubusercontent.com/9082460/192970131-543f6c14-7ad0-4d3a-ac5b-c1b46c0dae5b.png)
