### PR TITLE
fix(gio): Correct types for overridden `ActionMap.add_action_entries` method

### DIFF
--- a/examples/gio-2-action-entries/main.ts
+++ b/examples/gio-2-action-entries/main.ts
@@ -1,0 +1,93 @@
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+
+export class ExampleApplication extends Gio.Application {
+    static {
+        GObject.registerClass({
+            GTypeName: 'ExampleApplication'
+        }, this);
+    }
+
+    constructor() {
+        super({
+            application_id: 'org.example.ActionEntries',
+            flags: Gio.ApplicationFlags.FLAGS_NONE,
+        });
+        this.initActions();
+    }
+
+    private initActions() {
+        // Define multiple actions at once using ActionEntryObj type
+        const actions: Gio.ActionEntryObj[] = [
+            // Simple action without state or parameter
+            {
+                name: 'quit',
+                activate: () => {
+                    console.log('Quitting application...');
+                    this.quit();
+                },
+            },
+
+            // Action with parameter
+            {
+                name: 'greet',
+                parameter_type: 's',  // GVariant type string for string parameter
+                activate: (_action, parameter) => {
+                    if (parameter) {
+                        const name = parameter.get_string()[0];
+                        console.log(`Hello, ${name}!`);
+                    }
+                },
+            },
+
+            // Stateful toggle action
+            {
+                name: 'dark-mode',
+                state: 'false',  // Initial state as string
+                change_state: (_action, value) => {
+                    if (value) {
+                        const isDark = value.get_boolean();
+                        console.log(`Dark mode ${isDark ? 'enabled' : 'disabled'}`);
+                        // Get the action and set its state
+                        const action = this.lookup_action('dark-mode') as Gio.SimpleAction;
+                        action.set_state(value);
+                    }
+                },
+            },
+
+            // Action with optional parameter
+            {
+                name: 'save',
+                parameter_type: '(sb)',  // Tuple of string and boolean
+                activate: (_action, parameter) => {
+                    if (parameter) {
+                        const [filename, backup] = parameter.deep_unpack() as [string, boolean];
+                        console.log(`Saving ${filename} (backup: ${backup})`);
+                    } else {
+                        console.log('Quick save');
+                    }
+                },
+            },
+        ];
+
+        // Add all actions at once
+        this.add_action_entries(actions);
+    }
+
+    vfunc_activate() {
+        // Test the actions
+        this.activate_action('greet', GLib.Variant.new_string('World'));
+        
+        // For stateful actions, we should use change-state instead of activate
+        const darkModeAction = this.lookup_action('dark-mode') as Gio.SimpleAction;
+        darkModeAction.change_state(GLib.Variant.new_boolean(true));
+        
+        this.activate_action('save', GLib.Variant.new('(sb)', ['document.txt', true]));
+        this.activate_action('quit', null);
+    }
+}
+
+// Run the application
+const app = new ExampleApplication();
+app.run([]);

--- a/examples/gio-2-action-entries/package.json
+++ b/examples/gio-2-action-entries/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@ts-for-gir-example/gio-2-async",
+    "name": "@ts-for-gir-example/gio-2-action-entries",
     "version": "4.0.0-beta.19",
-    "description": "Example demonstrating promisified GIO async operations",
+    "description": "Example demonstrating Gio.ActionEntry",
     "type": "module",
     "private": true,
     "scripts": {

--- a/examples/gio-2-action-entries/tsconfig.json
+++ b/examples/gio-2-action-entries/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+      "lib": ["ESNext"],
+      "types": ["@girs/gjs", "@girs/gjs/dom", "@girs/gio-2.0", "@girs/glib-2.0"],
+      "target": "ESNext", 
+      "module": "ESNext",
+      "moduleResolution": "bundler",
+      "strict": true,
+      "noImplicitAny": true,
+      "strictNullChecks": true,
+      "noImplicitThis": true,
+      "alwaysStrict": true,
+      "outDir": "./dist"
+    },
+    "files": [
+      "main.ts"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12723,12 +12723,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@ts-for-gir-example/gio-2-action-entries@workspace:examples/gio-2-action-entries":
+  version: 0.0.0-use.local
+  resolution: "@ts-for-gir-example/gio-2-action-entries@workspace:examples/gio-2-action-entries"
+  dependencies:
+    "@girs/gio-2.0": "workspace:^"
+    "@girs/gjs": "workspace:^"
+    "@girs/glib-2.0": "workspace:^"
+    typescript: "npm:^5.6.3"
+  languageName: unknown
+  linkType: soft
+
 "@ts-for-gir-example/gio-2-async@workspace:examples/gio-2-async":
   version: 0.0.0-use.local
   resolution: "@ts-for-gir-example/gio-2-async@workspace:examples/gio-2-async"
   dependencies:
     "@girs/gio-2.0": "workspace:^"
     "@girs/gjs": "workspace:^"
+    "@girs/glib-2.0": "workspace:^"
     typescript: "npm:^5.6.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Adds proper TypeScript type definitions for the GJS-overridden `Gio.ActionMap.add_action_entries` method. This includes:

* Correct type definition matching GJS implementation
* Comprehensive documentation with references to GJS override
* Example demonstrating usage with different action types
* Type-safe parameter handling for action callbacks


## Related Issue
Fixes #153 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Type definition update
- [x] Documentation update

## Validation
**Test Location:** `examples/gio-2-action-entries/main.ts`

**Test Case:**
```typescript
import Gio from 'gi://Gio';
import GLib from 'gi://GLib';

const actions: Gio.ActionEntryObj[] = [{
    name: 'example',
    parameter_type: 's',
    activate: (_action, parameter) => {
        if (parameter) {
            const name = parameter.get_string()[0];
            console.log(`Hello, ${name}!`);
        }
    },
}];

// Should compile and work at runtime
this.add_action_entries(actions);
```

**Expected Behavior:**
1. Code should compile without type errors
2. Action entries should be properly typed with correct parameter types
3. Runtime behavior should match GJS override implementation
4. Stateful actions should work with change_state callbacks
5. Parameter types should be properly enforced

## Checklist
<!-- Please check all that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly 