### PR TITLE
fix(gobject): make bind_property_full Closure parameters nullable

### DIFF
--- a/examples/gobject-param-spec/README.md
+++ b/examples/gobject-param-spec/README.md
@@ -1,0 +1,88 @@
+# GObject ParamSpec Example
+
+This example demonstrates how to use GObject property specifications (ParamSpec) and property binding in TypeScript with GJS.
+
+## Features Demonstrated
+
+### ParamSpec Usage
+- String properties with full documentation (nick and blurb)
+- Properties with minimal documentation (null nick and blurb) 
+- Integer properties with ranges
+- Boolean properties
+- Object properties (Gio.File)
+
+### Property Access Methods
+- Direct property access via getters/setters
+- `get_property()` and `set_property()` with GObject.Value
+- Property introspection using `list_properties()`
+
+### Property Binding
+This example shows how to bind properties between GObject instances using `bind_property_full()`. Property binding automatically synchronizes values between source and target objects.
+
+The binding examples demonstrate:
+1. **Simple property binding** - changes in source property automatically update target
+2. **Bidirectional binding** - changes in either source or target update the other
+3. **Sync create binding** - target immediately gets source value when binding is created
+4. **Property notifications** - how to trigger binding updates manually
+
+```typescript
+// Simple property binding with default transformation
+const binding = sourceObj.bind_property_full(
+    'property-name',
+    targetObj,
+    'property-name',
+    GObject.BindingFlags.DEFAULT,
+    null, // Use default transformation
+    null  // Use default reverse transformation
+);
+
+// Bidirectional binding
+const binding = sourceObj.bind_property_full(
+    'count',
+    targetObj,
+    'count',
+    GObject.BindingFlags.BIDIRECTIONAL,
+    null, // No custom transformation needed
+    null  // No custom reverse transformation needed
+);
+```
+
+## Running the Example
+
+```bash
+yarn install
+yarn build
+yarn start
+```
+
+## Key Learning Points
+
+1. **ParamSpec Creation**: Different ways to create property specifications with varying levels of documentation
+2. **Property Binding**: How to bind properties between GObject instances for automatic synchronization
+3. **Type Safety**: TypeScript provides full type checking for property names and values
+4. **Property Notifications**: Understanding when and how property changes are propagated
+5. **Binding Lifecycle**: How to create, use, and clean up property bindings
+
+## Property Binding Patterns
+
+### Default Binding
+Use `null` for transformation functions when no custom conversion is needed:
+```typescript
+sourceObj.bind_property_full('prop', targetObj, 'prop', flags, null, null);
+```
+
+### With Custom Transformation
+Provide Closure objects when custom value transformation is required:
+```typescript
+const transformTo = new GObject.Closure(/* transformation function */);
+sourceObj.bind_property_full('prop', targetObj, 'prop', flags, transformTo, null);
+```
+
+### Binding Flags
+- `DEFAULT`: One-way binding from source to target
+- `BIDIRECTIONAL`: Two-way binding between source and target
+- `SYNC_CREATE`: Immediately sync target with source value on creation
+
+## Technical Details
+
+Property binding in GObject allows automatic synchronization of values between object properties. The `bind_property_full()` method provides complete control over binding behavior, including the ability to use default transformations by passing `null` for the transformation functions when no custom conversion is needed. 

--- a/examples/gobject-param-spec/main.ts
+++ b/examples/gobject-param-spec/main.ts
@@ -216,3 +216,116 @@ stringValue.unset();
 boolValue.unset();
 intValue.unset();
 objectValue.unset();
+
+// Demonstrate property binding between GObject instances
+console.log('\n=== Property Binding Examples ===');
+
+// Create two ExampleObject instances for property binding
+const sourceObj = new ExampleObject();
+const targetObj = new ExampleObject();
+
+// Set initial values
+sourceObj.full_property = 'Source Value';
+sourceObj.count = 25;
+sourceObj.active = true;
+
+targetObj.full_property = 'Target Value';
+targetObj.count = 0;
+targetObj.active = false;
+
+console.log('\nBefore binding:');
+console.log('Source full_property:', sourceObj.full_property);
+console.log('Target full_property:', targetObj.full_property);
+console.log('Source count:', sourceObj.count);
+console.log('Target count:', targetObj.count);
+console.log('Source active:', sourceObj.active);
+console.log('Target active:', targetObj.active);
+
+// Example 1: Simple property binding with default transformation
+console.log('\nExample 1: Simple property binding');
+const binding1 = sourceObj.bind_property_full(
+    'full-property',
+    targetObj,
+    'full-property',
+    GObject.BindingFlags.DEFAULT,
+    null, // Use default transformation (no custom conversion needed)
+    null  // Use default reverse transformation (not used in DEFAULT mode)
+);
+
+console.log('✅ Property binding created successfully');
+
+// Test the binding by changing the source value using notify
+sourceObj.full_property = 'Updated Source Value';
+sourceObj.notify('full-property'); // Trigger property change notification
+console.log('Source full_property changed to:', sourceObj.full_property);
+console.log('Target full_property now:', targetObj.full_property);
+
+// Example 2: Bidirectional binding
+console.log('\nExample 2: Bidirectional property binding');
+const binding2 = sourceObj.bind_property_full(
+    'count',
+    targetObj,
+    'count',
+    GObject.BindingFlags.BIDIRECTIONAL,
+    null, // Use default transformation for source-to-target
+    null  // Use default transformation for target-to-source
+);
+
+console.log('✅ Bidirectional binding created successfully');
+
+// Test bidirectional binding by changing both source and target
+sourceObj.count = 50;
+sourceObj.notify('count');
+console.log('Source count changed to:', sourceObj.count);
+console.log('Target count now:', targetObj.count);
+
+targetObj.count = 75;
+targetObj.notify('count');
+console.log('Target count changed to:', targetObj.count);
+console.log('Source count now:', sourceObj.count);
+
+// Example 3: Sync create binding
+console.log('\nExample 3: Binding with immediate synchronization');
+const binding3 = sourceObj.bind_property_full(
+    'active',
+    targetObj,
+    'active',
+    GObject.BindingFlags.SYNC_CREATE,
+    null, // Use default transformation
+    null  // Use default reverse transformation
+);
+
+console.log('✅ Sync create binding created successfully');
+console.log('Target active after sync create binding:', targetObj.active);
+
+// Test the binding by changing the source value
+sourceObj.active = false;
+sourceObj.notify('active');
+console.log('Source active changed to:', sourceObj.active);
+console.log('Target active now:', targetObj.active);
+
+// Example 4: Property changes using set_property
+console.log('\nExample 4: Property changes using set_property');
+const bindingStringValue = new GObject.Value();
+bindingStringValue.init(GObject.TYPE_STRING);
+bindingStringValue.set_string('Set via GObject.Value');
+sourceObj.set_property('full-property', bindingStringValue);
+console.log('Source full_property set via set_property to:', sourceObj.full_property);
+console.log('Target full_property now:', targetObj.full_property);
+bindingStringValue.unset();
+
+// Demonstrate that binding objects are returned and can be used
+console.log('\nBinding objects returned:');
+console.log('Binding 1 source:', binding1.get_source()?.constructor.name);
+console.log('Binding 1 target:', binding1.get_target()?.constructor.name);
+console.log('Binding 1 source property:', binding1.get_source_property());
+console.log('Binding 1 target property:', binding1.get_target_property());
+
+// Clean up bindings (optional, they will be cleaned up automatically when objects are destroyed)
+binding1.unbind();
+binding2.unbind();
+binding3.unbind();
+
+console.log('\n✅ All property binding examples completed successfully!');
+console.log('This demonstrates proper usage of bind_property_full() with different binding modes.');
+console.log('Using null for transformation functions provides default behavior without custom conversion.');


### PR DESCRIPTION
## Fix bind_property_full Closure parameters nullability

### Problem
The `bind_property_full` method in GObject had incorrect TypeScript type definitions where the `transform_to` and `transform_from` parameters were typed as `Closure` instead of `Closure | null`. This prevented users from passing `null` values for these parameters, even though the documentation clearly states "or %NULL to use the default".

### Root Cause
In the GObject-2.0.gir file, the `bind_property_with_closures` method (which shadows `bind_property_full`) is missing the `nullable="1"` and `allow-none="1"` attributes for its Closure parameters, despite the documentation indicating they can be null. This is an upstream bug in the GIR file.

Interestingly, the `BindingGroup.bind_with_closures` method has the same parameters correctly marked as nullable, showing the inconsistency.

### Solution
Added a specific fix in `packages/lib/src/injections/gobject.ts` that:

1. Finds the `bind_property_full` method that uses Closure parameters (the shadowed version)
2. Creates corrected parameters where `transform_to` and `transform_from` are nullable
3. Replaces the method with the corrected version

### Before
```typescript
bind_property_full(
    source_property: string,
    target: Object,
    target_property: string,
    flags: BindingFlags | null,
    transform_to: Closure,      // ❌ Not nullable
    transform_from: Closure,    // ❌ Not nullable
): Binding;
```

### After
```typescript
bind_property_full(
    source_property: string,
    target: Object,
    target_property: string,
    flags: BindingFlags | null,
    transform_to: Closure | null,   // ✅ Now nullable
    transform_from: Closure | null, // ✅ Now nullable
): Binding;
```

### Testing
- [x] Generated types now show correct nullable Closure parameters
- [x] Fix is specific to the problematic method and doesn't affect other functionality
- [x] Maintains compatibility with existing code that passes non-null Closures

Fixes #255