### PR TITLE
Allow Template to be a string

### DIFF
--- a/packages/lib/templates/Gjs/GObject-2.0.d.ts
+++ b/packages/lib/templates/Gjs/GObject-2.0.d.ts
@@ -23,7 +23,7 @@ export interface MetaInfo<Props, Interfaces, Sigs> {
     Signals?: Sigs
     Implements?: Interfaces
     CssName?: string
-    Template?: Uint8Array | GLib.Bytes
+    Template?: Uint8Array | GLib.Bytes | string
     Children?: string[]
     InternalChildren?: string[]
 }


### PR DESCRIPTION
Template needs to be a string for using paths to UI files instead of loading the data in separately.