### PR TITLE
feat(shell): Add Cogl.SnippetHook support for Shell.GLSLEffect.add_glsl_snippet

### DIFF
--- a/packages/lib/src/injections/inject.ts
+++ b/packages/lib/src/injections/inject.ts
@@ -5,6 +5,7 @@ import tracker1 from "./tracker1.js";
 import gee08 from "./gee08.js";
 import gee1 from "./gee1.js";
 import gtk4 from "./gtk4.js";
+import { shell14, shell15 } from "./shell.js";
 import { IntrospectedNamespace } from "../gir/namespace.js";
 import { NSRegistry } from "../gir/registry.js";
 
@@ -37,4 +38,6 @@ export function inject(registry: NSRegistry) {
     $_(gee08);
     $_(gee1);
     $_(gtk4);
+    $_(shell14);
+    $_(shell15);
 }

--- a/packages/lib/src/injections/shell.ts
+++ b/packages/lib/src/injections/shell.ts
@@ -1,0 +1,45 @@
+import { IntrospectedNamespace } from "../gir/namespace.js";
+import { TypeIdentifier, OrType, NullableType } from "../gir.js";
+import { NSRegistry } from "../gir/registry.js";
+
+const shellTemplate = (version: string) => ({
+    namespace: "Shell",
+    version,
+    modifier(namespace: IntrospectedNamespace, registry: NSRegistry) {
+        // Get the GLSLEffect class which contains the add_glsl_snippet method
+        const GLSLEffect = namespace.assertClass("GLSLEffect");
+        
+        // Find the add_glsl_snippet method
+        const addGlslSnippet = GLSLEffect.members.find(m => m.name === "add_glsl_snippet");
+        
+        // Change
+        // ```ts
+        // add_glsl_snippet(hook: SnippetHook | null, declarations: string, code: string, is_replace: boolean): void;
+        // ```
+        // to
+        // ```ts
+        // add_glsl_snippet(hook: SnippetHook | Cogl.SnippetHook | null, declarations: string, code: string, is_replace: boolean): void;
+        // ```
+        
+        if (addGlslSnippet) {
+            // Create a new parameter with updated type using copy()
+            const updatedParameter = addGlslSnippet.parameters[0].copy({
+                type: new NullableType(
+                    new OrType(
+                        new TypeIdentifier("SnippetHook", "Shell"),
+                        new TypeIdentifier("SnippetHook", "Cogl")
+                    )
+                )
+            });
+            
+            // Replace the original parameter
+            addGlslSnippet.parameters[0] = updatedParameter;
+        }
+    }
+});
+
+/** Shell 14 was introduced with GNOME 45 */
+export const shell14 = shellTemplate("14");
+
+/** Shell 15 was introduced with GNOME 48 */
+export const shell15 = shellTemplate("15");


### PR DESCRIPTION
This PR adds support for using `Cogl.SnippetHook` in `Shell.GLSLEffect.add_glsl_snippet()` method, which is required for GNOME Shell 48+ where `Shell.SnippetHook.FRAGMENT` was removed in favor of `Cogl.SnippetHook.FRAGMENT`.

## Changes
- Added support for both `Shell.SnippetHook` and `Cogl.SnippetHook` in the type definitions for Shell-14 and Shell-15
- Updated the injection logic to handle both hook types
- Added Shell 14 and 15 injections to the main inject function

## Context
Starting with GNOME 48, `Shell.SnippetHook.FRAGMENT` was removed and developers are required to use `Cogl.SnippetHook.FRAGMENT` instead. This change is documented in the [GNOME Shell 48 upgrade guide](https://gjs.guide/extensions/upgrading/gnome-shell-48.html#cogl-snippethook).

The type definitions now support both hook types to maintain compatibility with both GNOME 45-47 (Shell-14) and GNOME 48+ (Shell-15).

## Testing

Example usage that now works:
```typescript
this.add_glsl_snippet(Cogl.SnippetHook.FRAGMENT, '', '', false);
```

Fixes #234
