### PR TITLE
feat(gtk-4): type GJS-only Gtk.Builder constructor props and exposeObjects

### DIFF
--- a/examples/gtk-4-custom-widget/index.ts
+++ b/examples/gtk-4-custom-widget/index.ts
@@ -65,21 +65,31 @@ function onActivate() {
 	window.set_default_size(200, 200);
 	window.connect("close-request", onQuit);
 
-	const ui = getUI();
-	const builder = Gtk.Builder.new_from_string(ui, ui.length);
-	const root = builder.get_object("root") as Gtk.Box;
 	const custom = new CustomWidget();
-	root.append(custom);
-	custom.show();
 
-	const actionButton = builder.get_object("actionButton") as Gtk.Button;
-	actionButton?.connect("clicked", () => {
-		console.log("clicked");
-		custom.customMethod();
+	// Exercises GJS-only Builder constructor props (`data`, `callbacks`, `objects`)
+	// that are typed via the gtk-4.0 template — the `data` source is loaded with
+	// `add_from_string`, `<signal handler="...">` is resolved against `callbacks`,
+	// and `objects` registers existing widgets for `<object id="..." constructor="">`.
+	const builder = new Gtk.Builder({
+		data: getUI(),
+		callbacks: {
+			on_action_clicked: () => {
+				console.log("clicked");
+				custom.customMethod();
+			},
+			on_close_clicked: () => window.close(),
+		},
+		objects: { custom },
 	});
 
-	const closeButton = builder.get_object("closeButton") as Gtk.Button;
-	closeButton?.connect("clicked", () => window.close());
+	// Demonstrates the `exposeObjects` GJS-only convenience method (registers each
+	// entry by name so the UI XML can reference it via `<object constructor="...">`).
+	builder.exposeObjects({ window });
+
+	const root = builder.get_object("root") as Gtk.Box;
+	root.append(custom);
+	custom.show();
 
 	if (root) window.set_child(root);
 	window.present();
@@ -110,12 +120,14 @@ function getUI() {
           <object class="GtkButton" id="actionButton">
             <property name="label" translatable="yes">Action</property>
             <property name="receives_default">1</property>
+            <signal name="clicked" handler="on_action_clicked"/>
           </object>
         </child>
         <child>
           <object class="GtkButton" id="closeButton">
             <property name="label" translatable="yes">Close</property>
             <property name="receives_default">1</property>
+            <signal name="clicked" handler="on_close_clicked"/>
           </object>
         </child>
       </object>

--- a/packages/templates/templates/gtk-4.0.d.ts
+++ b/packages/templates/templates/gtk-4.0.d.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+
+/**
+ * GJS replaces `Gtk.Builder` with a JS subclass (`GtkJSBuilder`) whose constructor
+ * accepts five additional, JS-only properties on top of the GIR-derived ones:
+ * `data`, `filename`, `resource`, `callbacks`, and `objects`. They are consumed at
+ * construction time (used to call `add_from_string` / `add_from_file` /
+ * `add_from_resource`, set up a callback scope, and register named objects), so
+ * they appear only in the constructor signature, not as instance accessors.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/core/overrides/Gtk.js
+ * @example
+ * ```ts
+ * const builder = new Gtk.Builder({
+ *     filename: "window.ui",
+ *     callbacks: { on_clicked: () => print("clicked") },
+ *     objects: { existing: someExistingWidget },
+ * });
+ * ```
+ */
+export namespace Builder {
+    interface ConstructorProps {
+        /** Inline XML interface description. Calls `add_from_string` on construction. */
+        data?: string | Uint8Array
+        /** Path to a UI file. Calls `add_from_file` on construction. */
+        filename?: string
+        /** Resource path to a UI file. Calls `add_from_resource` on construction. */
+        resource?: string
+        /** Named signal callbacks resolved against `<signal>` `handler` attributes. */
+        callbacks?: Record<string, (...args: any[]) => any>
+        /** Pre-existing objects exposed to the UI via {@link Builder.exposeObjects}. */
+        objects?: Record<string, GObject.Object>
+    }
+}
+
+/**
+ * GJS-only convenience method on {@link Builder}: registers every entry of
+ * `objects` so the UI XML can reference them by name.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/core/overrides/Gtk.js
+ */
+export interface Builder {
+    exposeObjects(objects: Record<string, GObject.Object>): void
+}


### PR DESCRIPTION
## Summary

GJS replaces `Gtk.Builder` with a JS subclass (`GtkJSBuilder`) that accepts five constructor-only properties not present in the GIR XML:

- `data` — inline XML string (calls `add_from_string`)
- `filename` — path to UI file (calls `add_from_file`)
- `resource` — resource path (calls `add_from_resource`)
- `callbacks` — signal handler map resolved against `<signal handler="...">` attributes
- `objects` — pre-existing GObject instances to register

It also adds a convenience method `exposeObjects()` that registers objects by name so the UI XML can reference them.

## Implementation

- Added `packages/templates/templates/gtk-4.0.d.ts` — uses TypeScript declaration merging to extend `Builder.ConstructorProps` and `Builder` interface without touching GIR-generated output
- Updated `examples/gtk-4-custom-widget/index.ts` — exercises `new Gtk.Builder({ data, callbacks, objects })` and `builder.exposeObjects()` for both compile-time and runtime validation

## References

- GJS source: `modules/core/overrides/Gtk.js` lines 116–191
- Related to the "missing GJS runtime features" audit

## Test plan

- [x] `yarn build:types` — regenerated types include new `Builder.ConstructorProps` fields and `exposeObjects`
- [x] `yarn check:app` — passes with no type errors
- [x] `yarn build:examples` — gtk-4-custom-widget builds successfully
- [x] `yarn test:tests` — all tests pass