### PR TITLE
fix(cli): fall back to npm registry in prepack

### DIFF
--- a/packages/cli/scripts/process-templates.mjs
+++ b/packages/cli/scripts/process-templates.mjs
@@ -50,16 +50,41 @@ function buildVersionMap() {
 	return map;
 }
 
+const npmVersionCache = {};
+
+function resolveViaNpm(name) {
+	if (name in npmVersionCache) return npmVersionCache[name];
+	try {
+		const stdout = execFileSync("npm", ["view", name, "version"], {
+			encoding: "utf8",
+			stdio: ["pipe", "pipe", "pipe"],
+			timeout: 30 * 1000,
+		});
+		const version = stdout.trim();
+		npmVersionCache[name] = version || null;
+		return npmVersionCache[name];
+	} catch {
+		npmVersionCache[name] = null;
+		return null;
+	}
+}
+
 function resolveDeps(deps, versionMap, templateName) {
 	if (!deps) return;
 	for (const name of Object.keys(deps)) {
 		const spec = deps[name];
 		if (typeof spec !== "string" || !WORKSPACE_PREFIX_RE.test(spec)) continue;
-		const version = versionMap[name];
+		let version = versionMap[name];
+		if (!version) {
+			version = resolveViaNpm(name);
+			if (version) {
+				console.log(`[process-templates] resolved ${name} via npm registry: ${version}`);
+			}
+		}
 		if (!version) {
 			throw new Error(
 				`[process-templates] Template "${templateName}": cannot resolve workspace:^ for "${name}". ` +
-					"Make sure the package exists as a workspace in the monorepo.",
+					"Not found as a local workspace and not published to the npm registry.",
 			);
 		}
 		deps[name] = `^${version}`;


### PR DESCRIPTION
## Summary

Fixes the failed v4.0.0-rc.4 release ([workflow run #24462811559](https://github.com/gjsify/ts-for-gir/actions/runs/24462811559)). The publish aborted in the \`@ts-for-gir/cli\` prepack step:

\`\`\`
Error: [process-templates] Template \"types-npm\": cannot resolve workspace:^ for \"@girs/adw-1\".
    Make sure the package exists as a workspace in the monorepo.
\`\`\`

Root cause: the release-app workflow uses \`actions/checkout@v4\` without \`submodules: recursive\` and installs only the CLI workspace via \`yarn workspaces focus @ts-for-gir/cli\`. Both of these mean the \`types-dev/\` submodule — where \`process-templates.mjs\` reads \`@girs/*\` versions from — isn't on disk at prepack time. Locally the script sees 718 workspace packages; in CI it sees 14, and the \`@girs/*\` refs in the types-npm template's root \`package.json\` are unresolvable.

## Change

\`process-templates.mjs\` now falls back to \`npm view <name> version\` when a \`workspace:^\` ref isn't matched by a local workspace. Calls are cached per-package. Fails only if the package is neither a local workspace nor published to npm.

Local dev (types-dev present) is unchanged — 0 npm view calls. In CI, 5 calls for the types-npm template (adw-1, gio-2.0, gjs, glib-2.0, gtk-4.0), each ~300ms.

## Test plan

- [x] Simulate CI locally by stashing \`types-dev/\`:
    - Resolves 14 local packages + 5 via \`npm view\` fallback → dist-templates/types-npm/package.json pinned to \`^X.Y.Z-4.0.0-rc.4\` (what's actually on npm today).
- [x] With \`types-dev/\` back in place: 718 local packages, 0 npm view calls.
- [x] \`yarn check:app\` — clean.
- [ ] After merge: re-run the Release App workflow via \`workflow_dispatch\` on \`main\` so v4.0.0-rc.4 actually publishes.