### PR TITLE
Fix TypeScript module resolution issue in ambient declarations

### DIFF
--- a/packages/lib/src/dependency-manager.ts
+++ b/packages/lib/src/dependency-manager.ts
@@ -111,7 +111,7 @@ export class DependencyManager {
 	}
 
 	createImportProperties(namespace: string, packageName: string, version: string, libraryVersion?: LibraryVersion) {
-		const importPath = this.createImportPath(packageName, namespace, version);
+		const { importPath, importName, npmPackageName } = this.createImportPath(packageName, namespace, version);
 		const importDef = this.createImportDef(namespace, importPath);
 
 		// For GObject and Gio, use GLib's library version if available
@@ -122,22 +122,35 @@ export class DependencyManager {
 				effectiveLibraryVersion = glibDep.libraryVersion;
 			}
 		}
-
-		const packageJsonImport = this.createPackageJsonImport(importPath, effectiveLibraryVersion);
+		const packageJsonImport = this.createPackageJsonImport(npmPackageName, effectiveLibraryVersion);
 		return {
 			importPath,
+			importName,
+			npmPackageName,
 			importDef,
 			packageJsonImport,
 		};
 	}
 
-	createImportPath(packageName: string, namespace: string, version: string): string {
-		if (!this.config.package) {
-			return `gi://${namespace}?version=${version}`;
-		}
+	createImportPath(
+		packageName: string,
+		namespace: string,
+		version: string,
+	): { npmPackageName: string; importPath: string; importName: string } {
 		const importName = transformImportName(packageName);
-		const importPath = `${this.config.npmScope}/${importName}`;
-		return importPath;
+		const importPath = this.config.package
+			? `${this.config.npmScope}/${importName}/${importName}`
+			: `gi://${namespace}?version=${version}`;
+		const npmPackageName = `${this.config.npmScope}/${importName}`;
+
+		return {
+			/** E.g. '@girs/Gtk-4.0' */
+			npmPackageName,
+			/** E.g. '@girs/Gtk-4.0/Gtk-4.0' or 'gi://Gtk?version=4.0' */
+			importPath,
+			/** E.g. 'Gtk-4.0' */
+			importName,
+		};
 	}
 
 	createImportDef(namespace: string, importPath: string): string {
@@ -271,7 +284,6 @@ export class DependencyManager {
 			...fileInfo,
 			namespace,
 			packageName,
-			importName: transformImportName(packageName),
 			importNamespace: transformModuleNamespaceName(packageName),
 			version,
 			libraryVersion,
@@ -426,7 +438,6 @@ export class DependencyManager {
 			filename: "",
 			path: "",
 			packageName: packageName,
-			importName: transformImportName(packageName),
 			importNamespace: transformModuleNamespaceName(packageName),
 			version,
 			libraryVersion: new LibraryVersion(),

--- a/packages/templates/templates/module-ambient.d.ts
+++ b/packages/templates/templates/module-ambient.d.ts
@@ -5,7 +5,7 @@
 _%>
 
 declare module 'gi://<%= name %>?version=<%= version %>' {
-    import <%= girModule.importNamespace %> from '<%= girModule.importPath %>/<%= girModule.importNamespace.toLowerCase() %>';
+    import <%= girModule.importNamespace %> from '<%= girModule.importPath -%>';
     export default <%- girModule.importNamespace -%>;
 }
 

--- a/packages/templates/templates/package.json
+++ b/packages/templates/templates/package.json
@@ -15,8 +15,8 @@ _%>
     <%_ } _%>
     "description": "<%- PACKAGE_DESC %>",
     "type": "module",
-    "module": "<%- entryPointName %>.js",
-    "main": "<%- entryPointName %>.js",
+    "module": "index.js",
+    "main": "index.js",
     "exports": {
       "./ambient": {
         "types": "./<%- entryPointName %>-ambient.d.ts",


### PR DESCRIPTION
TypeScript does not recognize methods like `St.Widget.ease()`, although the code works at runtime. This issue was described in [gjsify/gnome-shell#65](https://github.com/gjsify/gnome-shell/issues/65) and [gjsify/gnome-shell#75](https://github.com/gjsify/gnome-shell/pull/75).

### Root Cause
Ambient module declarations like `declare module 'gi://Clutter?version=16'` were importing from `@girs/clutter-16`, which created circular dependencies and resolution issues.

The circular dependency occurred because:
1. `index.d.ts` imports `'./clutter-16-ambient.d.ts'`
2. `clutter-16-ambient.d.ts` imports from `'@girs/clutter-16'` 
3. `'@girs/clutter-16'` refers back to `index.d.ts`

### Attempted Solution
Changed the import path in the ambient template from `@girs/clutter-16` to `@girs/clutter-16/clutter-16` to directly reference the main type definition file, breaking the circular dependency.

This allows gjsify/gnome-shell and other consumers to use `@girs/clutter-16/clutter-16` for direct access to the main types without circular dependencies.