### PR TITLE
fix(#195): Enable instanceof checks

### DIFF
--- a/examples/gio-2-cat/main.ts
+++ b/examples/gio-2-cat/main.ts
@@ -11,33 +11,37 @@
  * the label should show a translation of 'Print help'
  */
 
-import '@girs/gjs';
-import '@girs/gjs/dom';
-import GLib from '@girs/glib-2.0';
-import Gio from '@girs/gio-2.0';
+import '@girs/gjs'
+import '@girs/gjs/dom'
+import GLib from '@girs/glib-2.0'
+import Gio from '@girs/gio-2.0'
 
-const loop = GLib.MainLoop.new(null, false);
+const loop = GLib.MainLoop.new(null, false)
 const textDecoder = new TextDecoder()
 
 function cat(filename: string) {
-    const file = Gio.file_new_for_path(filename);
-    file.load_contents_async(null, (obj, res) => {
-        let contents: Uint8Array;
-        try {
-            contents = obj!.load_contents_finish(res)![1];
-        } catch (e) {
-            logError(e);
-            loop.quit();
-            return;
-        }
-        print(textDecoder.decode(contents));
-        loop.quit();
-    });
+    const file = Gio.file_new_for_path(filename)
 
-    loop.run();
+    file.load_contents_async(null, (obj, res) => {
+        let contents: Uint8Array
+        try {
+            contents = obj!.load_contents_finish(res)![1]
+        } catch (e) {
+            logError(e)
+            loop.quit()
+            return
+        }
+        print(textDecoder.decode(contents))
+        loop.quit()
+    })
+
+    // Tests instanceof, see https://github.com/gjsify/ts-for-gir/issues/195
+    if (!(file instanceof Gio.File)) {
+        throw new Error('file is not an instance of Gio.File')
+    }
+
+    loop.run()
 }
 
-if (ARGV.length !== 1)
-    printerr('Usage: gio-cat.js filename');
-else
-    cat(ARGV[0]);
+if (ARGV.length !== 1) printerr('Usage: gio-cat.js filename')
+else cat(ARGV[0])

--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -217,7 +217,11 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
         ]
     }
     generateInterfaceDeclaration(node: IntrospectedInterface): string[] {
-        return [`\n\nexport const ${node.name}: ${node.name}Namespace;\n`]
+        return [
+            `\n\nexport const ${node.name}: ${node.name}Namespace & {
+        new (): ${node.name} // This allows \`obj instanceof ${node.name}\`
+    }\n`,
+        ]
     }
     generateError(node: IntrospectedError): string[] {
         const { namespace } = this


### PR DESCRIPTION
Enable `instanceof` checks by adding constructor to interface declaration. Fixes #195 