### PR TITLE
Add type for import.meta.url

### DIFF
--- a/packages/generator-typescript/templates/gjs/dom.d.ts
+++ b/packages/generator-typescript/templates/gjs/dom.d.ts
@@ -13,6 +13,15 @@
 
 declare global {
 
+    interface ImportMeta {
+        /**
+         * The absolute file: or resource: URL of the module.
+         *
+         * @see https://gitlab.gnome.org/GNOME/gjs/-/blob/master/doc/ESModules.md#importmetaurl
+         */
+        readonly url: string;
+    }
+
     // Timers
     // See https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/esm/_timers.js
 


### PR DESCRIPTION
Add to dom compatibility module because Typescript also defines this in its dom module, see https://github.com/saschanaz/types-web/blob/87cdc80239a5218065a4bde410583f0488b3073b/baselines/dom.generated.d.ts#L661

Closes https://github.com/gjsify/types/issues/4
