### PR TITLE
fix(generator-typescript): Handle guintptr

### DIFF
--- a/packages/lib/src/utils/types.ts
+++ b/packages/lib/src/utils/types.ts
@@ -182,6 +182,7 @@ export function resolvePrimitiveType(name: string): TypeExpression | null {
 		case "gint64":
 		case "gssize":
 		case "gsize":
+		case "guintptr": // Integer of the same width as a pointer
 		case "time_t": // C standard library time type (seconds since Unix epoch)
 		case "ulong": // C standard library unsigned long type
 			return BigintOrNumberType;
@@ -193,8 +194,6 @@ export function resolvePrimitiveType(name: string): TypeExpression | null {
 			return ObjectType;
 		case "va_list":
 			return AnyType;
-		case "guintptr": // You can't use pointers in GJS! (at least that I'm aware of)
-			return NeverType;
 		case "never": // Support TS "never"
 			return NeverType;
 		case "unknown": // Support TS "unknown"


### PR DESCRIPTION
## Description

guintptr isn't a pointer, it's an integer that is guaranteed to be the same size as a pointer. Handle it along with the other `bigint | number` integers.

(Looking at where the type definitions change, functions that accept or return guintptr are mostly useless in GJS; but some GStreamer libraries use them as a handle or ID, so not entirely useless.)

## Related Issue

None.

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

Existing tests pass. The only changes in the regenerated type definitions are `never` changing to `number` (for values going from C to JS) or `bigint | number` (for values going from JS to C).

## Checklist
<!-- Please check all that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly 