### PR TITLE
fix(lib): unwrap NullableType before filtering DestroyNotify params

### DIFF
--- a/examples/gio-2-dbus/dbus-server.ts
+++ b/examples/gio-2-dbus/dbus-server.ts
@@ -67,16 +67,11 @@ function onNameAcquired(_connection: Gio.DBusConnection, _name: string) {
 	// Clients will typically start connecting and using your interface now.
 
 	// Emit the TestSignal every few seconds
-	serviceSignalId = GLib.timeout_add_seconds(
-		GLib.PRIORITY_DEFAULT,
-		3,
-		() => {
-			serviceObj.emitTestSignal();
+	serviceSignalId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 3, () => {
+		serviceObj.emitTestSignal();
 
-			return GLib.SOURCE_CONTINUE;
-		},
-		null,
-	);
+		return GLib.SOURCE_CONTINUE;
+	});
 }
 
 function onNameLost(_connection: Gio.DBusConnection, _name: string) {

--- a/examples/glib-2-types/main.ts
+++ b/examples/glib-2-types/main.ts
@@ -230,15 +230,10 @@ function testPrecisionTimeAndTimeouts(): void {
 		const largeTimeoutMs = 2147483647; // Large timeout value
 		console.log(`Setting timeout with large value: ${largeTimeoutMs}ms`);
 
-		const timeoutId = GLib.timeout_add(
-			50,
-			largeTimeoutMs,
-			() => {
+		const timeoutId = GLib.timeout_add(50, largeTimeoutMs, () => {
 				console.log("  Large timeout value processed successfully");
 				return false;
-			},
-			null,
-		);
+			});
 
 		console.log(`  Timeout ID: ${timeoutId}`);
 	} catch (error) {
@@ -316,6 +311,34 @@ function testNullableParamsRequired(): void {
 }
 
 /**
+ * Tests that GLib.DestroyNotify params are stripped from _full-shadowed functions.
+ * GJS handles destroy-notify internally for scope="notified" callbacks and does not
+ * expose that parameter — idle_add and timeout_add only accept (priority, fn).
+ * Relates to: https://github.com/gjsify/ts-for-gir/issues/369
+ */
+function testDestroyNotifyParamsFiltered(): void {
+	// idle_add takes only (priority, callback) — no notify argument
+	const id = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+		GLib.Source.remove(id);
+		return GLib.SOURCE_REMOVE;
+	});
+	console.log(`  idle_add id: ${id}`);
+
+	// timeout_add takes (priority, interval, callback) — no notify argument
+	const tid = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1, () => {
+		GLib.Source.remove(tid);
+		return GLib.SOURCE_REMOVE;
+	});
+	console.log(`  timeout_add id: ${tid}`);
+
+	// Passing a spurious null as notify must be a type error (GJS would warn at runtime)
+	// @ts-expect-error
+	GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => false, null);
+	// @ts-expect-error
+	GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1, () => false, null);
+}
+
+/**
  * Displays summary of type handling capabilities
  */
 function displaySummary(): void {
@@ -327,6 +350,7 @@ function displaySummary(): void {
 	console.log("✓ Large number ranges work with GObject property specifications");
 	console.log("✓ High-precision time functions return proper numeric types");
 	console.log("✓ Trailing nullable params are required (not optional) — GJS throws if omitted");
+	console.log("✓ DestroyNotify params stripped from idle_add/timeout_add — GJS handles destroy internally");
 	console.log("✓ All type mappings provide TypeScript safety");
 }
 
@@ -336,16 +360,11 @@ function displaySummary(): void {
 function runMainLoop(): void {
 	const loop = GLib.MainLoop.new(null, false);
 
-	GLib.timeout_add(
-		100,
-		0,
-		() => {
-			console.log("\nExample completed successfully!");
-			loop.quit();
-			return false;
-		},
-		null,
-	);
+	GLib.timeout_add(100, 0, () => {
+		console.log("\nExample completed successfully!");
+		loop.quit();
+		return false;
+	});
 
 	loop.run();
 }
@@ -363,6 +382,7 @@ function main(): void {
 	testEnumGType();
 	testEnumNotIntrospectable();
 	testBigintOrNumber();
+	testDestroyNotifyParamsFiltered();
 	testNullableParamsRequired();
 	displaySummary();
 	runMainLoop();

--- a/examples/glib-2-types/main.ts
+++ b/examples/glib-2-types/main.ts
@@ -231,9 +231,9 @@ function testPrecisionTimeAndTimeouts(): void {
 		console.log(`Setting timeout with large value: ${largeTimeoutMs}ms`);
 
 		const timeoutId = GLib.timeout_add(50, largeTimeoutMs, () => {
-				console.log("  Large timeout value processed successfully");
-				return false;
-			});
+			console.log("  Large timeout value processed successfully");
+			return false;
+		});
 
 		console.log(`  Timeout ID: ${timeoutId}`);
 	} catch (error) {
@@ -301,13 +301,16 @@ function testNullableParamsRequired(): void {
 	console.log(`  canonicalize_filename("foo.txt", null): "${canonical}"`);
 	console.log(`  strcmp0(null, null): ${cmp}`);
 
-	// Omitting nullable params must be a type error — GJS throws at runtime if omitted
-	// @ts-expect-error
-	GLib.base64_encode();
-	// @ts-expect-error
-	GLib.canonicalize_filename("foo.txt");
-	// @ts-expect-error
-	GLib.strcmp0();
+	// Omitting nullable params is a compile-time type error.
+	// Wrapped in `if (false)` so TypeScript still checks the types but the code never runs.
+	if (false as boolean) {
+		// @ts-expect-error
+		GLib.base64_encode();
+		// @ts-expect-error
+		GLib.canonicalize_filename("foo.txt");
+		// @ts-expect-error
+		GLib.strcmp0();
+	}
 }
 
 /**
@@ -331,11 +334,14 @@ function testDestroyNotifyParamsFiltered(): void {
 	});
 	console.log(`  timeout_add id: ${tid}`);
 
-	// Passing a spurious null as notify must be a type error (GJS would warn at runtime)
-	// @ts-expect-error
-	GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => false, null);
-	// @ts-expect-error
-	GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1, () => false, null);
+	// Passing a spurious null as notify is a compile-time type error.
+	// Wrapped in `if (false)` so TypeScript still checks the types but the code never runs.
+	if (false as boolean) {
+		// @ts-expect-error
+		GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => false, null);
+		// @ts-expect-error
+		GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1, () => false, null);
+	}
 }
 
 /**

--- a/examples/glib-2-variant/main.ts
+++ b/examples/glib-2-variant/main.ts
@@ -102,16 +102,11 @@ function main(): void {
 
 	// Keep the example short-lived in CI and local runs
 	const loop = GLib.MainLoop.new(null, false);
-	GLib.timeout_add(
-		GLib.PRIORITY_DEFAULT,
-		1000,
-		() => {
-			print("\nDone.");
-			loop.quit();
-			return GLib.SOURCE_REMOVE;
-		},
-		null,
-	);
+	GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+		print("\nDone.");
+		loop.quit();
+		return GLib.SOURCE_REMOVE;
+	});
 	loop.run();
 }
 

--- a/packages/lib/src/gir/function.ts
+++ b/packages/lib/src/gir/function.ts
@@ -235,7 +235,10 @@ export class IntrospectedFunction extends IntrospectedNamespaceMember {
 	): IntrospectedFunctionParameter[] {
 		return parameters
 			.filter((_, i) => !length_params.includes(i) && !user_data_params.includes(i))
-			.filter((v) => !(v.type instanceof TypeIdentifier && v.type.is("GLib", "DestroyNotify")));
+			.filter((v) => {
+				const unwrapped = v.type.unwrap();
+				return !(unwrapped instanceof TypeIdentifier && unwrapped.is("GLib", "DestroyNotify"));
+			});
 	}
 
 	private static processOptionalParameters(


### PR DESCRIPTION
## Summary

- `filterParameters` in `packages/lib/src/gir/function.ts` was checking `v.type instanceof TypeIdentifier` to drop `GLib.DestroyNotify` parameters from generated signatures
- However, `getType()` in `gir-parsing.ts` already wraps `nullable="1"` parameters in `NullableType` before returning them — so the type of `notify` was `NullableType(TypeIdentifier("DestroyNotify"))`, not a plain `TypeIdentifier`
- The `instanceof` check never matched, so `notify` was never filtered out

**Before #369** this was invisible: `notify` stayed in the signature as `notify?: DestroyNotify | null` (optional), so callers could safely omit it.

**After #369** (trailing nullable → required): TypeScript forced callers to write `GLib.idle_add(priority, fn, null)`, which triggered a GJS runtime warning:
```
Too many arguments to function GLib.idle_add: expected 2, got 3
```

GJS handles `data` (closure) and `notify` (destroy-notify) internally for `scope="notified"` callbacks and does not expose them — only `(priority, _function)` are valid arguments.

**Fix:** call `unwrap()` on the type before the `instanceof TypeIdentifier` check, so `NullableType(DestroyNotify)` is also caught and filtered. Generated signatures after fix:

```ts
// before fix
function idle_add(priority: number, _function: SourceFunc, notify: (DestroyNotify | null)): number;
function timeout_add(priority: number, interval: number, _function: SourceFunc, notify: (DestroyNotify | null)): number;

// after fix
function idle_add(priority: number, _function: SourceFunc): number;
function timeout_add(priority: number, interval: number, _function: SourceFunc): number;
```

Same fix applies to `timeout_add_seconds`, `child_watch_add`, and other `_full` variants that shadow a simpler form.

## Example

Updated `examples/glib-2-types/main.ts` with `testDestroyNotifyParamsFiltered()`:
- Calls `GLib.idle_add(priority, fn)` and `GLib.timeout_add(priority, interval, fn)` without `notify` — compiles and runs without GJS warnings ✓
- `@ts-expect-error` annotations show that passing `null` as a 3rd/4th arg is a compile-time error; at runtime GJS emits the same "Too many arguments" warning that was the original bug
- Removed the trailing `null` from existing `timeout_add` calls in the example

## Test plan

- [x] `yarn ts-for-gir-dev generate GLib-2.0` — verified `idle_add` and `timeout_add` signatures no longer include `notify`
- [x] `yarn workspace @ts-for-gir-example/glib-2-types run check` — passes (exit 0)
- [x] `yarn workspace @ts-for-gir-example/glib-2-types run build && gjs -m dist/main.js` — `idle_add` and `timeout_add` run without GJS warnings
- [x] `yarn workspace @ts-for-gir-test/types-locally run test` — passes
- [x] `yarn test:tests` — passes

Relates to #369 / #370