### PR TITLE
Docs: Avoid telling developers on fedora to update their system

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,7 +18,7 @@ sudo apt-get update && sudo apt-get install \
     libadwaita-1-dev
 
 # Fedora
-sudo dnf update && sudo dnf install \
+sudo dnf install \
     libappindicator-gtk3-devel \
     libgda-devel \
     gobject-introspection-devel \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently the development instructions tell fedora users to run `sudo dnf update` before installing the required development packages. Considering the `sudo apt-get update` instruction in the ubuntu guide I'm assuming the intent with that instruction was to make sure people's package managers have an up to date list of available packages but `dnf update` doesn't do that, it just updates all packages on the system.

`dnf` usually takes care of refreshing its cache of package metadata on its own so the fedora instructions should be fine with just `sudo dnf install ...`

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Type definition update
- [x] Documentation update

## Checklist
<!-- Please check all that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly 