### PR TITLE
fix: use correct gir paths for NixOS

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -37,7 +37,7 @@ export class Config {
         print: false,
         configName: '.ts-for-girrc.js',
         outdir: './@types',
-        girDirectories: OS.platform() === 'darwin' ? ['/usr/local/share/gir-1.0'] : ['/usr/share/gir-1.0'],
+        girDirectories: getDefaultGirDirectories(),
         modules: ['*'],
         ignore: [],
         verbose: false,
@@ -529,4 +529,16 @@ export class Config {
 
         return await this.validate(config)
     }
+}
+
+function getDefaultGirDirectories(): string[] {
+    const girDirectories = OS.platform() === 'darwin' ? ['/usr/local/share/gir-1.0'] : ['/usr/share/gir-1.0']
+    // NixOS does not have a /usr/local/share directory.  Instead, the nix store paths with Gir
+    // files are set as XDG_DATA_DIRS.  See:
+    //   https://github.com/NixOS/nixpkgs/blob/96e18717904dfedcd884541e5a92bf9ff632cf39/pkgs/development/libraries/gobject-introspection/setup-hook.sh#L7-L10
+    const dataDirs = process.env['XDG_DATA_DIRS']?.split(':') || []
+    for (const dataDir of dataDirs) {
+        girDirectories.push(join(dataDir, 'gir-1.0'))
+    }
+    return girDirectories
 }


### PR DESCRIPTION
**Problem:** running the CLI would error on NixOS as it does not have `/usr/share`:

```sh
$ yarn build; and yarn ts-for-gir generate
ERROR: No module found in /usr/share/gir-1.0!
Please make sure that you have installed the necessary gir files.
For example with "sudo apt install libgtk-3-dev" for Gtk3 on Ubuntu or "sudo dnf install gtk3-devel" on Fedora. []
```

**Solution:** use `XDG_DATA_DIRS` as commented in code.  I think this is harmless on other distros.