### PR TITLE
fix(lib): expose array fields of complex GBoxed records (#180)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,8 @@ Demonstrate TS+GJS apps, validate generated types, serve as CI test cases.
 Patterns: `GObject.registerClass` with Properties/Signals | type-safe signal connections | Gtk.Template | bundler integrations (Vite, Webpack, esbuild, Rollup)
 All examples built+validated in CI; create/adapt examples when type issues are found.
 
+**Required for every type-generation PR**: Create or update an example that uses the previously-broken construct. The example exercises the affected types both at compile time (via `tsc --noEmit`) and at runtime (when executed with GJS), giving the fix static and dynamic regression coverage. Prefer extending an existing namespace example (e.g. `gio-2-dbus`, `glib-2-types`) over adding a new one. Mention the example update in the PR description.
+
 ## New Packages
 
 Structure: `packages/[name]/{src/index.ts, package.json, tsconfig.json(opt)}`

--- a/examples/gio-2-dbus/dbus-client.ts
+++ b/examples/gio-2-dbus/dbus-client.ts
@@ -6,6 +6,30 @@ import Gio from "gi://Gio?version=2.0";
 import GLib from "gi://GLib?version=2.0";
 import { type DbusIfaceXml, dbusIfaceXml } from "./dbus-ifrace-xml.ts";
 
+/**
+ * Walk the introspection tree exposed by Gio.DBusNodeInfo.
+ *
+ * Exercises array fields that were previously stripped from the generated
+ * types by the over-conservative `removeComplexFields` validator
+ * (see https://github.com/gjsify/ts-for-gir/issues/180):
+ *   - DBusNodeInfo.interfaces, DBusNodeInfo.nodes
+ *   - DBusInterfaceInfo.properties
+ */
+function inspectDbusIntrospection(): void {
+	const nodeInfo = Gio.DBusNodeInfo.new_for_xml(dbusIfaceXml);
+
+	for (const iface of nodeInfo.interfaces) {
+		print(`interface: ${iface.name}`);
+		for (const method of iface.methods) print(`  method: ${method.name}`);
+		for (const signal of iface.signals) print(`  signal: ${signal.name}`);
+		for (const property of iface.properties) {
+			print(`  property: ${property.name} (signature=${property.signature})`);
+		}
+	}
+
+	for (const child of nodeInfo.nodes) print(`node: ${child.path ?? "<anonymous>"}`);
+}
+
 // Pass the XML string to make a re-usable proxy class for an interface proxies.
 const TestProxy = Gio.DBusProxy.makeProxyWrapper<DbusIfaceXml>(dbusIfaceXml);
 
@@ -116,6 +140,7 @@ function onNameVanished(_connection: Gio.DBusConnection, name: string) {
 }
 
 print("Start DBus client");
+inspectDbusIntrospection();
 const busWatchId = Gio.bus_watch_name(
 	Gio.BusType.SESSION,
 	"org.gnome.gjs.Test",

--- a/packages/lib/src/utils/conflicts.ts
+++ b/packages/lib/src/utils/conflicts.ts
@@ -261,8 +261,13 @@ function checkFunctionConflicts<T extends IntrospectedClassFunction | Introspect
 		});
 	});
 
-	// Check field/property conflicts
-	const hasFieldConflicts = checkFieldPropertyConflicts(base, functionElement.name);
+	// Static methods can coexist with instance fields/properties of the same name
+	// in TypeScript (e.g. `static map(...)` alongside `map: T[]`), so skip the check
+	// for them. The conflict only applies to instance methods.
+	const hasFieldConflicts =
+		functionElement instanceof IntrospectedStaticClassFunction
+			? false
+			: checkFieldPropertyConflicts(base, functionElement.name);
 
 	// Check GObject reserved methods
 	const hasGObjectConflicts = checkGObjectConflicts(base, functionElement.name);

--- a/packages/lib/src/validators/class.ts
+++ b/packages/lib/src/validators/class.ts
@@ -3,7 +3,7 @@ import { IntrospectedError } from "../gir/error.ts";
 import type { IntrospectedBaseClass, IntrospectedClass, IntrospectedInterface } from "../gir/introspected-classes.ts";
 import { IntrospectedClassFunction, IntrospectedStaticClassFunction } from "../gir/introspected-classes.ts";
 import { IntrospectedRecord } from "../gir/record.ts";
-import { AnyType, NativeType, TypeIdentifier } from "../gir.ts";
+import { AnyType, ArrayType, NativeType, TypeIdentifier } from "../gir.ts";
 import { resolveTypeIdentifier } from "../utils/type-resolution.ts";
 import { GirVisitor } from "../visitor.ts";
 
@@ -125,9 +125,10 @@ const fixMissingParent = <T extends IntrospectedBaseClass>(node: T): T => {
 };
 
 /**
- * Fields cannot be array types, error types,
- * or class-like types in GJS. This strips
- * fields which have these "complex" types.
+ * Removes fields with types that GJS cannot directly expose on a struct instance.
+ * Error types and non-simple non-pointer struct fields are removed.
+ * Array fields (zero-terminated pointer arrays, T**) are always safe in GJS and are only
+ * rejected if the element type is private or disguised.
  *
  * @param node
  */
@@ -135,6 +136,17 @@ const removeComplexFields = <T extends IntrospectedBaseClass>(node: T): T => {
 	const { namespace } = node;
 
 	node.fields = node.fields.filter((f) => {
+		// Array fields (T**) are marshalled by GJS for any GBoxed element type.
+		// Only reject arrays of private/disguised element types.
+		if (f.type instanceof ArrayType) {
+			const elementType = f.type.deepUnwrap();
+			if (elementType instanceof TypeIdentifier) {
+				const classNode = resolveTypeIdentifier(namespace, elementType);
+				return !classNode?.isPrivate;
+			}
+			return true;
+		}
+
 		const type = f.type.deepUnwrap();
 
 		if (type instanceof NativeType) {


### PR DESCRIPTION
## Summary

Fixes #180 — `Gio.DBusNodeInfo` was missing `interfaces` and `nodes` fields (and `Gio.DBusInterfaceInfo` was missing `properties`), even though they are correctly defined in the GIR XML and fully accessible at GJS runtime.

## Root cause

`removeComplexFields` in `packages/lib/src/validators/class.ts` used `f.type.deepUnwrap()` to get the element type of an array field, then called `isSimple()` on the resolved record. If the element record had any complex nested fields, `isSimple()` returned `false` and the entire array field was filtered out.

The check is correct for non-pointer embedded struct fields (where GJS can't allocate a complex struct inline), but wrong for array fields (`T**` zero-terminated pointer arrays): GJS marshals those into JS arrays for any GBoxed type via `gjs_array_from_zero_terminated_c_array()` regardless of element complexity.

## Change

Added an early `ArrayType` branch in `removeComplexFields` that only rejects arrays of private/disguised element types and skips the `isSimple()` check entirely for arrays. `isSimple()` and `isSimpleType()` are unchanged — they remain correct for determining whether a record can be directly constructed.

## Impact on generated types

28 files changed, +138 / -57 lines:
- `Gio.DBusNodeInfo` gains `interfaces: DBusInterfaceInfo[]`, `nodes: DBusNodeInfo[]`
- `Gio.DBusInterfaceInfo` gains `properties: DBusPropertyInfo[]`
- Various records across other namespaces (audio, qmi, secret, gst-*, gtk-3.0 etc.) gain previously-missing array fields pointing to other records
- No previously-exposed fields are removed

## Test plan

- [x] `yarn check:app` passes
- [x] `yarn build:types` regenerates expected output
- [x] `yarn test:tests` passes
- [x] `Gio.DBusNodeInfo.interfaces` and `.nodes` appear in `types-dev/gio-2.0/gio-2.0.d.ts`