### PR TITLE
fix(node-gtk): override array type only on gjs, fixes #127

### DIFF
--- a/packages/lib/src/gir-module.ts
+++ b/packages/lib/src/gir-module.ts
@@ -598,7 +598,7 @@ export class GirModule {
             arrayType = typeArray[0]
         }
 
-        if (isArray && arrayType?.$?.name && ARRAY_TYPE_MAP[arrayType.$.name]) {
+        if (this.config.environment == 'gjs' && isArray && arrayType?.$?.name && ARRAY_TYPE_MAP[arrayType.$.name]) {
             isArray = false
             overrideTypeName = ARRAY_TYPE_MAP[arrayType.$.name] as string | undefined
         }


### PR DESCRIPTION
Node-gtk doesn't do array type override.