### PR TITLE
Gtk 4 generics should not be required

### DIFF
--- a/packages/lib/src/generics/generify.ts
+++ b/packages/lib/src/generics/generify.ts
@@ -32,8 +32,9 @@ export function generify(registry: NSRegistry, inferGenerics: boolean) {
 
     $(gio);
     $(glib);
-    $(gtk);
     const $_ = generifyDefinitions(registry, inferGenerics, false);
+
+    $_(gtk);
 
     $_(clutter10);
     $_(clutter11);


### PR DESCRIPTION
This fixes #248

@ewlsh Is there any specific reason why you have marked Gtk 4 generics as required?