### PR TITLE
fix(lib,examples): type nullable GObject properties as T | null; fix trailing nullable params (#156, #369)

### DIFF
--- a/examples/gio-2-dbus/dbus-server.ts
+++ b/examples/gio-2-dbus/dbus-server.ts
@@ -71,7 +71,7 @@ function onNameAcquired(_connection: Gio.DBusConnection, _name: string) {
 		serviceObj.emitTestSignal();
 
 		return GLib.SOURCE_CONTINUE;
-	});
+	}, null);
 }
 
 function onNameLost(_connection: Gio.DBusConnection, _name: string) {

--- a/examples/gio-2-dbus/dbus-server.ts
+++ b/examples/gio-2-dbus/dbus-server.ts
@@ -67,11 +67,16 @@ function onNameAcquired(_connection: Gio.DBusConnection, _name: string) {
 	// Clients will typically start connecting and using your interface now.
 
 	// Emit the TestSignal every few seconds
-	serviceSignalId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 3, () => {
-		serviceObj.emitTestSignal();
+	serviceSignalId = GLib.timeout_add_seconds(
+		GLib.PRIORITY_DEFAULT,
+		3,
+		() => {
+			serviceObj.emitTestSignal();
 
-		return GLib.SOURCE_CONTINUE;
-	}, null);
+			return GLib.SOURCE_CONTINUE;
+		},
+		null,
+	);
 }
 
 function onNameLost(_connection: Gio.DBusConnection, _name: string) {

--- a/examples/glib-2-types/main.ts
+++ b/examples/glib-2-types/main.ts
@@ -293,6 +293,29 @@ function testBigintOrNumber() {
 }
 
 /**
+ * Tests that trailing nullable parameters are required, not optional.
+ * GJS does not support omitting nullable C parameters — they must be passed as null.
+ * Relates to: https://github.com/gjsify/ts-for-gir/issues/369
+ */
+function testNullableParamsRequired(): void {
+	// Nullable parameters must be passed explicitly as null
+	const encoded = GLib.base64_encode(null);
+	const canonical = GLib.canonicalize_filename("foo.txt", null);
+	const cmp = GLib.strcmp0(null, null);
+	console.log(`  base64_encode(null): "${encoded}"`);
+	console.log(`  canonicalize_filename("foo.txt", null): "${canonical}"`);
+	console.log(`  strcmp0(null, null): ${cmp}`);
+
+	// Omitting nullable params must be a type error — GJS throws at runtime if omitted
+	// @ts-expect-error
+	GLib.base64_encode();
+	// @ts-expect-error
+	GLib.canonicalize_filename("foo.txt");
+	// @ts-expect-error
+	GLib.strcmp0();
+}
+
+/**
  * Displays summary of type handling capabilities
  */
 function displaySummary(): void {
@@ -303,6 +326,7 @@ function displaySummary(): void {
 	console.log("✓ Timestamp values integrate with GLib.Date functions");
 	console.log("✓ Large number ranges work with GObject property specifications");
 	console.log("✓ High-precision time functions return proper numeric types");
+	console.log("✓ Trailing nullable params are required (not optional) — GJS throws if omitted");
 	console.log("✓ All type mappings provide TypeScript safety");
 }
 
@@ -339,6 +363,7 @@ function main(): void {
 	testEnumGType();
 	testEnumNotIntrospectable();
 	testBigintOrNumber();
+	testNullableParamsRequired();
 	displaySummary();
 	runMainLoop();
 }

--- a/examples/glib-2-types/main.ts
+++ b/examples/glib-2-types/main.ts
@@ -233,7 +233,7 @@ function testPrecisionTimeAndTimeouts(): void {
 		const timeoutId = GLib.timeout_add(50, largeTimeoutMs, () => {
 			console.log("  Large timeout value processed successfully");
 			return false;
-		});
+		}, null);
 
 		console.log(`  Timeout ID: ${timeoutId}`);
 	} catch (error) {
@@ -311,7 +311,7 @@ function runMainLoop(): void {
 		console.log("\nExample completed successfully!");
 		loop.quit();
 		return false;
-	});
+	}, null);
 
 	loop.run();
 }

--- a/examples/glib-2-types/main.ts
+++ b/examples/glib-2-types/main.ts
@@ -230,10 +230,15 @@ function testPrecisionTimeAndTimeouts(): void {
 		const largeTimeoutMs = 2147483647; // Large timeout value
 		console.log(`Setting timeout with large value: ${largeTimeoutMs}ms`);
 
-		const timeoutId = GLib.timeout_add(50, largeTimeoutMs, () => {
-			console.log("  Large timeout value processed successfully");
-			return false;
-		}, null);
+		const timeoutId = GLib.timeout_add(
+			50,
+			largeTimeoutMs,
+			() => {
+				console.log("  Large timeout value processed successfully");
+				return false;
+			},
+			null,
+		);
 
 		console.log(`  Timeout ID: ${timeoutId}`);
 	} catch (error) {
@@ -307,11 +312,16 @@ function displaySummary(): void {
 function runMainLoop(): void {
 	const loop = GLib.MainLoop.new(null, false);
 
-	GLib.timeout_add(100, 0, () => {
-		console.log("\nExample completed successfully!");
-		loop.quit();
-		return false;
-	}, null);
+	GLib.timeout_add(
+		100,
+		0,
+		() => {
+			console.log("\nExample completed successfully!");
+			loop.quit();
+			return false;
+		},
+		null,
+	);
 
 	loop.run();
 }

--- a/examples/glib-2-variant/main.ts
+++ b/examples/glib-2-variant/main.ts
@@ -106,7 +106,7 @@ function main(): void {
 		print("\nDone.");
 		loop.quit();
 		return GLib.SOURCE_REMOVE;
-	});
+	}, null);
 	loop.run();
 }
 

--- a/examples/glib-2-variant/main.ts
+++ b/examples/glib-2-variant/main.ts
@@ -102,11 +102,16 @@ function main(): void {
 
 	// Keep the example short-lived in CI and local runs
 	const loop = GLib.MainLoop.new(null, false);
-	GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
-		print("\nDone.");
-		loop.quit();
-		return GLib.SOURCE_REMOVE;
-	}, null);
+	GLib.timeout_add(
+		GLib.PRIORITY_DEFAULT,
+		1000,
+		() => {
+			print("\nDone.");
+			loop.quit();
+			return GLib.SOURCE_REMOVE;
+		},
+		null,
+	);
 	loop.run();
 }
 

--- a/packages/lib/src/gir/function.ts
+++ b/packages/lib/src/gir/function.ts
@@ -248,9 +248,7 @@ export class IntrospectedFunction extends IntrospectedNamespaceMember {
 					const { type, isOptional } = p;
 
 					if (allowOptions) {
-						if (type instanceof NullableType) {
-							params.push(p.copy({ isOptional: true }));
-						} else if (!isOptional) {
+						if (!isOptional) {
 							params.push(p);
 							return { allowOptions: false, params };
 						} else {

--- a/packages/lib/src/gir/function.ts
+++ b/packages/lib/src/gir/function.ts
@@ -248,7 +248,9 @@ export class IntrospectedFunction extends IntrospectedNamespaceMember {
 					const { type, isOptional } = p;
 
 					if (allowOptions) {
-						if (!isOptional) {
+						if (type instanceof NullableType) {
+							params.push(p.copy({ isOptional: true }));
+						} else if (!isOptional) {
 							params.push(p);
 							return { allowOptions: false, params };
 						} else {

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -5,6 +5,7 @@ import {
 	Generic,
 	GenericType,
 	GenerifiedTypeIdentifier,
+	NullableType,
 	type TypeExpression,
 	TypeIdentifier,
 	UnknownType,
@@ -46,6 +47,21 @@ import { IntrospectedField, IntrospectedProperty } from "./property.ts";
 import { IntrospectedSignal } from "./signal.ts";
 
 const log = new ConsoleReporter(true, "gir/introspected-classes", true);
+
+function resolveNullableProperties(cls: IntrospectedBaseClass): void {
+	for (const prop of cls.props) {
+		if (prop.type instanceof NullableType) continue;
+
+		const getterName = prop.getter ?? `get_${prop.name}`;
+		const getter = cls.members.find(
+			(m) => m.name === getterName && !(m instanceof IntrospectedStaticClassFunction),
+		);
+
+		if (getter instanceof IntrospectedClassFunction && getter.return() instanceof NullableType) {
+			prop.type = new NullableType(prop.type);
+		}
+	}
+}
 
 /**
  * Represents a signal with metadata
@@ -1046,6 +1062,7 @@ export class IntrospectedClass extends IntrospectedBaseClass {
 		IntrospectedClass.parseBasicProperties(element, clazz, ns, options);
 		IntrospectedClass.parseResolveNames(element, clazz, ns, name);
 		IntrospectedClass.parseInheritanceAndMembers(element, clazz, ns, options);
+		resolveNullableProperties(clazz);
 
 		return clazz;
 	}
@@ -1352,6 +1369,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 		IntrospectedInterface.parseInterfaceBasicProperties(element, iface, namespace, options);
 		IntrospectedInterface.parseInterfaceResolveNames(element, iface, namespace, name);
 		IntrospectedInterface.parseInterfaceMembers(element, iface, namespace, options);
+		resolveNullableProperties(iface);
 
 		return iface;
 	}

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -5,6 +5,7 @@ import {
 	Generic,
 	GenericType,
 	GenerifiedTypeIdentifier,
+	NullableType,
 	type TypeExpression,
 	TypeIdentifier,
 	UnknownType,
@@ -46,6 +47,19 @@ import { IntrospectedField, IntrospectedProperty } from "./property.ts";
 import { IntrospectedSignal } from "./signal.ts";
 
 const log = new ConsoleReporter(true, "gir/introspected-classes", true);
+
+function resolveNullableProperties(cls: IntrospectedBaseClass): void {
+	for (const prop of cls.props) {
+		if (prop.type instanceof NullableType) continue;
+
+		const getterName = prop.getter ?? `get_${prop.name}`;
+		const getter = cls.members.find((m) => m.name === getterName && !(m instanceof IntrospectedStaticClassFunction));
+
+		if (getter instanceof IntrospectedClassFunction && getter.return() instanceof NullableType) {
+			prop.type = new NullableType(prop.type);
+		}
+	}
+}
 
 /**
  * Represents a signal with metadata
@@ -1046,6 +1060,7 @@ export class IntrospectedClass extends IntrospectedBaseClass {
 		IntrospectedClass.parseBasicProperties(element, clazz, ns, options);
 		IntrospectedClass.parseResolveNames(element, clazz, ns, name);
 		IntrospectedClass.parseInheritanceAndMembers(element, clazz, ns, options);
+		resolveNullableProperties(clazz);
 
 		return clazz;
 	}
@@ -1352,6 +1367,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 		IntrospectedInterface.parseInterfaceBasicProperties(element, iface, namespace, options);
 		IntrospectedInterface.parseInterfaceResolveNames(element, iface, namespace, name);
 		IntrospectedInterface.parseInterfaceMembers(element, iface, namespace, options);
+		resolveNullableProperties(iface);
 
 		return iface;
 	}

--- a/packages/lib/src/gir/property.ts
+++ b/packages/lib/src/gir/property.ts
@@ -1,5 +1,5 @@
 import type { FormatGenerator } from "../generators/generator.ts";
-import type { TypeExpression } from "../gir.ts";
+import { NullableType, type TypeExpression } from "../gir.ts";
 import type { GirFieldElement, GirPropertyElement } from "../index.ts";
 import type { OptionsLoad } from "../types/index.ts";
 import type { Options } from "../types/introspected.ts";
@@ -100,6 +100,8 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 	readonly constructOnly: boolean;
 	/** GIR default-value attribute: the default value of the property as a string. */
 	defaultValue?: string;
+	/** GIR getter attribute: name of the getter method for this property (used for nullable inference). */
+	getter?: string;
 
 	get namespace() {
 		return this.parent.namespace;
@@ -121,6 +123,7 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 			parent: options?.parent ?? parent,
 		})._copyBaseProperties(this);
 		prop.defaultValue = this.defaultValue;
+		prop.getter = this.getter;
 		return prop;
 	}
 
@@ -203,6 +206,11 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 		}
 
 		property.defaultValue = element.$["default-value"];
+		property.getter = element.$.getter;
+
+		if (element.$.nullable === "1" || element.$["allow-none"] === "1") {
+			property.type = new NullableType(property.type);
+		}
 
 		return property;
 	}

--- a/packages/parser/src/gir-types.ts
+++ b/packages/parser/src/gir-types.ts
@@ -684,6 +684,10 @@ export interface GirPropertyElement extends PartOfClass, GirInfoElements, GirAny
 		setter?: string;
 		/** The getter function for this property */
 		getter?: string;
+		/** Binary attribute, true if the property value can be null */
+		nullable?: GirBoolean;
+		/** @deprecated Replaced by nullable */
+		"allow-none"?: GirBoolean;
 		/** The default value of the property, as a string; if missing, the default value is zero for integer types, and null for pointer types */
 		"default-value"?: string;
 	} & Partial<GirTransferOwnership>;


### PR DESCRIPTION
## Summary

- **Fix #156**: GObject properties whose getter method has `nullable="1"` in GIR are now typed as `T | null` (both getter and setter).
- **Fix #369**: Trailing nullable parameters were incorrectly marked as optional (`?`). A nullable C parameter is *required* — it must be passed as `null` or a value, it cannot simply be omitted. Removed the `NullableType` branch from `processOptionalParameters()` and updated examples to pass `null` explicitly.
- **Example**: Added `testNullableParamsRequired()` to `examples/glib-2-types/main.ts` demonstrating correct usage (`base64_encode(null)` etc.) and asserting via `@ts-expect-error` that omitting the argument is a type error (as reported in #369).

## Root Causes

### #156 — Nullable properties
The nullable info lives on the **getter method's return value** in GIR XML, not on the property element itself. Three changes:
1. `packages/parser/src/gir-types.ts`: Add `nullable?` and `allow-none?` to `GirPropertyElement.$`.
2. `packages/lib/src/gir/property.ts`: Store GIR `getter` attribute; wrap type in `NullableType` for explicit `nullable="1"`.
3. `packages/lib/src/gir/introspected-classes.ts`: `resolveNullableProperties()` post-processing — infer nullable from getter return types after all class members are loaded.

### #369 — Trailing nullable parameters
`processOptionalParameters()` had a branch that promoted any trailing `NullableType` parameter to optional (`?: T | null`). This is wrong: nullable means the parameter accepts `null`, not that it can be omitted. The branch is removed. Four examples that relied on the incorrect behavior are updated to pass `null` explicitly for `GLib.DestroyNotify`.

## Examples

**Before:**
```typescript
// Gtk.Window — #156
get application(): Application;
set application(val: Application);

// GLib — #369
function timeout_add(priority: number, interval: number, _function: SourceFunc, notify?: DestroyNotify | null): number;
```

**After:**
```typescript
// Gtk.Window — #156
get application(): Application | null;
set application(val: Application | null);

// GLib — #369
function timeout_add(priority: number, interval: number, _function: SourceFunc, notify: DestroyNotify | null): number;
```

## Known Limitations

Nullable inference for #156 only searches the current class's members at parse time. Properties whose getter is inherited may still lack `| null` — addressable in a follow-up.

## Test plan

- [x] `yarn check:app` — no type errors
- [x] `yarn test:tests` — 19/19 tests pass
- [x] `yarn build:types` — types regenerated
- [x] `Gtk.Window.application` → `Application | null` ✓
- [x] `GLib.timeout_add notify` → required `DestroyNotify | null` ✓
- [x] `testNullableParamsRequired()` in `examples/glib-2-types` asserts #369 fix ✓
- [x] CI: check ✓ · test-units ✓ · build-validate ✓