### PR TITLE
fix(cairo): correct fontExtents, camelCase FontExtents fields, add textPath

### DIFF
--- a/packages/templates/templates/gjs/cairo.d.ts
+++ b/packages/templates/templates/gjs/cairo.d.ts
@@ -64,9 +64,9 @@ import Cairo from '<%- Cairo.importPath %>';
         /** Recommended vertical distance between baselines for consecutive lines */
         height: number;
         /** Maximum X advance for any glyph */
-        max_x_advance: number;
+        maxXAdvance: number;
         /** Maximum Y advance for any glyph (typically 0 for horizontal text) */
-        max_y_advance: number;
+        maxYAdvance: number;
     }
 
     /**
@@ -534,6 +534,13 @@ import Cairo from '<%- Cairo.importPath %>';
         showText(utf8: string): void;
 
         /**
+         * Adds the text outline to the current path (cairo_text_path).
+         * After this call the context will have a current point.
+         * @param utf8 A string of text encoded in UTF-8
+         */
+        textPath(utf8: string): void;
+
+        /**
          * Strokes the current path using the current line width, line join,
          * line cap, and dash settings, then clears the path
          */
@@ -561,7 +568,7 @@ import Cairo from '<%- Cairo.importPath %>';
          * Gets the font extents for the currently selected font
          * @returns Font extents in user-space coordinates
          */
-        getFontExtents(): FontExtents;
+        fontExtents(): FontExtents;
 
         /**
          * Renders an array of glyphs at the current point (low-level text API)


### PR DESCRIPTION
## Summary

Fixes three bugs in the GJS Cairo type overrides, verified against `gjs/installed-tests/js/testCairo.js`:

- **`getFontExtents()` → `fontExtents()`**: GJS exposes the method as `fontExtents()`, not `getFontExtents()`. The old name would result in a runtime error.
- **`max_x_advance` / `max_y_advance` → `maxXAdvance` / `maxYAdvance`**: The `FontExtents` interface used snake_case, but GJS returns camelCase property names. This caused a type mismatch when destructuring the result.
- **Add missing `textPath(utf8: string): void`**: `cairo_text_path()` was not typed at all. GJS tests assert that after calling `textPath('Hello')` the context has a current point.

All three issues were confirmed by reading the GJS test suite directly (`testCairo.js` lines 130–156).

## Test plan

- [x] `yarn check:app` passes (19/19 language-server-validation tests green)
- [x] `yarn format` — no changes needed
- [x] Template source `packages/templates/templates/gjs/cairo.d.ts` is the only changed file; `types-dev` will be updated on next `yarn build:types`

Closes #118