### PR TITLE
chore: Update package dependencies to latest versions

### DIFF
--- a/examples/adw-1-hello/package.json
+++ b/examples/adw-1-hello/package.json
@@ -19,7 +19,7 @@
 	"license": "MIT",
 	"devDependencies": {
 		"typescript": "^5.8.3",
-		"vite": "^6.3.5"
+		"vite": "^7.0.0"
 	},
 	"dependencies": {
 		"@girs/adw-1": "workspace:^",

--- a/examples/gtk-3-editor/package.json
+++ b/examples/gtk-3-editor/package.json
@@ -28,10 +28,10 @@
 	"author": "",
 	"license": "Apache-2.0",
 	"devDependencies": {
-		"@parcel/config-default": "^2.15.2",
-		"@parcel/plugin": "^2.15.2",
-		"@parcel/resolver-default": "^2.15.2",
-		"parcel": "^2.15.2",
+		"@parcel/config-default": "^2.15.4",
+		"@parcel/plugin": "^2.15.4",
+		"@parcel/resolver-default": "^2.15.4",
+		"parcel": "^2.15.4",
 		"parcel-plugin-externals": "^0.5.2",
 		"typescript": "^5.8.3"
 	},

--- a/examples/gtk-3-hello/package.json
+++ b/examples/gtk-3-hello/package.json
@@ -20,7 +20,7 @@
 	"license": "Apache-2.0",
 	"devDependencies": {
 		"@rollup/plugin-node-resolve": "^16.0.1",
-		"rollup": "^4.43.0",
+		"rollup": "^4.44.0",
 		"typescript": "^5.8.3"
 	},
 	"dependencies": {

--- a/examples/gtk-4-template-vite/package.json
+++ b/examples/gtk-4-template-vite/package.json
@@ -19,7 +19,7 @@
 	"license": "MIT",
 	"devDependencies": {
 		"typescript": "^5.8.3",
-		"vite": "^6.3.5"
+		"vite": "^7.0.0"
 	},
 	"dependencies": {
 		"@girs/gdk-4.0": "workspace:^",

--- a/examples/soup-3-http/package.json
+++ b/examples/soup-3-http/package.json
@@ -18,7 +18,7 @@
 	"author": "Pascal Garber <pascal@artandcode.studio>",
 	"license": "MIT",
 	"devDependencies": {
-		"concurrently": "^9.1.2",
+		"concurrently": "^9.2.0",
 		"esbuild": "^0.25.5",
 		"typescript": "^5.8.3"
 	},

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.0.5",
 		"@ts-for-gir/cli": "workspace:^",
-		"concurrently": "^9.1.2",
+		"concurrently": "^9.2.0",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3"
 	},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
 	"devDependencies": {
 		"@types/ejs": "^3.1.5",
 		"@types/inquirer": "^9.0.8",
-		"@types/node": "^24.0.1",
+		"@types/node": "^24.0.4",
 		"@types/yargs": "^17.0.33",
 		"dpdm": "^3.14.0",
 		"esbuild": "^0.25.5",
@@ -82,7 +82,7 @@
 		"ejs": "^3.1.10",
 		"glob": "^11.0.3",
 		"inquirer": "^12.6.3",
-		"prettier": "^3.6.0",
+		"prettier": "^3.6.1",
 		"yargs": "^18.0.0"
 	}
 }

--- a/packages/generator-base/package.json
+++ b/packages/generator-base/package.json
@@ -32,7 +32,7 @@
 		".": "./src/index.ts"
 	},
 	"devDependencies": {
-		"@types/node": "^24.0.1",
+		"@types/node": "^24.0.4",
 		"typescript": "^5.8.3"
 	},
 	"dependencies": {

--- a/packages/generator-html-doc/package.json
+++ b/packages/generator-html-doc/package.json
@@ -35,7 +35,7 @@
 		".": "./src/index.ts"
 	},
 	"devDependencies": {
-		"@types/node": "^24.0.1",
+		"@types/node": "^24.0.4",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3"
 	},

--- a/packages/generator-typescript/package.json
+++ b/packages/generator-typescript/package.json
@@ -33,7 +33,7 @@
 	],
 	"devDependencies": {
 		"@types/ejs": "^3.1.5",
-		"@types/node": "^24.0.1",
+		"@types/node": "^24.0.4",
 		"@types/xml2js": "^0.4.14",
 		"typescript": "^5.8.3"
 	},

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -43,8 +43,8 @@
 	],
 	"devDependencies": {
 		"@types/ejs": "^3.1.5",
-		"@types/lodash": "^4.17.17",
-		"@types/node": "^24.0.1",
+		"@types/lodash": "^4.17.18",
+		"@types/node": "^24.0.4",
 		"rimraf": "^6.0.1",
 		"typescript": "^5.8.3"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -11596,17 +11596,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/bundler-default@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/bundler-default@npm:2.15.2"
+"@parcel/bundler-default@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/bundler-default@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/graph": "npm:3.5.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/graph": "npm:3.5.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/a83bceadfd2223667379b28f32f5fbabe2a58924a785483aeae733002500ff8788215d4c840d746c02d8a72935374ae7845b065e5648c0b787bd34459bcfe023
+  checksum: 10/6ff4fc908e335747ff57a1aaf7f348ab9887c0b9ff49388239c1ff76d2d0ba2cb15ff744ac9a876dde216c241a26e8bd559deb6476be305acd0c35684659a115
   languageName: node
   linkType: hard
 
@@ -11624,17 +11624,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/cache@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/cache@npm:2.15.2"
+"@parcel/cache@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/cache@npm:2.15.4"
   dependencies:
-    "@parcel/fs": "npm:2.15.2"
-    "@parcel/logger": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/fs": "npm:2.15.4"
+    "@parcel/logger": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     lmdb: "npm:2.8.5"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/ebfb49774b8164f2aa74cd14ca6c39c52c5cffb76d30b1da7dd4fbadbd34b37466c0e9ba2b8b6c553a65424dabead90ea44d048f7930d5be5a5ef5c76acfb298
+    "@parcel/core": ^2.15.4
+  checksum: 10/f4517c7845220925b3ccc626a0d66ef12dd90d59947ab9dca8b19edbd4f0cf4dafca6f4702ac5c8950621cbb6fd96bb6d0dbd27c6269fb3ee0a4adfa64fd87e0
   languageName: node
   linkType: hard
 
@@ -11647,63 +11647,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/codeframe@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/codeframe@npm:2.15.2"
+"@parcel/codeframe@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/codeframe@npm:2.15.4"
   dependencies:
     chalk: "npm:^4.1.2"
-  checksum: 10/c30f308c152d779451fb575039c04f3ad2270791e0ad36de5e25728f1460386d567654ece47b081329e2d4b47bd99964b6e18546508954044cf2d61138303345
+  checksum: 10/3dea557ac84f34d36e2d40664798537713a58d430c2c791eeef2bb13b0c769c3adc2b4c9215a9c1590047e0f69f6b4c91eb4fe54ecc5cd37f6f81c0d378e2d1d
   languageName: node
   linkType: hard
 
-"@parcel/compressor-raw@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/compressor-raw@npm:2.15.2"
+"@parcel/compressor-raw@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/compressor-raw@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-  checksum: 10/9b9ba57cd7125c298228699fe3df9fe1b7d6e306ad601aefe9f4459beeceec616432e428ab2119342eea699047f75ca234ad2c208bee9ecdfea76c8f3648608d
+    "@parcel/plugin": "npm:2.15.4"
+  checksum: 10/337b83c4b8973eb2b6592c665e63cd2be733ba61801e01face616aa831a7f74d2f70bc3c467f7fcc44d2e00c6f656633ae68fbbb40ce0e23b989ae8a53ab50d0
   languageName: node
   linkType: hard
 
-"@parcel/config-default@npm:2.15.2, @parcel/config-default@npm:^2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/config-default@npm:2.15.2"
+"@parcel/config-default@npm:2.15.4, @parcel/config-default@npm:^2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/config-default@npm:2.15.4"
   dependencies:
-    "@parcel/bundler-default": "npm:2.15.2"
-    "@parcel/compressor-raw": "npm:2.15.2"
-    "@parcel/namer-default": "npm:2.15.2"
-    "@parcel/optimizer-css": "npm:2.15.2"
-    "@parcel/optimizer-html": "npm:2.15.2"
-    "@parcel/optimizer-image": "npm:2.15.2"
-    "@parcel/optimizer-svg": "npm:2.15.2"
-    "@parcel/optimizer-swc": "npm:2.15.2"
-    "@parcel/packager-css": "npm:2.15.2"
-    "@parcel/packager-html": "npm:2.15.2"
-    "@parcel/packager-js": "npm:2.15.2"
-    "@parcel/packager-raw": "npm:2.15.2"
-    "@parcel/packager-svg": "npm:2.15.2"
-    "@parcel/packager-wasm": "npm:2.15.2"
-    "@parcel/reporter-dev-server": "npm:2.15.2"
-    "@parcel/resolver-default": "npm:2.15.2"
-    "@parcel/runtime-browser-hmr": "npm:2.15.2"
-    "@parcel/runtime-js": "npm:2.15.2"
-    "@parcel/runtime-rsc": "npm:2.15.2"
-    "@parcel/runtime-service-worker": "npm:2.15.2"
-    "@parcel/transformer-babel": "npm:2.15.2"
-    "@parcel/transformer-css": "npm:2.15.2"
-    "@parcel/transformer-html": "npm:2.15.2"
-    "@parcel/transformer-image": "npm:2.15.2"
-    "@parcel/transformer-js": "npm:2.15.2"
-    "@parcel/transformer-json": "npm:2.15.2"
-    "@parcel/transformer-node": "npm:2.15.2"
-    "@parcel/transformer-postcss": "npm:2.15.2"
-    "@parcel/transformer-posthtml": "npm:2.15.2"
-    "@parcel/transformer-raw": "npm:2.15.2"
-    "@parcel/transformer-react-refresh-wrap": "npm:2.15.2"
-    "@parcel/transformer-svg": "npm:2.15.2"
+    "@parcel/bundler-default": "npm:2.15.4"
+    "@parcel/compressor-raw": "npm:2.15.4"
+    "@parcel/namer-default": "npm:2.15.4"
+    "@parcel/optimizer-css": "npm:2.15.4"
+    "@parcel/optimizer-html": "npm:2.15.4"
+    "@parcel/optimizer-image": "npm:2.15.4"
+    "@parcel/optimizer-svg": "npm:2.15.4"
+    "@parcel/optimizer-swc": "npm:2.15.4"
+    "@parcel/packager-css": "npm:2.15.4"
+    "@parcel/packager-html": "npm:2.15.4"
+    "@parcel/packager-js": "npm:2.15.4"
+    "@parcel/packager-raw": "npm:2.15.4"
+    "@parcel/packager-svg": "npm:2.15.4"
+    "@parcel/packager-wasm": "npm:2.15.4"
+    "@parcel/reporter-dev-server": "npm:2.15.4"
+    "@parcel/resolver-default": "npm:2.15.4"
+    "@parcel/runtime-browser-hmr": "npm:2.15.4"
+    "@parcel/runtime-js": "npm:2.15.4"
+    "@parcel/runtime-rsc": "npm:2.15.4"
+    "@parcel/runtime-service-worker": "npm:2.15.4"
+    "@parcel/transformer-babel": "npm:2.15.4"
+    "@parcel/transformer-css": "npm:2.15.4"
+    "@parcel/transformer-html": "npm:2.15.4"
+    "@parcel/transformer-image": "npm:2.15.4"
+    "@parcel/transformer-js": "npm:2.15.4"
+    "@parcel/transformer-json": "npm:2.15.4"
+    "@parcel/transformer-node": "npm:2.15.4"
+    "@parcel/transformer-postcss": "npm:2.15.4"
+    "@parcel/transformer-posthtml": "npm:2.15.4"
+    "@parcel/transformer-raw": "npm:2.15.4"
+    "@parcel/transformer-react-refresh-wrap": "npm:2.15.4"
+    "@parcel/transformer-svg": "npm:2.15.4"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/f37042aa8f5442abdf81c0dcbd26f081c7690d689199c903a64f9be4159ec7b0c626c3acb0cb03ff9e5a3ed34625aaf0d685989a9cc1b5a7309a3c8c8a803a82
+    "@parcel/core": ^2.15.4
+  checksum: 10/8e1d904c664df824d0ba1f3e021de5966a4b0961903a35f7b2968bab63a404ce4a6efb3b9d1ef1b4e40bd3bfd24b86c5a2185cf74d79ea65335eaa7a9f8d8363
   languageName: node
   linkType: hard
 
@@ -11740,26 +11740,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/core@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/core@npm:2.15.2"
+"@parcel/core@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/core@npm:2.15.4"
   dependencies:
     "@mischnic/json-sourcemap": "npm:^0.1.1"
-    "@parcel/cache": "npm:2.15.2"
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/events": "npm:2.15.2"
-    "@parcel/feature-flags": "npm:2.15.2"
-    "@parcel/fs": "npm:2.15.2"
-    "@parcel/graph": "npm:3.5.2"
-    "@parcel/logger": "npm:2.15.2"
-    "@parcel/package-manager": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/profiler": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
+    "@parcel/cache": "npm:2.15.4"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/events": "npm:2.15.4"
+    "@parcel/feature-flags": "npm:2.15.4"
+    "@parcel/fs": "npm:2.15.4"
+    "@parcel/graph": "npm:3.5.4"
+    "@parcel/logger": "npm:2.15.4"
+    "@parcel/package-manager": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/profiler": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/types": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-    "@parcel/workers": "npm:2.15.2"
+    "@parcel/types": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+    "@parcel/workers": "npm:2.15.4"
     base-x: "npm:^3.0.11"
     browserslist: "npm:^4.24.5"
     clone: "npm:^2.1.2"
@@ -11769,7 +11769,7 @@ __metadata:
     msgpackr: "npm:^1.11.2"
     nullthrows: "npm:^1.1.1"
     semver: "npm:^7.7.1"
-  checksum: 10/8e28b94958eab1cafa7404a278b5067298fc2a5b9df821f747b36b5de7984b5edcd874b58841d8c392f3103f502e3bdc4756e7d3f14fb6142831c26288c7016f
+  checksum: 10/ff2544e230f1e64138a53b0d6ec226c182891c95fc3ca68168687b50c46f48a766cf619700f2d7e19a7d7feffc8b2b60f6b3d58929def9f9688ca7c4311d2d44
   languageName: node
   linkType: hard
 
@@ -11783,20 +11783,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/diagnostic@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/diagnostic@npm:2.15.2"
+"@parcel/diagnostic@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/diagnostic@npm:2.15.4"
   dependencies:
     "@mischnic/json-sourcemap": "npm:^0.1.1"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/ef98eb4311888d132512d1c59dbf6fe74456deb5a8930c12d0d958a87f850cb9d296d01446585be0514717bf50618cab42d85042f736bfc8af7651e2c9f04b45
+  checksum: 10/8591d0ccee35292054e90d26dffd6ede8b147ffbfda2e5a295f4ce65e9d618f6787340f3c4975fd66f8b785aaeba4b33184f2dadf73d0c8c1bbb12bfd1e88ff3
   languageName: node
   linkType: hard
 
-"@parcel/error-overlay@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/error-overlay@npm:2.15.2"
-  checksum: 10/c1c5923751f24f3bf1abdb394cfa054a15b38e2605a6bdb30c6db2158c4c92b0c224e82f549df10693bd507f2f2bc6bfd40899fdbf1caf7ebe6f7b3733212019
+"@parcel/error-overlay@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/error-overlay@npm:2.15.4"
+  checksum: 10/d3b4aef037c859cfa7b158b0a214ce73339e1094e94a4b4c6894a13a0d106666f83f2d3ad8bdb7456311883cc4175e974275d5a0bd1070c8e2527e935712fa83
   languageName: node
   linkType: hard
 
@@ -11807,17 +11807,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/events@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/events@npm:2.15.2"
-  checksum: 10/fcf8d1ab0c7c55ade6029808f84f2b4a7db3092906ce0282b9ac0679bb7cbb8603ae4b5f58b39236114546a49bc4aa8a7304f136ce86b1ff90054c2ef5ebd461
+"@parcel/events@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/events@npm:2.15.4"
+  checksum: 10/307b4049d35c7274084416b127de60b8aec3ba2e54145481421cfc80f1122d868d6e6d3ae686462e0dd568a5c22547e29df403c61b12cf221b8ede376681f3bc
   languageName: node
   linkType: hard
 
-"@parcel/feature-flags@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/feature-flags@npm:2.15.2"
-  checksum: 10/237d807ac7327c484d9f28c08912abfd37a87c4939aa865fc60a513d49e618c5713ba158e7a57ea3099df223e2c30fa8fb8d910ff6f96a53fa84aee5423ee11e
+"@parcel/feature-flags@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/feature-flags@npm:2.15.4"
+  checksum: 10/7da7e1d9f64ca99ceb97fb74a07c206d901da5f4f1b0410cb964a70104b1d131ade1a031383090269f081a4fc2403c512d222ab6781b95a5c7082b8ca0286b6d
   languageName: node
   linkType: hard
 
@@ -11836,19 +11836,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/fs@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/fs@npm:2.15.2"
+"@parcel/fs@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/fs@npm:2.15.4"
   dependencies:
-    "@parcel/feature-flags": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/types-internal": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/feature-flags": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/types-internal": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     "@parcel/watcher": "npm:^2.0.7"
-    "@parcel/workers": "npm:2.15.2"
+    "@parcel/workers": "npm:2.15.4"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/e94b8d99528cbfd163783aa46e791bca3e758dd05926d4677a2d6ee0fc510bba89c69f3ba928d8a426f2f2cc1174e04f054293089badccd988b214329cbd7c4d
+    "@parcel/core": ^2.15.4
+  checksum: 10/155681fcbb3afec6097a6bcc473f90f3992461ccb269ee03407a449e4cf59df8c092926206b0301b01cb70794a5c94f57342052aae2ae4f49cc2154e60b59e03
   languageName: node
   linkType: hard
 
@@ -11861,13 +11861,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/graph@npm:3.5.2":
-  version: 3.5.2
-  resolution: "@parcel/graph@npm:3.5.2"
+"@parcel/graph@npm:3.5.4":
+  version: 3.5.4
+  resolution: "@parcel/graph@npm:3.5.4"
   dependencies:
-    "@parcel/feature-flags": "npm:2.15.2"
+    "@parcel/feature-flags": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/4f5d4511a3afa170c4fe07cc831c3111c236919c07873c24dde9fc1704dc2b46b1dc754f9e588afbee65e868b26f0cc528e7638f6ab835cbd45734e8472adb17
+  checksum: 10/850e865b4d789596f1f2281864fed9d8557ae9e14c236b7f34d307142e9a8dcfa8a9788b138ff777f9c06d9fff37e0bc29d9a92ec15f228b10ce650d06bc8eeb
   languageName: node
   linkType: hard
 
@@ -11881,13 +11881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/logger@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/logger@npm:2.15.2"
+"@parcel/logger@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/logger@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/events": "npm:2.15.2"
-  checksum: 10/fdeeff72ab29c786df714bde1a49e3c24f368c05340e1ef32c2044962d254562d3859cb9131d85d9dbafa6ee762014baaee47287b51a1cfcf40fa231d1918abc
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/events": "npm:2.15.4"
+  checksum: 10/a08ca76125c1751eaa4d63dd480d790fb64c07c2aa3bf476ebdede03f104e2a120e64fcd5b301cba6681bd9641b79c84fb28c4a441c8a20f39000b4b3b9f1cb2
   languageName: node
   linkType: hard
 
@@ -11900,23 +11900,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/markdown-ansi@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/markdown-ansi@npm:2.15.2"
+"@parcel/markdown-ansi@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/markdown-ansi@npm:2.15.4"
   dependencies:
     chalk: "npm:^4.1.2"
-  checksum: 10/54a8084a5b869d55526f5febc64819c0a2e2bdc9457a4c4f5498dcb68cb2b966590aca6a2856bdbbbc5c5d25551a3b9c2837cc5dd73e2abe8ad7f06c1fd5ca07
+  checksum: 10/9a7895d86a25c25abef1a740f141645d55ddd0b27d08c9078347f3af74a46ceceb39f98704099e6d0159c68b33241df796a9a3c5f8f2a045fe864758da6c6497
   languageName: node
   linkType: hard
 
-"@parcel/namer-default@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/namer-default@npm:2.15.2"
+"@parcel/namer-default@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/namer-default@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/4010d2d34f7d2ea9fbfec897f2e93323441626d837215d653afa8b9656dca012b4bbddafe2cdb9ff356007f39691c7910a00fe4a5b85d3b32d5d52952c260f66
+  checksum: 10/f9bce0258b370222f183c62cc2c7255db84bfddb40089c767dda1a7bf3eec396ca71f2412c399971f0867a38029c9c4585b3bd8e2c291fd84195245cf44ca2f3
   languageName: node
   linkType: hard
 
@@ -11935,84 +11935,84 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/node-resolver-core@npm:3.6.2":
-  version: 3.6.2
-  resolution: "@parcel/node-resolver-core@npm:3.6.2"
+"@parcel/node-resolver-core@npm:3.6.4":
+  version: 3.6.4
+  resolution: "@parcel/node-resolver-core@npm:3.6.4"
   dependencies:
     "@mischnic/json-sourcemap": "npm:^0.1.1"
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/fs": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/fs": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
     semver: "npm:^7.7.1"
-  checksum: 10/c6084af8581e4f5f11263604402ea9099b2575262153546d46b3c0719a1dbf549489c64130762e2b54798d19a5ebec6ae82e44d451cd6d6711274e720028b8f7
+  checksum: 10/9a0b1d0fd6ee233a5e333c016d843c36e3ef0fd654e865c2efc70bcb0ac10e0dde813078b5dcd6ba76b89f34c1105c527616fabd025fa9013b081af4dcb4b20f
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-css@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/optimizer-css@npm:2.15.2"
+"@parcel/optimizer-css@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/optimizer-css@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/utils": "npm:2.15.4"
     browserslist: "npm:^4.24.5"
     lightningcss: "npm:^1.30.1"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/71806d466d03140b1bdde4182af680f8a2c4bbfd06fd8a297baa61729da3a7ce9544c3baba36e3bfe51ee897cbfa7efd700b2effaebd47aaa6754ec499a663c2
+  checksum: 10/140c809370101063a14606a226bfeaa343caad31a12b33df3a191c32d0812c58eed8d5704796efe65876caa037d60a63a037168d679097da325f5f3449432bcc
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-html@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/optimizer-html@npm:2.15.2"
+"@parcel/optimizer-html@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/optimizer-html@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-  checksum: 10/aa4001257932c239cbb30844b56705e378a20d52837523596846965037b3b70529200fc1ae3d34fd346bab0ab25d30dda610fcd5d65640e0602f1596a0c33493
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+  checksum: 10/7e5ab282e2944465c4a5d234c94a80dfd38cc159de329e9ef824e3d2411df1090b7bb91bd8f39c4640d8f2b09d986934fa93761a7da78e49e6a241b5e92946df
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-image@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/optimizer-image@npm:2.15.2"
+"@parcel/optimizer-image@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/optimizer-image@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-    "@parcel/workers": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+    "@parcel/workers": "npm:2.15.4"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/26e099ad06024175a53860721e5c2eec102158666c5cefa2472fedd96fb5f3c733cde77521ca1069d58a3b627709f7f25c75c914a5bdd7e8b1fc3880393084ef
+    "@parcel/core": ^2.15.4
+  checksum: 10/15b6b9aa0d0f428aac429b821c884c8e1688e7018d3c0b3fd615d13a1a9cc12737cb3bcfc37b29140e3d8f28147221fca94a5d9fb62901526f24aae954962928
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-svg@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/optimizer-svg@npm:2.15.2"
+"@parcel/optimizer-svg@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/optimizer-svg@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-  checksum: 10/9b34a93a3ff238e1eb1fe5e38b1fd40298f9b2c89c514383f3e4a0dbe9146ede76ebbe7ba6d9df5a984a30ff4e2993a36c6c270fcf111c6de98367f4d213b6a2
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+  checksum: 10/a4674c0cda6146f47b7bf637a9a27eca5626ad1855b5dfe01696a93bde2ff71527958cb42dcdccf397f4a24436b8af7605204fa799cbef1b55eddc1715e15ad7
   languageName: node
   linkType: hard
 
-"@parcel/optimizer-swc@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/optimizer-swc@npm:2.15.2"
+"@parcel/optimizer-swc@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/optimizer-swc@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/utils": "npm:2.15.4"
     "@swc/core": "npm:^1.11.24"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/0088757b55456ca3db0012c9ff956aaf9071e9870d242c6512b9c1ca1ace17cfebe63eab1f7c4983cce47cb3603184f81523bbd5d4a33e903dd2808a5f817698
+  checksum: 10/094f3b54f0c7499800d924741df2cbb6510b2aa24e17b840250dee90d85c792f075bc23ff3f0e49e018f5f68881b7bf9f27d90f94235a3356f7b7f9f9a9752a8
   languageName: node
   linkType: hard
 
@@ -12035,94 +12035,94 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/package-manager@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/package-manager@npm:2.15.2"
+"@parcel/package-manager@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/package-manager@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/fs": "npm:2.15.2"
-    "@parcel/logger": "npm:2.15.2"
-    "@parcel/node-resolver-core": "npm:3.6.2"
-    "@parcel/types": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-    "@parcel/workers": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/fs": "npm:2.15.4"
+    "@parcel/logger": "npm:2.15.4"
+    "@parcel/node-resolver-core": "npm:3.6.4"
+    "@parcel/types": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+    "@parcel/workers": "npm:2.15.4"
     "@swc/core": "npm:^1.11.24"
     semver: "npm:^7.7.1"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/ac3ac03ca18fa8bc032e8017927573fb2afdab202b87edcfb4898b1c9c7ead02ca2068fbe9b110301c99ce3cc4a233bd0a4739e5e21dbf6c41738c52ccab3a89
+    "@parcel/core": ^2.15.4
+  checksum: 10/e0fb7de9ddc6f5b2c3b2b0aa084f728075239f82aa9a04fcac18904edb1b2d6b03c75adbdeed31a381f6ea9460fc72282e3172cb2a8475a402fbe16ba2a12efd
   languageName: node
   linkType: hard
 
-"@parcel/packager-css@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/packager-css@npm:2.15.2"
+"@parcel/packager-css@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/packager-css@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/utils": "npm:2.15.4"
     lightningcss: "npm:^1.30.1"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/518d3a182d24f4057a08b337ba66f8575871b9c7d5f33f1513d44678516976c3a0c7ef5b54078db0e69c4cff8b0b7f4b274fe4fedaf6cc3cfaf46e693e1a64e1
+  checksum: 10/3715b91354f536768358a0b7b14bbfd7269888db45653a34ed69b5ba31f57a930b31b0f864dbbdb45faad7dd1fc768521d694fc79811956e227faa497d10cacb
   languageName: node
   linkType: hard
 
-"@parcel/packager-html@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/packager-html@npm:2.15.2"
+"@parcel/packager-html@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/packager-html@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/types": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-  checksum: 10/148547b8b3d13088aca4a2ae42be5d096ca2a78c5d05e9919073cf28561b40a36c27e7914c714bc683604b2616bcee8e80873d9b37c69897efcfa1d6a81cd589
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/types": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+  checksum: 10/f38d3c7727b6fe9f0c6e0e6c30c3dbb35183458f98d95d4890fb081dbe238f50c5f8220766d09a3374eb41b450590fa388f17c1b8a31cdbd9832223ac9a23607
   languageName: node
   linkType: hard
 
-"@parcel/packager-js@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/packager-js@npm:2.15.2"
+"@parcel/packager-js@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/packager-js@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/types": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/types": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     globals: "npm:^13.24.0"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/a226cac4131ea892b2366c2baa6b45a56211f1fd958593076b2e02aced4fec46a89704e284636b7b73129fb82c6dbf481837e23f1ea23998eeea46e6988e751c
+  checksum: 10/d28a9d796fc17fdd9c0d5b56f2ebc645b443a83a4658ab0ed939e53e09e7ec735350fb15b97f171d22ca2b896fa4b18883628314e6396bf141e459fb0c27afd4
   languageName: node
   linkType: hard
 
-"@parcel/packager-raw@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/packager-raw@npm:2.15.2"
+"@parcel/packager-raw@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/packager-raw@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-  checksum: 10/6225f6aeb4fd08e351de1c6a9c6946e6f9e998e312e772a3feaf6996e6dace6611fdc541e64cda53df7955c23b5e309c85cb493d3263170dc4507273335dd2b6
+    "@parcel/plugin": "npm:2.15.4"
+  checksum: 10/f82f995c685b807c07db71e581b1a12498939dfc86fee545e172cad4bb807e818b0205afcdbd53b9f2daec61ca4e5ed5f23278b44ad042568e6a4c6e80a22a99
   languageName: node
   linkType: hard
 
-"@parcel/packager-svg@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/packager-svg@npm:2.15.2"
+"@parcel/packager-svg@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/packager-svg@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/types": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-  checksum: 10/cae3db7f345c500e93b613b720b3b5f733f0dabdf38572928b506dff053c2a34eb461644bd3a6158b635578def1ae4a977a6002ec3350a871f9fda2c81798460
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/types": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+  checksum: 10/aae7fd3a1ef41f8e8f74d51eaa042e457a505b7cd3fd815b053bf12f782cf5d5fb1644efdc92e790fec68ee4e6399fdd4044002caf9fe22a74840bde169fd5f0
   languageName: node
   linkType: hard
 
-"@parcel/packager-wasm@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/packager-wasm@npm:2.15.2"
+"@parcel/packager-wasm@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/packager-wasm@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-  checksum: 10/26992920a264292e1a7c7b7f410ffbe427b8b5a6e94f98c826f052253f344e117c8e03ae41464e3c52a518c1b0a52117bf72b1682229ebdbd346df08bf47f109
+    "@parcel/plugin": "npm:2.15.4"
+  checksum: 10/90e5dd0b15c599bd2ff831fd85ccda8eb9e21d2d478753b869828ea8301c475fbf506910f50f3a203756d37578377436954d42ab0cfc76dfd7af1864ab2cb98f
   languageName: node
   linkType: hard
 
@@ -12135,12 +12135,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/plugin@npm:2.15.2, @parcel/plugin@npm:^2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/plugin@npm:2.15.2"
+"@parcel/plugin@npm:2.15.4, @parcel/plugin@npm:^2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/plugin@npm:2.15.4"
   dependencies:
-    "@parcel/types": "npm:2.15.2"
-  checksum: 10/af353c2a22b5596fd8aac9427e6af2bb005bec09203523830973f34d5841f07dd572612be68a8f35262f8a34d96f9b4276426861adcd6cb0779fa90a40b3c346
+    "@parcel/types": "npm:2.15.4"
+  checksum: 10/528d687143d9c3af45fc8135353cc604c850f1aa72df71d439d04e5b842fa499e8e1ef07b8852aed000d8c457c62df7a3515be81d8a4807cef24b410ed870bfb
   languageName: node
   linkType: hard
 
@@ -12155,162 +12155,162 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/profiler@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/profiler@npm:2.15.2"
+"@parcel/profiler@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/profiler@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/events": "npm:2.15.2"
-    "@parcel/types-internal": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/events": "npm:2.15.4"
+    "@parcel/types-internal": "npm:2.15.4"
     chrome-trace-event: "npm:^1.0.2"
-  checksum: 10/ad9262e48dafd0d87d23fc73bd51b561bfa7af70bce1ca9ab272aaeb01a2a806faa79b17d2068196ef0946210598656d77d1a48c829dbb420be667be69959c34
+  checksum: 10/db3809ee557ac73d8c744da0a08b728e527a079ef257b1fa92960838aa336a9fef265d94676b6ceb92cda203fa9e650ea02f77b07d13db1fa39062551b456a0f
   languageName: node
   linkType: hard
 
-"@parcel/reporter-cli@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/reporter-cli@npm:2.15.2"
+"@parcel/reporter-cli@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/reporter-cli@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/types": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/types": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     chalk: "npm:^4.1.2"
     term-size: "npm:^2.2.1"
-  checksum: 10/d62eff23b0a4f8f7a965e01391ab6bb5f7376b8f4a427e311097da6b7807c41c6805962535d9c86962a688df99257cd118a483abe66f86e5faeb2be3ac29854c
+  checksum: 10/88cbcb7f49a7cca6a21664690b367974764e6fb9e15a190d840f10a12b48c3ffec01428f3a517680e0d0774f0abaeea0b80cba7aa912a078ba796a016aef7ab9
   languageName: node
   linkType: hard
 
-"@parcel/reporter-dev-server@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/reporter-dev-server@npm:2.15.2"
+"@parcel/reporter-dev-server@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/reporter-dev-server@npm:2.15.4"
   dependencies:
-    "@parcel/codeframe": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/codeframe": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.15.2"
-  checksum: 10/4dd2c000e870cc7a1559346bef0250bd9eddaaf8d60376bb9f044eccb6bc488e43c617d2f71c34a3d59db967e90ce3e98cb12e7900d5798f00a059905ddfdaea
+    "@parcel/utils": "npm:2.15.4"
+  checksum: 10/fa09c7d867e9e00ad0bbce33d4cf8251d1aaecf73ec29298ca9ce4f7556fe71c7ae9a7ecada6028ad6bc9ce7291deb8b710253ce0fe1f3a33eb5eada626dd192
   languageName: node
   linkType: hard
 
-"@parcel/reporter-tracer@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/reporter-tracer@npm:2.15.2"
+"@parcel/reporter-tracer@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/reporter-tracer@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     chrome-trace-event: "npm:^1.0.3"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/08b060649e51d6135c797b8e9b11d7bab6f509e58ed273051c601658bb0fd95b1ccbb37df4fa91ef8b90ad93c80faabc32bdddefa34d3774004dd23ee79560b9
+  checksum: 10/083292b23b4026d584d9487989dd9c31947049ad6a75f7926e5c9fecd6aad0a2fee70a869b92ef09f4e25dad691e19fb4f6034f19da959981404bb2ea1884c92
   languageName: node
   linkType: hard
 
-"@parcel/resolver-default@npm:2.15.2, @parcel/resolver-default@npm:^2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/resolver-default@npm:2.15.2"
+"@parcel/resolver-default@npm:2.15.4, @parcel/resolver-default@npm:^2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/resolver-default@npm:2.15.4"
   dependencies:
-    "@parcel/node-resolver-core": "npm:3.6.2"
-    "@parcel/plugin": "npm:2.15.2"
-  checksum: 10/c3b53e336bc88d97416c39877a87cad7c4972239e18271b3265293ac1470d8ad31cf37a29ce3c1f87874e222232f3becf91f561a4f2cb4cd76680d6bb8dc5eed
+    "@parcel/node-resolver-core": "npm:3.6.4"
+    "@parcel/plugin": "npm:2.15.4"
+  checksum: 10/32148a69a2410c0feb71cbceaced6fcaefffe1524c58587000096401447e8d921f5ca0198727742b660b38f12abaa08c281cabf1b64d352d79b058112f297942
   languageName: node
   linkType: hard
 
-"@parcel/runtime-browser-hmr@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/runtime-browser-hmr@npm:2.15.2"
+"@parcel/runtime-browser-hmr@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/runtime-browser-hmr@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-  checksum: 10/acbba7bbf98b8a3904ac0ec557678a92ca44f40aff360e93669d360fcc97a3298f838770c6ec8d0602c341bda1358b1e414f5af1b5c1facc52d58f308d834446
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+  checksum: 10/7484bebda8fd68dcaf62303ab7cdc7584c7f2d1548b336559b81b185aa2f72ea8cf945a1498158782dadff0d0f8d76e98830a46cfed9b2c5e8505d122d840891
   languageName: node
   linkType: hard
 
-"@parcel/runtime-js@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/runtime-js@npm:2.15.2"
+"@parcel/runtime-js@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/runtime-js@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/3c22f46191e81bf226f21549b53580b904759821d7ab54effd5149c49c639fc90d4f68f990e5b51585f5ccc26c4eb8b8d51c1f9d986a72ec16af4accb73415d1
+  checksum: 10/fcebcc800d883d1fb7f5193a904ef977004c0830a4e455bae1784d4e82ba71ff99871ba485de35899ea766509a3f0d41c8642feabdc4245cd1fc8ee916065a0c
   languageName: node
   linkType: hard
 
-"@parcel/runtime-rsc@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/runtime-rsc@npm:2.15.2"
+"@parcel/runtime-rsc@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/runtime-rsc@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/b006276d91007710cf13609c1eafd9f23568fcc74f443643a5052b10318f9aaf45eef3d4827ff299d276c963a96aa4c74d16e5f76a480f181457d2c6ef0e33ea
+  checksum: 10/aae48ea8fe9ce727ac1b9feb12ea04ffdb301d79f27817f636422be270933daca2f2f60824246824d9a5798e43c748d9504aa40b334f873b5cd31b3578c6d288
   languageName: node
   linkType: hard
 
-"@parcel/runtime-service-worker@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/runtime-service-worker@npm:2.15.2"
+"@parcel/runtime-service-worker@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/runtime-service-worker@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/6f113e41f4889dcdc7b9f0d7513eca130c4f505d9a6eca33bb50733f3cf3444d8346c96f67a82c3192b2523a95a56869c934a55c89ed7b2d581f6ad9afe467c5
+  checksum: 10/2c47cbc7e8c783f289923aa406dc8f469091e177309038881d76154d9ab2006f818744787a43e2e48af3264217a01ccdf1c3901c46541026e9efe738eb6fd2c7
   languageName: node
   linkType: hard
 
-"@parcel/rust-darwin-arm64@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-darwin-arm64@npm:2.15.2"
+"@parcel/rust-darwin-arm64@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-darwin-arm64@npm:2.15.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@parcel/rust-darwin-x64@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-darwin-x64@npm:2.15.2"
+"@parcel/rust-darwin-x64@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-darwin-x64@npm:2.15.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@parcel/rust-linux-arm-gnueabihf@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-linux-arm-gnueabihf@npm:2.15.2"
+"@parcel/rust-linux-arm-gnueabihf@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-linux-arm-gnueabihf@npm:2.15.4"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@parcel/rust-linux-arm64-gnu@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-linux-arm64-gnu@npm:2.15.2"
+"@parcel/rust-linux-arm64-gnu@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-linux-arm64-gnu@npm:2.15.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@parcel/rust-linux-arm64-musl@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-linux-arm64-musl@npm:2.15.2"
+"@parcel/rust-linux-arm64-musl@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-linux-arm64-musl@npm:2.15.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@parcel/rust-linux-x64-gnu@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-linux-x64-gnu@npm:2.15.2"
+"@parcel/rust-linux-x64-gnu@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-linux-x64-gnu@npm:2.15.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@parcel/rust-linux-x64-musl@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-linux-x64-musl@npm:2.15.2"
+"@parcel/rust-linux-x64-musl@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-linux-x64-musl@npm:2.15.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@parcel/rust-win32-x64-msvc@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust-win32-x64-msvc@npm:2.15.2"
+"@parcel/rust-win32-x64-msvc@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust-win32-x64-msvc@npm:2.15.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -12322,18 +12322,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/rust@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/rust@npm:2.15.2"
+"@parcel/rust@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/rust@npm:2.15.4"
   dependencies:
-    "@parcel/rust-darwin-arm64": "npm:2.15.2"
-    "@parcel/rust-darwin-x64": "npm:2.15.2"
-    "@parcel/rust-linux-arm-gnueabihf": "npm:2.15.2"
-    "@parcel/rust-linux-arm64-gnu": "npm:2.15.2"
-    "@parcel/rust-linux-arm64-musl": "npm:2.15.2"
-    "@parcel/rust-linux-x64-gnu": "npm:2.15.2"
-    "@parcel/rust-linux-x64-musl": "npm:2.15.2"
-    "@parcel/rust-win32-x64-msvc": "npm:2.15.2"
+    "@parcel/rust-darwin-arm64": "npm:2.15.4"
+    "@parcel/rust-darwin-x64": "npm:2.15.4"
+    "@parcel/rust-linux-arm-gnueabihf": "npm:2.15.4"
+    "@parcel/rust-linux-arm64-gnu": "npm:2.15.4"
+    "@parcel/rust-linux-arm64-musl": "npm:2.15.4"
+    "@parcel/rust-linux-x64-gnu": "npm:2.15.4"
+    "@parcel/rust-linux-x64-musl": "npm:2.15.4"
+    "@parcel/rust-win32-x64-msvc": "npm:2.15.4"
   peerDependencies:
     napi-wasm: ^1.1.2
   dependenciesMeta:
@@ -12356,7 +12356,7 @@ __metadata:
   peerDependenciesMeta:
     napi-wasm:
       optional: true
-  checksum: 10/58924683044aeba57679f2e1bdd8dc031eb5bfb08dc166376565dd02d70745c1cccd10ef9afbb839aea34f572e0c396dbb3e5b2acadcbb905cdb8de743067ecd
+  checksum: 10/905964ecf64c1be42077918de91552e3377ff758f27b21a1001030ec4fe79d172f5906c063711ce623bd71aa48a04819aa65e67fb8a8606a2fde37800a5d4315
   languageName: node
   linkType: hard
 
@@ -12369,169 +12369,169 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/transformer-babel@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-babel@npm:2.15.2"
+"@parcel/transformer-babel@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-babel@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/utils": "npm:2.15.4"
     browserslist: "npm:^4.24.5"
     json5: "npm:^2.2.3"
     nullthrows: "npm:^1.1.1"
     semver: "npm:^7.7.1"
-  checksum: 10/5cdb6e0837229f51ec1fb7b6b960cf1ceb4ac74d3bdde66041b35fde33c630f8f244844a324ce3b2785d3176d4210e703001ad0c8acdb80598c8a982d21019ae
+  checksum: 10/f77949121eb35d6b97f38a6b40ecd9c4e0615917a66b3ab51fba0b59c69140714a065caa2cba36ffb96683a51a3b4296e585dc3848320bef0b366484c352299f
   languageName: node
   linkType: hard
 
-"@parcel/transformer-css@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-css@npm:2.15.2"
+"@parcel/transformer-css@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-css@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/utils": "npm:2.15.4"
     browserslist: "npm:^4.24.5"
     lightningcss: "npm:^1.30.1"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/2998f87a1be5734f62a98186f5e46beba0b874148de26bb6cd1f417a1a2ddec02b6ec6a38fbca4a4dbf455c7c60ba533ed33814b47184937c2d08330383a901b
+  checksum: 10/84fe61e218b679495797ec1897220df00affcff1affdaa655d158114d58599b21c10259a49af31fd716988356dec56af04ce542124e78c0233279e812f6b08ea
   languageName: node
   linkType: hard
 
-"@parcel/transformer-html@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-html@npm:2.15.2"
+"@parcel/transformer-html@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-html@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-  checksum: 10/ab630ac8657711eb4a3d79002dee9192c7820a563ffe292d4a3ec4a6491216009d580f5c094543313d449a89b1fa45f5f7886caf771714592089137a2fbc79d8
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+  checksum: 10/c0ab5166c1faaeafd914f221663f14f6f4529d89e6171e5a36ae1b45fb437a63b668fd5020b3ca980c6362c78e886a61413eb984c1f2008d0218be56aa5176ff
   languageName: node
   linkType: hard
 
-"@parcel/transformer-image@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-image@npm:2.15.2"
+"@parcel/transformer-image@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-image@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-    "@parcel/workers": "npm:2.15.2"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+    "@parcel/workers": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/07de875065cfbd0f8c89fe677f9c6029cae69343aebea1894952dbfbb1b496931d1428e8e749c191eda1d1c140339c5ccd21eb55fca167d9b1a55ce1e6d1e07f
+    "@parcel/core": ^2.15.4
+  checksum: 10/9456486fce752870841216c8738c49ad7386d2fd2d13b922604efc8ded39414a7263876273dba1b86271eaa1ca86b594503942b3b1c377f476bc5057ce90076f
   languageName: node
   linkType: hard
 
-"@parcel/transformer-js@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-js@npm:2.15.2"
+"@parcel/transformer-js@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-js@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
-    "@parcel/utils": "npm:2.15.2"
-    "@parcel/workers": "npm:2.15.2"
+    "@parcel/utils": "npm:2.15.4"
+    "@parcel/workers": "npm:2.15.4"
     "@swc/helpers": "npm:^0.5.0"
     browserslist: "npm:^4.24.5"
     nullthrows: "npm:^1.1.1"
     regenerator-runtime: "npm:^0.14.1"
     semver: "npm:^7.7.1"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/ef00d4f9a0b175476302dd4f8ecff129786f528fe7f15fa4147c91db80a116d0802b99e0f56219043c02d0b4fe628eacda7ff09ca4c568a9b996b671bced2017
+    "@parcel/core": ^2.15.4
+  checksum: 10/dee370c08fd1abce6fe21d789d8c77de2e41347d3c14f4ff243fa0ae26dda3a56eb36b36617c8340951a95d3b92f859c5726958f0d3d196ccbdfaf41ef4b51f8
   languageName: node
   linkType: hard
 
-"@parcel/transformer-json@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-json@npm:2.15.2"
+"@parcel/transformer-json@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-json@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
+    "@parcel/plugin": "npm:2.15.4"
     json5: "npm:^2.2.3"
-  checksum: 10/d7ebea569d6afeaeab375285dece10bd421224c2b758aa35a60b7d5522020c42c4ab7576bef1533f92eaa4dc8cad458c35836fd0fa4b4d40d79f2ca1fcd6426d
+  checksum: 10/52f6d1c7852024aedf187ce5c6d74f5a603ff6906faf650f764a397798b6ae276f40a50060871ca20b09db872f4c4b925a6d5a7bb96468ef7ee31f1ce997bfc3
   languageName: node
   linkType: hard
 
-"@parcel/transformer-node@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-node@npm:2.15.2"
+"@parcel/transformer-node@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-node@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-  checksum: 10/deca697a61a2a7e921db2e18418b0305a9bf50a12ed60dee7b6f26513cf452a92e617c7ae53ca4bf53aad602c40789c2ddbdfdbf0a21d3540b0fcb65c86be3dc
+    "@parcel/plugin": "npm:2.15.4"
+  checksum: 10/3fcbdaf4f9cbaee58d1e3f58dfda50b65eae5c6836f1121bcfa5ff0198d2500091d770b6cb7e0c1a6d86faa23269261ab7adda05a31854661eb4dfc83c342303
   languageName: node
   linkType: hard
 
-"@parcel/transformer-postcss@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-postcss@npm:2.15.2"
+"@parcel/transformer-postcss@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-postcss@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     clone: "npm:^2.1.2"
     nullthrows: "npm:^1.1.1"
     postcss-value-parser: "npm:^4.2.0"
     semver: "npm:^7.7.1"
-  checksum: 10/de0cbc999e350fef3193971af96ec7d3466eb7776799fb5ec3dc92556578f84a8b6080f73f6154c35a3d9e12c3dacd4b81f994d6c856e34abea92361a755299f
+  checksum: 10/71c065adf8cd2c91d76084b9adae9a26dc729056d9477f23599256fa03427deee83e213c350c09681e64f2d1337e56295f669ba06235c2eff82c9d6deb40d39d
   languageName: node
   linkType: hard
 
-"@parcel/transformer-posthtml@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-posthtml@npm:2.15.2"
+"@parcel/transformer-posthtml@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-posthtml@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
-  checksum: 10/d38e4943bc939ece5a0b803fa3526a114d2c2cb87353bcdbdd7b714c1c3d2a8180274293514d730fe9d9974aa71c4a94f7fe62bf3e9b1cf6976948385b3e6a1f
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
+  checksum: 10/d19ca3d51f435081d9b1ccc33b3ed13f1197dd790191587402256e9548000e2838f6d211970007152cabb77dc68a0e67be4376f8eabcc51f474f37baf71a44b3
   languageName: node
   linkType: hard
 
-"@parcel/transformer-raw@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-raw@npm:2.15.2"
+"@parcel/transformer-raw@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-raw@npm:2.15.4"
   dependencies:
-    "@parcel/plugin": "npm:2.15.2"
-  checksum: 10/98185551d99cc899881ac7ff430c2eceea4c33bf6e727c811d61082e3bcb3c73e7afbeeff315a1882df5db2253219458e67d6b781b596620bca15313e791adad
+    "@parcel/plugin": "npm:2.15.4"
+  checksum: 10/2a5cd9a64c7b9c1c21f6eeab2dcf59ae4fb1c1fcafb3a12cf51b55daf7c3078df21533d5155d5781621583432f90ea6408294c65ef292341af51ff90df87b7e0
   languageName: node
   linkType: hard
 
-"@parcel/transformer-react-refresh-wrap@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.15.2"
+"@parcel/transformer-react-refresh-wrap@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-react-refresh-wrap@npm:2.15.4"
   dependencies:
-    "@parcel/error-overlay": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/error-overlay": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     react-refresh: "npm:^0.16.0"
-  checksum: 10/435d60c241080e2e84c2a4a15d745a0a1c4eb90705ec7a38addc57a8dc8cc4e86d4c365abcba2e1eb0c8fc5d0a06cb3e5f1838a70a08c07d88a7d2a31da1b513
+  checksum: 10/e7fedc97ba47f45f14b58c6bfbe467d56bd1dac8a084a4fa4e48e0cdf23b6bd188f1e3787cd6077aa477f6df568a572a1cf098ae341ff5413e324a22b6cf8346
   languageName: node
   linkType: hard
 
-"@parcel/transformer-svg@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/transformer-svg@npm:2.15.2"
+"@parcel/transformer-svg@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/transformer-svg@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/plugin": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
-  checksum: 10/90ade79551f0964a6bc403f20e3b840568e7b939aac5a3426945dc19ddfbad9137e65d0ab344a565fea05ae3f209a8eddfef46ea4f7edd7fe7d29e71c8226103
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/plugin": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
+  checksum: 10/906ad00b86e1680f51c8595325713058ce5f927e940354f82d8223194310e4be945f5e98902d0825fa4b4d844715da10199cad016cba6c2c173c59b5b165f66e
   languageName: node
   linkType: hard
 
-"@parcel/types-internal@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/types-internal@npm:2.15.2"
+"@parcel/types-internal@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/types-internal@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/feature-flags": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/feature-flags": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
     utility-types: "npm:^3.11.0"
-  checksum: 10/449061e5eb2b8c0489eab45188c26925c9594b8c2e2a3c15306294491c5ef216914b210614454d2ad927ec49f5f2820db57a9fc04ca844fe008ec7ea323a5282
+  checksum: 10/601dc76f445830ffcf365b3b4d4f18abd2487029d0b5e4fc629f8d3c3ef0116b59f2cb95066ed07752234006c4e4fdeb1c2061e162982c5c54ce4f1eadb2c472
   languageName: node
   linkType: hard
 
@@ -12550,13 +12550,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/types@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/types@npm:2.15.2"
+"@parcel/types@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/types@npm:2.15.4"
   dependencies:
-    "@parcel/types-internal": "npm:2.15.2"
-    "@parcel/workers": "npm:2.15.2"
-  checksum: 10/1e3e88d8624edf04e0edfd16994abb9e9869c9b41c3dbdf78acb1eb6b1aac252acf0813d1215594062fb9b4716b250a21a2c81791afea36b0674b5245bb90d3f
+    "@parcel/types-internal": "npm:2.15.4"
+    "@parcel/workers": "npm:2.15.4"
+  checksum: 10/fd69c202e651cee7252e3b1d2afa8020792b062b490350fd1437de35f057cd6c81589562dc3131cc3624400a406b33ac28bc6857f628557e52d6c4ef55ee8fc7
   languageName: node
   linkType: hard
 
@@ -12576,19 +12576,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/utils@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/utils@npm:2.15.2"
+"@parcel/utils@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/utils@npm:2.15.4"
   dependencies:
-    "@parcel/codeframe": "npm:2.15.2"
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/logger": "npm:2.15.2"
-    "@parcel/markdown-ansi": "npm:2.15.2"
-    "@parcel/rust": "npm:2.15.2"
+    "@parcel/codeframe": "npm:2.15.4"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/logger": "npm:2.15.4"
+    "@parcel/markdown-ansi": "npm:2.15.4"
+    "@parcel/rust": "npm:2.15.4"
     "@parcel/source-map": "npm:^2.1.1"
     chalk: "npm:^4.1.2"
     nullthrows: "npm:^1.1.1"
-  checksum: 10/ee41da6c7694ce2d6db992b706de74e89cf34f437195c4ecf4ce8d38afb46dcca95ec9a17c7d1a6514f7ad9ed4cea5b85b83b5d036d07c9b71ae3aebcac1fd78
+  checksum: 10/6fcbe680c589ad833195b1a15e47417dab2d755117d138a765fb99a09f72740ffd6ff4642a9d6a85aa05a15bcfb72c1274cd3f7673bdbef84ffe4dbe3f0c506a
   languageName: node
   linkType: hard
 
@@ -12742,19 +12742,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@parcel/workers@npm:2.15.2":
-  version: 2.15.2
-  resolution: "@parcel/workers@npm:2.15.2"
+"@parcel/workers@npm:2.15.4":
+  version: 2.15.4
+  resolution: "@parcel/workers@npm:2.15.4"
   dependencies:
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/logger": "npm:2.15.2"
-    "@parcel/profiler": "npm:2.15.2"
-    "@parcel/types-internal": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/logger": "npm:2.15.4"
+    "@parcel/profiler": "npm:2.15.4"
+    "@parcel/types-internal": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     nullthrows: "npm:^1.1.1"
   peerDependencies:
-    "@parcel/core": ^2.15.2
-  checksum: 10/5193c308a6d22788bb52040a7ca1472ee710a7f060fc61e9117c748f51b829d8adcdf29e8fb44d8939180e97e02e1e24832023ca1a5826bcb17dc2bcaab32719
+    "@parcel/core": ^2.15.4
+  checksum: 10/45900bcd05910d1d32be78be96e34eb6816b9c008fb8e5e11adbcaecdf6326c0d06d54d4bf343942edb269b1ca3ac1ec2c01e3d6b6b0d9694aed7fc9e91ef11a
   languageName: node
   linkType: hard
 
@@ -12799,282 +12799,142 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.40.1"
+"@rollup/rollup-android-arm-eabi@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.44.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.43.0"
-  conditions: os=android & cpu=arm
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-android-arm64@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-android-arm64@npm:4.40.1"
+"@rollup/rollup-android-arm64@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.44.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-android-arm64@npm:4.43.0"
-  conditions: os=android & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-darwin-arm64@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.40.1"
+"@rollup/rollup-darwin-arm64@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.44.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.43.0"
-  conditions: os=darwin & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-darwin-x64@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-darwin-x64@npm:4.40.1"
+"@rollup/rollup-darwin-x64@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.44.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-darwin-x64@npm:4.43.0"
-  conditions: os=darwin & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-freebsd-arm64@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.40.1"
+"@rollup/rollup-freebsd-arm64@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.44.0"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.43.0"
-  conditions: os=freebsd & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-freebsd-x64@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.40.1"
+"@rollup/rollup-freebsd-x64@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.44.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.43.0"
-  conditions: os=freebsd & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.40.1"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.44.0"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.43.0"
-  conditions: os=linux & cpu=arm & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-arm-musleabihf@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.40.1"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.44.0"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.43.0"
-  conditions: os=linux & cpu=arm & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-arm64-gnu@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.40.1"
+"@rollup/rollup-linux-arm64-gnu@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.44.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.43.0"
-  conditions: os=linux & cpu=arm64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-arm64-musl@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.40.1"
+"@rollup/rollup-linux-arm64-musl@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.44.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.43.0"
-  conditions: os=linux & cpu=arm64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.40.1"
+"@rollup/rollup-linux-loongarch64-gnu@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.44.0"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.43.0"
-  conditions: os=linux & cpu=loong64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.40.1"
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.44.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.43.0"
-  conditions: os=linux & cpu=ppc64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-riscv64-gnu@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.40.1"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.44.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.43.0"
-  conditions: os=linux & cpu=riscv64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-riscv64-musl@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.40.1"
+"@rollup/rollup-linux-riscv64-musl@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.44.0"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-musl@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.43.0"
-  conditions: os=linux & cpu=riscv64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-s390x-gnu@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.40.1"
+"@rollup/rollup-linux-s390x-gnu@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.44.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.43.0"
-  conditions: os=linux & cpu=s390x & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-x64-gnu@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.40.1"
+"@rollup/rollup-linux-x64-gnu@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.44.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.43.0"
-  conditions: os=linux & cpu=x64 & libc=glibc
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-linux-x64-musl@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.40.1"
+"@rollup/rollup-linux-x64-musl@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.44.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.43.0"
-  conditions: os=linux & cpu=x64 & libc=musl
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-win32-arm64-msvc@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.40.1"
+"@rollup/rollup-win32-arm64-msvc@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.44.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.43.0"
-  conditions: os=win32 & cpu=arm64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-win32-ia32-msvc@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.40.1"
+"@rollup/rollup-win32-ia32-msvc@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.44.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.43.0"
-  conditions: os=win32 & cpu=ia32
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-win32-x64-msvc@npm:4.40.1":
-  version: 4.40.1
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.40.1"
-  conditions: os=win32 & cpu=x64
-  languageName: node
-  linkType: hard
-
-"@rollup/rollup-win32-x64-msvc@npm:4.43.0":
-  version: 4.43.0
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.43.0"
+"@rollup/rollup-win32-x64-msvc@npm:4.44.0":
+  version: 4.44.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.44.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -13355,7 +13215,7 @@ __metadata:
     "@girs/glib-2.0": "workspace:^"
     "@girs/gtk-4.0": "workspace:^"
     typescript: "npm:^5.8.3"
-    vite: "npm:^6.3.5"
+    vite: "npm:^7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -13576,10 +13436,10 @@ __metadata:
     "@girs/gjs": "workspace:^"
     "@girs/gtk-3.0": "workspace:^"
     "@girs/gtksource-3.0": "workspace:^"
-    "@parcel/config-default": "npm:^2.15.2"
-    "@parcel/plugin": "npm:^2.15.2"
-    "@parcel/resolver-default": "npm:^2.15.2"
-    parcel: "npm:^2.15.2"
+    "@parcel/config-default": "npm:^2.15.4"
+    "@parcel/plugin": "npm:^2.15.4"
+    "@parcel/resolver-default": "npm:^2.15.4"
+    parcel: "npm:^2.15.4"
     parcel-plugin-externals: "npm:^0.5.2"
     typescript: "npm:^5.8.3"
   languageName: unknown
@@ -13603,7 +13463,7 @@ __metadata:
     "@girs/gjs": "workspace:^"
     "@girs/gtk-3.0": "workspace:^"
     "@rollup/plugin-node-resolve": "npm:^16.0.1"
-    rollup: "npm:^4.43.0"
+    rollup: "npm:^4.44.0"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -13729,7 +13589,7 @@ __metadata:
     "@girs/gobject-2.0": "workspace:^"
     "@girs/gtk-4.0": "workspace:^"
     typescript: "npm:^5.8.3"
-    vite: "npm:^6.3.5"
+    vite: "npm:^7.0.0"
   languageName: unknown
   linkType: soft
 
@@ -13764,7 +13624,7 @@ __metadata:
     "@girs/gjs": "workspace:^"
     "@girs/glib-2.0": "workspace:^"
     "@girs/soup-3.0": "workspace:^"
-    concurrently: "npm:^9.1.2"
+    concurrently: "npm:^9.2.0"
     esbuild: "npm:^0.25.5"
     typescript: "npm:^5.8.3"
   languageName: unknown
@@ -13829,7 +13689,7 @@ __metadata:
     "@ts-for-gir/templates": "workspace:^"
     "@types/ejs": "npm:^3.1.5"
     "@types/inquirer": "npm:^9.0.8"
-    "@types/node": "npm:^24.0.1"
+    "@types/node": "npm:^24.0.4"
     "@types/yargs": "npm:^17.0.33"
     colorette: "npm:^2.0.20"
     cosmiconfig: "npm:^9.0.0"
@@ -13839,7 +13699,7 @@ __metadata:
     esbuild-node-externals: "npm:^1.18.0"
     glob: "npm:^11.0.3"
     inquirer: "npm:^12.6.3"
-    prettier: "npm:^3.6.0"
+    prettier: "npm:^3.6.1"
     rimraf: "npm:^6.0.1"
     typescript: "npm:^5.8.3"
     yargs: "npm:^18.0.0"
@@ -13853,7 +13713,7 @@ __metadata:
   resolution: "@ts-for-gir/generator-base@workspace:packages/generator-base"
   dependencies:
     "@ts-for-gir/lib": "workspace:^"
-    "@types/node": "npm:^24.0.1"
+    "@types/node": "npm:^24.0.4"
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
@@ -13864,7 +13724,7 @@ __metadata:
   dependencies:
     "@ts-for-gir/generator-base": "workspace:^"
     "@ts-for-gir/lib": "workspace:^"
-    "@types/node": "npm:^24.0.1"
+    "@types/node": "npm:^24.0.4"
     rimraf: "npm:^6.0.1"
     typescript: "npm:^5.8.3"
   languageName: unknown
@@ -13879,7 +13739,7 @@ __metadata:
     "@ts-for-gir/lib": "workspace:^"
     "@ts-for-gir/templates": "workspace:^"
     "@types/ejs": "npm:^3.1.5"
-    "@types/node": "npm:^24.0.1"
+    "@types/node": "npm:^24.0.4"
     "@types/xml2js": "npm:^0.4.14"
     ejs: "npm:^3.1.10"
     typescript: "npm:^5.8.3"
@@ -13893,8 +13753,8 @@ __metadata:
   dependencies:
     "@gi.ts/parser": "workspace:^"
     "@types/ejs": "npm:^3.1.5"
-    "@types/lodash": "npm:^4.17.17"
-    "@types/node": "npm:^24.0.1"
+    "@types/lodash": "npm:^4.17.18"
+    "@types/node": "npm:^24.0.4"
     colorette: "npm:^2.0.20"
     ejs: "npm:^3.1.10"
     glob: "npm:^11.0.3"
@@ -13944,10 +13804,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:1.0.7":
-  version: 1.0.7
-  resolution: "@types/estree@npm:1.0.7"
-  checksum: 10/419c845ece767ad4b21171e6e5b63dabb2eb46b9c0d97361edcd9cabbf6a95fcadb91d89b5fa098d1336fa0b8fceaea82fca97a2ef3971f5c86e53031e157b21
+"@types/estree@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@types/estree@npm:1.0.8"
+  checksum: 10/25a4c16a6752538ffde2826c2cc0c6491d90e69cd6187bef4a006dd2c3c45469f049e643d7e516c515f21484dc3d48fd5c870be158a5beb72f5baf3dc43e4099
   languageName: node
   linkType: hard
 
@@ -13975,10 +13835,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.17.17":
-  version: 4.17.17
-  resolution: "@types/lodash@npm:4.17.17"
-  checksum: 10/496459a3cb1a0733bb60532de3899ad6297717af0b9b26ad6821154b2005fec86f29ccd47a2e6f4da4a8c7c818bb8ae73901144e8057ea86b7b02a3d7bb9d13f
+"@types/lodash@npm:^4.17.18":
+  version: 4.17.18
+  resolution: "@types/lodash@npm:4.17.18"
+  checksum: 10/54ebb15b29925112dbe9da3abd99fb80d7202bc5ba20fc1b4fc8ea835d0012f00cbd9a3e7f367b70e7c3f2d5ee635964e3920a489625647b558f02994b3dd381
   languageName: node
   linkType: hard
 
@@ -13991,12 +13851,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^24.0.1":
-  version: 24.0.1
-  resolution: "@types/node@npm:24.0.1"
+"@types/node@npm:^24.0.4":
+  version: 24.0.4
+  resolution: "@types/node@npm:24.0.4"
   dependencies:
     undici-types: "npm:~7.8.0"
-  checksum: 10/6b77554f8308148e00e9c7c264ccad3e9a3d360f10b75a727d44b9bba2377022179a76905fbe1bb426ea4c6ee9f45186797ec335a5dcab803435336576db18c6
+  checksum: 10/81cd63dfeea7b7cd0d13a6435c3aa38de48da1eb59a5572f3528396dd5a8d9ff6811d947a2a6856d38e3b813ac26207abb1b44eb98848f78553a8fb4b2886e37
   languageName: node
   linkType: hard
 
@@ -14772,9 +14632,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"concurrently@npm:^9.1.2":
-  version: 9.1.2
-  resolution: "concurrently@npm:9.1.2"
+"concurrently@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "concurrently@npm:9.2.0"
   dependencies:
     chalk: "npm:^4.1.2"
     lodash: "npm:^4.17.21"
@@ -14786,7 +14646,7 @@ __metadata:
   bin:
     conc: dist/bin/concurrently.js
     concurrently: dist/bin/concurrently.js
-  checksum: 10/52f20653db53e25950e84026d153177af976d6d0e139b95fc5983c684221cc20ef5548ad5dc8885f146fff2c87bc7f7beb18f5fa54eee3bb62b5e795234d6cbc
+  checksum: 10/fdf5d3b583640b11ef84fab3ffdf77ed9c6878fa0a56f6787b6cd46b7011305c71d9e0067a814ca4fa52bea6f20ddb466bb97a13d61999628e43e550ddad7c93
   languageName: node
   linkType: hard
 
@@ -15386,6 +15246,18 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10/d0000d6b790059b35f4ed19acc8847a66452e0bc68b28766c929ffd523e5ec2083811fc8a545e4a1d4945ce70e887b3a610c145c681073b506143ae3076342ed
+  languageName: node
+  linkType: hard
+
+"fdir@npm:^6.4.6":
+  version: 6.4.6
+  resolution: "fdir@npm:6.4.6"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10/c186ba387e7b75ccf874a098d9bc5fe0af0e9c52fc56f8eac8e80aa4edb65532684bf2bf769894ff90f53bf221d6136692052d31f07a9952807acae6cbe7ee50
   languageName: node
   linkType: hard
 
@@ -16527,12 +16399,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
+"nanoid@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/2d1766606cf0d6f47b6f0fdab91761bb81609b2e3d367027aff45e6ee7006f660fb7e7781f4a34799fe6734f1268eeed2e37a5fdee809ade0c2d4eb11b0f9c40
+  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
   languageName: node
   linkType: hard
 
@@ -16759,28 +16631,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parcel@npm:^2.15.2":
-  version: 2.15.2
-  resolution: "parcel@npm:2.15.2"
+"parcel@npm:^2.15.4":
+  version: 2.15.4
+  resolution: "parcel@npm:2.15.4"
   dependencies:
-    "@parcel/config-default": "npm:2.15.2"
-    "@parcel/core": "npm:2.15.2"
-    "@parcel/diagnostic": "npm:2.15.2"
-    "@parcel/events": "npm:2.15.2"
-    "@parcel/feature-flags": "npm:2.15.2"
-    "@parcel/fs": "npm:2.15.2"
-    "@parcel/logger": "npm:2.15.2"
-    "@parcel/package-manager": "npm:2.15.2"
-    "@parcel/reporter-cli": "npm:2.15.2"
-    "@parcel/reporter-dev-server": "npm:2.15.2"
-    "@parcel/reporter-tracer": "npm:2.15.2"
-    "@parcel/utils": "npm:2.15.2"
+    "@parcel/config-default": "npm:2.15.4"
+    "@parcel/core": "npm:2.15.4"
+    "@parcel/diagnostic": "npm:2.15.4"
+    "@parcel/events": "npm:2.15.4"
+    "@parcel/feature-flags": "npm:2.15.4"
+    "@parcel/fs": "npm:2.15.4"
+    "@parcel/logger": "npm:2.15.4"
+    "@parcel/package-manager": "npm:2.15.4"
+    "@parcel/reporter-cli": "npm:2.15.4"
+    "@parcel/reporter-dev-server": "npm:2.15.4"
+    "@parcel/reporter-tracer": "npm:2.15.4"
+    "@parcel/utils": "npm:2.15.4"
     chalk: "npm:^4.1.2"
     commander: "npm:^12.1.0"
     get-port: "npm:^4.2.0"
   bin:
     parcel: lib/bin.js
-  checksum: 10/7599ad3053b200692ae2fc09472f8428d8aa6c7a1e1d8c37deea478adcdf292b992519554afc367bdaa4164217ce3b7f8340a00013e05afb79b365b5c8e36e04
+  checksum: 10/590e6ac2595b7a2a98533ef7ba72f8ba64c2222f8be8f60d2ebe2fa374d018cd4776d168dd2a77db884e79559bbe4b515ae74c70ea4a525bf57a66768a4778c2
   languageName: node
   linkType: hard
 
@@ -16914,23 +16786,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.3":
-  version: 8.5.3
-  resolution: "postcss@npm:8.5.3"
+"postcss@npm:^8.5.6":
+  version: 8.5.6
+  resolution: "postcss@npm:8.5.6"
   dependencies:
-    nanoid: "npm:^3.3.8"
+    nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/6d7e21a772e8b05bf102636918654dac097bac013f0dc8346b72ac3604fc16829646f94ea862acccd8f82e910b00e2c11c1f0ea276543565d278c7ca35516a7c
+  checksum: 10/9e4fbe97574091e9736d0e82a591e29aa100a0bf60276a926308f8c57249698935f35c5d2f4e80de778d0cbb8dcffab4f383d85fd50c5649aca421c3df729b86
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "prettier@npm:3.6.0"
+"prettier@npm:^3.6.1":
+  version: 3.6.1
+  resolution: "prettier@npm:3.6.1"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10/5c0db5a8e32d2ac9824d8bc652990dfd534bc7a7c6f26d99d50c9146a2d9befb3cd1cc86c4aee71caf6b264d421a4b4b5961e31a62dda3790b8fec2521a76eef
+  checksum: 10/e2c4b47bf1bda4f932143e52e0f57239dd60cfef08296b56d4073426e2d310edc353a7daa5285a546bd3c1619c76894759cc98d82d4ac710f72a711ae2899bcc
   languageName: node
   linkType: hard
 
@@ -17112,31 +16984,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.34.9":
-  version: 4.40.1
-  resolution: "rollup@npm:4.40.1"
+"rollup@npm:^4.40.0, rollup@npm:^4.44.0":
+  version: 4.44.0
+  resolution: "rollup@npm:4.44.0"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.40.1"
-    "@rollup/rollup-android-arm64": "npm:4.40.1"
-    "@rollup/rollup-darwin-arm64": "npm:4.40.1"
-    "@rollup/rollup-darwin-x64": "npm:4.40.1"
-    "@rollup/rollup-freebsd-arm64": "npm:4.40.1"
-    "@rollup/rollup-freebsd-x64": "npm:4.40.1"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.40.1"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.40.1"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.40.1"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.40.1"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.40.1"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.40.1"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.40.1"
-    "@rollup/rollup-linux-riscv64-musl": "npm:4.40.1"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.40.1"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.40.1"
-    "@rollup/rollup-linux-x64-musl": "npm:4.40.1"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.40.1"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.40.1"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.40.1"
-    "@types/estree": "npm:1.0.7"
+    "@rollup/rollup-android-arm-eabi": "npm:4.44.0"
+    "@rollup/rollup-android-arm64": "npm:4.44.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.44.0"
+    "@rollup/rollup-darwin-x64": "npm:4.44.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.44.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.44.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.44.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.44.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.44.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.44.0"
+    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.44.0"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.44.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.44.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.44.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.44.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.44.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.44.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.44.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.44.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.44.0"
+    "@types/estree": "npm:1.0.8"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
     "@rollup/rollup-android-arm-eabi":
@@ -17183,82 +17055,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10/35d5e83a69000ddd6c087015eb5f862943c53b6e20702575ef50aeb99ce99b864fa74cca630815eb97cdfe1f278f5602f782e55f227b32ac2301f2a5f1fc5373
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^4.43.0":
-  version: 4.43.0
-  resolution: "rollup@npm:4.43.0"
-  dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.43.0"
-    "@rollup/rollup-android-arm64": "npm:4.43.0"
-    "@rollup/rollup-darwin-arm64": "npm:4.43.0"
-    "@rollup/rollup-darwin-x64": "npm:4.43.0"
-    "@rollup/rollup-freebsd-arm64": "npm:4.43.0"
-    "@rollup/rollup-freebsd-x64": "npm:4.43.0"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.43.0"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.43.0"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.43.0"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.43.0"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.43.0"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.43.0"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.43.0"
-    "@rollup/rollup-linux-riscv64-musl": "npm:4.43.0"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.43.0"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.43.0"
-    "@rollup/rollup-linux-x64-musl": "npm:4.43.0"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.43.0"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.43.0"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.43.0"
-    "@types/estree": "npm:1.0.7"
-    fsevents: "npm:~2.3.2"
-  dependenciesMeta:
-    "@rollup/rollup-android-arm-eabi":
-      optional: true
-    "@rollup/rollup-android-arm64":
-      optional: true
-    "@rollup/rollup-darwin-arm64":
-      optional: true
-    "@rollup/rollup-darwin-x64":
-      optional: true
-    "@rollup/rollup-freebsd-arm64":
-      optional: true
-    "@rollup/rollup-freebsd-x64":
-      optional: true
-    "@rollup/rollup-linux-arm-gnueabihf":
-      optional: true
-    "@rollup/rollup-linux-arm-musleabihf":
-      optional: true
-    "@rollup/rollup-linux-arm64-gnu":
-      optional: true
-    "@rollup/rollup-linux-arm64-musl":
-      optional: true
-    "@rollup/rollup-linux-loongarch64-gnu":
-      optional: true
-    "@rollup/rollup-linux-powerpc64le-gnu":
-      optional: true
-    "@rollup/rollup-linux-riscv64-gnu":
-      optional: true
-    "@rollup/rollup-linux-riscv64-musl":
-      optional: true
-    "@rollup/rollup-linux-s390x-gnu":
-      optional: true
-    "@rollup/rollup-linux-x64-gnu":
-      optional: true
-    "@rollup/rollup-linux-x64-musl":
-      optional: true
-    "@rollup/rollup-win32-arm64-msvc":
-      optional: true
-    "@rollup/rollup-win32-ia32-msvc":
-      optional: true
-    "@rollup/rollup-win32-x64-msvc":
-      optional: true
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: 10/c7f436880dfd5bd54e9ac579625b5355be58b5437ebb386eb88d709d6bed733a4411673cc80fd64dc5514cd71794544bc83775842108c86ed2b51827e11b33b8
+  checksum: 10/2182fc751734277972c011bf62a07cd01de44aaa408f29d3be51b6c7373aa179c9e20d5b9b9fa46268c7d65fc8edb033243f501495465b13dd05d1f99635a7fa
   languageName: node
   linkType: hard
 
@@ -17667,13 +17464,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.13":
-  version: 0.2.13
-  resolution: "tinyglobby@npm:0.2.13"
+"tinyglobby@npm:^0.2.14":
+  version: 0.2.14
+  resolution: "tinyglobby@npm:0.2.14"
   dependencies:
     fdir: "npm:^6.4.4"
     picomatch: "npm:^4.0.2"
-  checksum: 10/b04557ee58ad2be5f2d2cbb4b441476436c92bb45ba2e1fc464d686b793392b305ed0bcb8b877429e9b5036bdd46770c161a08384c0720b6682b7cd6ac80e403
+  checksum: 10/3d306d319718b7cc9d79fb3f29d8655237aa6a1f280860a217f93417039d0614891aee6fc47c5db315f4fcc6ac8d55eb8e23e2de73b2c51a431b42456d9e5764
   languageName: node
   linkType: hard
 
@@ -17710,7 +17507,7 @@ __metadata:
   dependencies:
     "@biomejs/biome": "npm:^2.0.5"
     "@ts-for-gir/cli": "workspace:^"
-    concurrently: "npm:^9.1.2"
+    concurrently: "npm:^9.2.0"
     rimraf: "npm:^6.0.1"
     typescript: "npm:^5.8.3"
   languageName: unknown
@@ -17911,26 +17708,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.3.5":
-  version: 6.3.5
-  resolution: "vite@npm:6.3.5"
+"vite@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "vite@npm:7.0.0"
   dependencies:
     esbuild: "npm:^0.25.0"
-    fdir: "npm:^6.4.4"
+    fdir: "npm:^6.4.6"
     fsevents: "npm:~2.3.3"
     picomatch: "npm:^4.0.2"
-    postcss: "npm:^8.5.3"
-    rollup: "npm:^4.34.9"
-    tinyglobby: "npm:^0.2.13"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.40.0"
+    tinyglobby: "npm:^0.2.14"
   peerDependencies:
-    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@types/node": ^20.19.0 || >=22.12.0
     jiti: ">=1.21.0"
-    less: "*"
+    less: ^4.0.0
     lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
     terser: ^5.16.0
     tsx: ^4.8.1
     yaml: ^2.4.2
@@ -17962,7 +17759,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/7bc3a1c5ef79413ad70daeeaf69b76cd1218d16aa18ed8ee08d74648ef17284f4a17c11f5cf42b573b6dc5e3d5f115110b67b1d23c2c699cfe404757764a634a
+  checksum: 10/2501b706dc481529efb16c6241794a66d68ea7a074d49f22e45b701769fbeeccc721c58272c9fce743d3b1472a3de497f85ca18cb059b1b8b906b2b295e524dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Upgraded `concurrently` to version 9.2.0 in multiple package.json files.
- Updated `vite` to version 7.0.0 in example projects.
- Bumped `@types/node` to version 24.0.4 across various packages.
- Updated `prettier` to version 3.6.1 in the cli package.
- Adjusted `@parcel` dependencies to version 2.15.4 in example projects.
- Incremented `@types/lodash` to version 4.17.18 in the lib package.