### PR TITLE
feat(lib): use GIR attributes glib:finish-func, default-value, shadowed-by

### DIFF
--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -464,6 +464,8 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 		if (tsProp.constructOnly) propTags.push({ tagName: "construct-only", paramName: "", text: "" });
 		else if (tsProp.readable && !tsProp.writable) propTags.push({ tagName: "read-only", paramName: "", text: "" });
 		else if (tsProp.writable && !tsProp.readable) propTags.push({ tagName: "write-only", paramName: "", text: "" });
+		if (tsProp.defaultValue !== undefined)
+			propTags.push({ tagName: "default", paramName: "", text: tsProp.defaultValue });
 		desc.push(...this.addGirDocComment(tsProp.doc, propTags, indentCount));
 
 		const indent = generateIndent(indentCount);

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -75,6 +75,8 @@ export class IntrospectedClassFunction<
 	returnTypeDoc?: string | null;
 	/** If this function was generated from a signal, stores the signal name. */
 	signalOrigin?: string;
+	/** GIR glib:finish-func attribute: name of the function that finishes this async operation. */
+	finishFuncName?: string;
 
 	generics: Generic[] = [];
 
@@ -143,6 +145,7 @@ export class IntrospectedClassFunction<
 
 		fn.generics = [...this.generics];
 		fn.returnTypeDoc = this.returnTypeDoc;
+		fn.finishFuncName = this.finishFuncName;
 
 		if (interfaceParent) {
 			fn.interfaceParent = interfaceParent;
@@ -177,6 +180,10 @@ export class IntrospectedClassFunction<
 		// Convert the function to a class function
 		const { raw_name: name, output_parameters, parameters, return_type, doc, isIntrospectable } = fn;
 
+		// A function with shadowed-by is superseded by the shadowing function (which uses `shadows`)
+		// and takes the original name. Do not emit the shadowed function to avoid duplicate declarations.
+		const isShadowedBy = element.$["shadowed-by"] != null;
+
 		const classFn = new IntrospectedClassFunction({
 			parent,
 			name,
@@ -184,11 +191,12 @@ export class IntrospectedClassFunction<
 			parameters,
 			return_type,
 			doc,
-			isIntrospectable,
+			isIntrospectable: isIntrospectable && !isShadowedBy,
 		});
 
 		classFn.returnTypeDoc = fn.returnTypeDoc;
 		classFn.generics = [...fn.generics];
+		classFn.finishFuncName = element.$["glib:finish-func"];
 
 		return classFn;
 	}
@@ -396,6 +404,8 @@ export class IntrospectedStaticClassFunction extends IntrospectedClassFunction {
 		// Convert the function to a static class function
 		const { raw_name: name, output_parameters, parameters, return_type, doc, isIntrospectable } = fn;
 
+		const isShadowedBy = m.$["shadowed-by"] != null;
+
 		return new IntrospectedStaticClassFunction({
 			parent,
 			name,
@@ -403,7 +413,7 @@ export class IntrospectedStaticClassFunction extends IntrospectedClassFunction {
 			parameters,
 			return_type,
 			doc,
-			isIntrospectable,
+			isIntrospectable: isIntrospectable && !isShadowedBy,
 		});
 	}
 }

--- a/packages/lib/src/gir/promisify.ts
+++ b/packages/lib/src/gir/promisify.ts
@@ -62,6 +62,11 @@ function findFinishMethodInClass(cls: IntrospectedBaseClass, node: IntrospectedC
 			? [...cls.constructors, ...cls.members.filter((m) => m instanceof IntrospectedStaticClassFunction)]
 			: [...cls.members.filter((m) => !(m instanceof IntrospectedStaticClassFunction))];
 
+	// Prefer the GIR-specified finish function name over name heuristics
+	if (node.finishFuncName) {
+		return members.find((m) => m.name === node.finishFuncName);
+	}
+
 	return members.find(
 		(m) => m.name === `${node.name.replace(/_async$/, "")}_finish` || m.name === `${node.name}_finish`,
 	);

--- a/packages/lib/src/gir/property.ts
+++ b/packages/lib/src/gir/property.ts
@@ -98,6 +98,8 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 	readonly writable: boolean = false;
 	readonly readable: boolean = true;
 	readonly constructOnly: boolean;
+	/** GIR default-value attribute: the default value of the property as a string. */
+	defaultValue?: string;
 
 	get namespace() {
 		return this.parent.namespace;
@@ -110,7 +112,7 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 	}): IntrospectedProperty {
 		const { name, writable, readable, type, constructOnly, parent } = this;
 
-		return new IntrospectedProperty({
+		const prop = new IntrospectedProperty({
 			name: options?.name ?? name,
 			writable,
 			readable,
@@ -118,6 +120,8 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 			constructOnly,
 			parent: options?.parent ?? parent,
 		})._copyBaseProperties(this);
+		prop.defaultValue = this.defaultValue;
+		return prop;
 	}
 
 	accept(visitor: GirVisitor): IntrospectedProperty {
@@ -197,6 +201,8 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 			property.doc = parseDoc(element);
 			property.metadata = parseMetadata(element);
 		}
+
+		property.defaultValue = element.$["default-value"];
 
 		return property;
 	}


### PR DESCRIPTION
## Summary

Implements three previously-defined-but-unused GIR attributes, addressing Issue #115.

### 1. `glib:finish-func` in promisify (Priority 1 — highest impact)

`promisify.ts` previously used name-based heuristics to pair async functions with their finish counterpart (`_finish` / `_async_finish` suffix). These heuristics break for non-standard naming conventions.

Now `IntrospectedClassFunction` stores the `glib:finish-func` attribute from the GIR element. `findFinishMethodInClass` checks this attribute first; the name heuristic is kept as a fallback for GIRs that don't provide the attribute.

Files: `packages/lib/src/gir/introspected-classes.ts`, `packages/lib/src/gir/promisify.ts`

### 2. `default-value` on properties (Priority 2)

`IntrospectedProperty` now reads the `default-value` attribute from GIR and stores it as `defaultValue?: string`. The TypeScript generator emits it as a `@default` JSDoc tag so API consumers can see default values in their IDE.

Files: `packages/lib/src/gir/property.ts`, `packages/generator-typescript/src/module-generator.ts`

### 3. `shadowed-by` suppression (Priority 3)

Functions with a `shadowed-by` attribute are superseded by the function that carries the matching `shadows` attribute (which takes the original name). Previously both functions were emitted, causing duplicate declarations (e.g. `Gio.DBusConnection.register_object` appeared twice). Now the shadowed function is treated as non-introspectable and suppressed.

Files: `packages/lib/src/gir/introspected-classes.ts`

## Test plan

- [x] `yarn check:app` — no type errors
- [x] `yarn workspace @ts-for-gir-test/language-server-validation run test` — 19/19 tests pass
- [x] `yarn format` — no issues

Closes #115