### PR TITLE
Add pkg to global

### DIFF
--- a/packages/lib/templates/Gjs/index.d.ts
+++ b/packages/lib/templates/Gjs/index.d.ts
@@ -201,6 +201,8 @@ declare global {
 
         logDomain: string
     }
+  
+    const pkg: typeof Gjs.Package
 
     <% if(!noDOMLib){ %>
     const console: Console


### PR DESCRIPTION
According to the [docs](https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/Package/Specification.md), `pkg` is a global object. It should be made available for ESM projects that avoids using `imports`.