### PR TITLE
fix(lib): stop duplicating GObject.Object members on classes implementing interfaces (#222)

### DIFF
--- a/examples/virtual-interface-test/main.ts
+++ b/examples/virtual-interface-test/main.ts
@@ -157,8 +157,19 @@ class IssueGh222Regression extends GObject.Object implements Gdk.Paintable.Inter
 	declare get_intrinsic_height: Gdk.Paintable["get_intrinsic_height"];
 	declare get_intrinsic_width: Gdk.Paintable["get_intrinsic_width"];
 
+	declare value: number;
+
 	static {
-		GObject.registerClass({ GTypeName: "IssueGh222Regression", Implements: [Gdk.Paintable] }, IssueGh222Regression);
+		GObject.registerClass(
+			{
+				GTypeName: "IssueGh222Regression",
+				Implements: [Gdk.Paintable],
+				Properties: {
+					value: GObject.ParamSpec.int("value", "Value", "A test property", GObject.ParamFlags.READWRITE, 0, 100, 0),
+				},
+			},
+			IssueGh222Regression,
+		);
 	}
 
 	vfunc_get_current_image(this: this & Gdk.Paintable): Gdk.Paintable {
@@ -207,13 +218,15 @@ function main() {
 	// callable with their real signatures rather than `(...args: never[]): any`.
 	console.log("\n3. Testing issue #222 regression (Gdk.Paintable + GObject.Object methods):");
 	const subject = new IssueGh222Regression();
-	const target = new GObject.Object();
-	const binding = subject.bind_property_full("x", target, "y", GObject.BindingFlags.DEFAULT, null, null);
-	binding.unbind();
+	const target = new IssueGh222Regression();
+	const binding = subject.bind_property_full("value", target, "value", GObject.BindingFlags.DEFAULT, null, null);
 	subject.freeze_notify();
-	subject.notify("x");
+	subject.value = 42;
 	subject.thaw_notify();
-	console.log(`  bind_property_full + notify roundtrip OK on ${subject.constructor.name}`);
+	subject.notify("value");
+	const propagated = target.value;
+	binding.unbind();
+	console.log(`  bind_property_full + notify roundtrip OK on ${subject.constructor.name}, target.value=${propagated}`);
 }
 
 // Run the test

--- a/examples/virtual-interface-test/main.ts
+++ b/examples/virtual-interface-test/main.ts
@@ -140,6 +140,45 @@ class CustomPaintable extends GObject.Object implements Gdk.Paintable.Interface 
 	}
 }
 
+/**
+ * Regression for https://github.com/gjsify/ts-for-gir/issues/222
+ *
+ * Before the fix, a class that extended GObject.Object and implemented an
+ * interface whose `<prerequisite>` was GObject.Object (e.g. Gdk.Paintable) had
+ * every GObject.Object member duplicated into its body. The conflict resolver
+ * then emitted a `(...args: never[]): any` overload alongside each duplicate,
+ * which broke real call sites such as `bind_property_full(...)`. This class
+ * exercises the previously broken methods to lock in the fix.
+ */
+class IssueGh222Regression extends GObject.Object implements Gdk.Paintable.Interface {
+	declare get_current_image: Gdk.Paintable["get_current_image"];
+	declare get_flags: Gdk.Paintable["get_flags"];
+	declare get_intrinsic_aspect_ratio: Gdk.Paintable["get_intrinsic_aspect_ratio"];
+	declare get_intrinsic_height: Gdk.Paintable["get_intrinsic_height"];
+	declare get_intrinsic_width: Gdk.Paintable["get_intrinsic_width"];
+
+	static {
+		GObject.registerClass({ GTypeName: "IssueGh222Regression", Implements: [Gdk.Paintable] }, IssueGh222Regression);
+	}
+
+	vfunc_get_current_image(this: this & Gdk.Paintable): Gdk.Paintable {
+		return this;
+	}
+	vfunc_get_flags(): Gdk.PaintableFlags {
+		return Gdk.PaintableFlags.STATIC_SIZE;
+	}
+	vfunc_get_intrinsic_aspect_ratio(): number {
+		return 1;
+	}
+	vfunc_get_intrinsic_height(): number {
+		return 0;
+	}
+	vfunc_get_intrinsic_width(): number {
+		return 0;
+	}
+	vfunc_snapshot(_snapshot: Gdk.Snapshot, _width: number, _height: number): void {}
+}
+
 function main() {
 	console.log("=== Virtual Interface Demo ===");
 
@@ -163,6 +202,18 @@ function main() {
 	console.log(`Intrinsic height: ${paintable.get_intrinsic_height()}`);
 	console.log(`Aspect ratio: ${paintable.get_intrinsic_aspect_ratio()}`);
 	console.log(`Flags: ${paintable.get_flags()}`);
+
+	// Issue #222 regression: methods inherited from GObject.Object must be
+	// callable with their real signatures rather than `(...args: never[]): any`.
+	console.log("\n3. Testing issue #222 regression (Gdk.Paintable + GObject.Object methods):");
+	const subject = new IssueGh222Regression();
+	const target = new GObject.Object();
+	const binding = subject.bind_property_full("x", target, "y", GObject.BindingFlags.DEFAULT, null, null);
+	binding.unbind();
+	subject.freeze_notify();
+	subject.notify("x");
+	subject.thaw_notify();
+	console.log(`  bind_property_full + notify roundtrip OK on ${subject.constructor.name}`);
 }
 
 // Run the test

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -48,6 +48,27 @@ import { IntrospectedSignal } from "./signal.ts";
 
 const log = new ConsoleReporter(true, "gir/introspected-classes", true);
 
+/**
+ * Walks the implementing class's `extends` chain (skipping the prerequisite class
+ * itself) and reports whether any ancestor *shadows* a member by declaring its
+ * own member of the given name. A shadow indicates the parent chain has
+ * overridden the prerequisite's member with a possibly incompatible type, which
+ * would otherwise leave the implementing class unable to satisfy the
+ * interface's contract.
+ */
+function hasExtendsShadowOf(cls: IntrospectedBaseClass, prerequisite: IntrospectedBaseClass, name: string): boolean {
+	let current = cls.resolveParents().extends();
+	while (current) {
+		const node = current.node;
+		if (node !== prerequisite) {
+			const hasOwn = [...node.props, ...node.fields, ...node.members].some((m) => m.name === name);
+			if (hasOwn) return true;
+		}
+		current = current.extends();
+	}
+	return false;
+}
+
 function resolveNullableProperties(cls: IntrospectedBaseClass): void {
 	for (const prop of cls.props) {
 		if (prop.type instanceof NullableType) continue;
@@ -877,13 +898,19 @@ export class IntrospectedClass extends IntrospectedBaseClass {
 			});
 		}
 
-		// If an interface inherits from a class (such as Gtk.Widget)
-		// we need to pull in every item from that class...
+		// An interface's <prerequisite> of class type is always satisfied by the
+		// implementing class's actual parent chain — those members are already
+		// inherited via TS class inheritance, so we don't re-emit them. The one
+		// case we still need to handle: when the parent chain has a same-named
+		// member with an incompatible signature/type, we re-emit the interface's
+		// version so `filterConflicts` / `filterFunctionConflict` can broaden or
+		// override it to satisfy both `extends` and `implements` simultaneously.
 		for (const implemented of resolution.implements()) {
 			const extended = implemented.extends();
 			if (extended?.node instanceof IntrospectedClass) {
 				for (const item of getItems(extended.node)) {
 					if (items.has(item.name) || !validate(item)) continue;
+					if (!hasExtendsShadowOf(this, extended.node, item.name)) continue;
 					items.set(item.name, item);
 				}
 			}


### PR DESCRIPTION
Fixes #222.

## Summary
- `collectImplementedItems` walked each implemented interface's `<prerequisite>` class and copied every one of its members into the implementing class body. Because GIR `<prerequisite>` of class type is always satisfied by the implementer's actual `extends` chain (e.g. `Gtk.MediaStream extends GObject.Object` already inherits everything from `GObject.Object`), this was pure duplication. The duplicates then collided with the inherited copies and the conflict resolver emitted `(...args: never[]): any` overloads, breaking real call sites such as `bind_property_full(...)`.
- Replace the unconditional copy with a guarded version: only re-emit a prerequisite class member when an ancestor in the implementer's `extends` chain *shadows* it (declares its own same-named member). The shadow case is the only one where the broadened-via-`filterConflicts` copy is structurally needed — e.g. `Gtk.Dialog.window: Gtk.Window` (field) shadows `Gtk.Widget.window: Gdk.Window | null` (accessor), and `Gtk.AppChooserDialog implements AppChooser` requires a broadened `window: (Gdk.Window | null) | any` to satisfy both `extends` and `implements`.
- Extend `examples/virtual-interface-test` with `IssueGh222Regression` (a class shaped exactly like the bug report) that calls `bind_property_full`, `freeze_notify`, `notify`, and `thaw_notify` — locking in compile-time + runtime regression coverage as required by `CLAUDE.md`.

## Effect on generated output
After `yarn build:types`:
- `gtk-4.0.d.ts`: 294,112 → 141,809 lines (~52% smaller)
- 397 generated `.d.ts` files: net -3.34M lines
- `Gtk.MediaStream` body shrunk from ~1300 to 675 lines; the `// Conflicted with GObject.Object.bind_property_full` and `bind_property_full(...args: never[]): any` overloads from the issue are gone.

## Test plan
- [x] `yarn build:types` regenerates types cleanly
- [x] `yarn build:examples` builds all examples
- [x] `yarn check` (lint + app type-check) passes
- [x] `yarn test:tests` passes
- [x] `yarn workspace @ts-for-gir-example/virtual-interface-test run check` passes (`tsc --noEmit`)
- [x] Manual: run the extended example under GJS and verify `bind_property_full`/`notify` roundtrip prints OK