### PR TITLE
Make raw pointer (`void*`) handling more like GJS

### DIFF
--- a/examples/glib-2-types/main.ts
+++ b/examples/glib-2-types/main.ts
@@ -313,6 +313,31 @@ function testNullableParamsRequired(): void {
 	}
 }
 
+function testRawPointers(): void {
+	// Non-nullable raw pointers cannot be passed to functions, either according
+	// to TypeScript or at runtime
+	let failed = false;
+	try {
+		// @ts-expect-error
+		GLib.str_hash("foobar");
+	} catch (_) {
+		failed = true;
+	}
+	if (!failed) throw new Error("Passing value to non-nullable raw pointer failed");
+
+	// Nullable raw pointers are always marshalled as C null, even if you pass
+	// something else
+	// @ts-expect-error
+	const nonnullHash = GLib.direct_hash("foobar");
+	const nullHash = GLib.direct_hash(null);
+	if (nonnullHash !== nullHash) throw new Error("Passing value to nullable raw pointer failed");
+
+	// Raw pointers are always marshalled as JS null, even if the function
+	// returns something else
+	const pointer: null = GLib.aligned_alloc0(1, 64, 8);
+	if (pointer !== null) throw new Error("Returning raw pointer from function failed");
+}
+
 /**
  * Tests that GLib.DestroyNotify params are stripped from _full-shadowed functions.
  * GJS handles destroy-notify internally for scope="notified" callbacks and does not
@@ -390,6 +415,7 @@ function main(): void {
 	testBigintOrNumber();
 	testDestroyNotifyParamsFiltered();
 	testNullableParamsRequired();
+	testRawPointers();
 	displaySummary();
 	runMainLoop();
 }

--- a/packages/lib/src/gir.ts
+++ b/packages/lib/src/gir.ts
@@ -633,6 +633,7 @@ export class NullableType extends BinaryType {
 }
 
 export function makeNullable(type: TypeExpression) {
+	if (type === RawPointerType) return NullType;
 	if (type === AnyType) return AnyType;
 	return new NullableType(type);
 }
@@ -871,5 +872,8 @@ export const NullType = new NativeType("null");
 export const VoidType = new NativeType("void");
 export const UnknownType = new NativeType("unknown");
 export const AnyFunctionType = new NativeType("(...args: any[]) => any");
+// Distinct from NeverType, so that we can transform it into NullType when
+// marshalled from C to JS
+export const RawPointerType = new NativeType("never");
 
 export type GirClassField = IntrospectedProperty | IntrospectedField;

--- a/packages/lib/src/gir.ts
+++ b/packages/lib/src/gir.ts
@@ -624,12 +624,17 @@ export class NullableType extends BinaryType {
 	}
 
 	rewrap(type: TypeExpression): TypeExpression {
-		return new NullableType(this.a.rewrap(type));
+		return makeNullable(this.a.rewrap(type));
 	}
 
 	get type() {
 		return this.a;
 	}
+}
+
+export function makeNullable(type: TypeExpression) {
+	if (type === AnyType) return AnyType;
+	return new NullableType(type);
 }
 
 export class PromiseType extends TypeExpression {

--- a/packages/lib/src/gir/function.ts
+++ b/packages/lib/src/gir/function.ts
@@ -4,6 +4,7 @@ import {
 	ArrayType,
 	ClosureType,
 	type Generic,
+	makeNullable,
 	NullableType,
 	type TypeExpression,
 	TypeIdentifier,
@@ -259,7 +260,7 @@ export class IntrospectedFunction extends IntrospectedNamespaceMember {
 						}
 					} else {
 						if (isOptional) {
-							params.push(p.copy({ type: new NullableType(type), isOptional: false }));
+							params.push(p.copy({ type: makeNullable(type), isOptional: false }));
 						} else {
 							params.push(p);
 						}

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -5,6 +5,7 @@ import {
 	Generic,
 	GenericType,
 	GenerifiedTypeIdentifier,
+	makeNullable,
 	NullableType,
 	type TypeExpression,
 	TypeIdentifier,
@@ -77,7 +78,7 @@ function resolveNullableProperties(cls: IntrospectedBaseClass): void {
 		const getter = cls.members.find((m) => m.name === getterName && !(m instanceof IntrospectedStaticClassFunction));
 
 		if (getter instanceof IntrospectedClassFunction && getter.return() instanceof NullableType) {
-			prop.type = new NullableType(prop.type);
+			prop.type = makeNullable(prop.type);
 		}
 	}
 }

--- a/packages/lib/src/gir/property.ts
+++ b/packages/lib/src/gir/property.ts
@@ -1,5 +1,5 @@
 import type { FormatGenerator } from "../generators/generator.ts";
-import { NullableType, type TypeExpression } from "../gir.ts";
+import { makeNullable, type TypeExpression } from "../gir.ts";
 import type { GirFieldElement, GirPropertyElement } from "../index.ts";
 import type { OptionsLoad } from "../types/index.ts";
 import type { Options } from "../types/introspected.ts";
@@ -210,7 +210,7 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 		property.getter = element.$.getter;
 
 		if (element.$.nullable === "1" || element.$["allow-none"] === "1") {
-			property.type = new NullableType(property.type);
+			property.type = makeNullable(property.type);
 		}
 
 		return property;

--- a/packages/lib/src/gir/signal.ts
+++ b/packages/lib/src/gir/signal.ts
@@ -3,6 +3,7 @@ import { GirDirection } from "@gi.ts/parser";
 import type { FormatGenerator } from "../generators/generator.ts";
 import {
 	ArrayType,
+	makeNullable,
 	NativeType,
 	NullableType,
 	NumberType,
@@ -171,7 +172,7 @@ export class IntrospectedSignal extends IntrospectedClassMember<IntrospectedClas
 						}
 					} else {
 						if (isOptional) {
-							params.push(p.copy({ type: new NullableType(type), isOptional: false }));
+							params.push(p.copy({ type: makeNullable(type), isOptional: false }));
 						} else {
 							params.push(p);
 						}

--- a/packages/lib/src/utils/gir-parsing.ts
+++ b/packages/lib/src/utils/gir-parsing.ts
@@ -17,8 +17,8 @@ import {
 	BigintOrNumberType,
 	ClosureType,
 	GenerifiedTypeIdentifier,
+	makeNullable,
 	NativeType,
-	NullableType,
 	type TypeExpression,
 	TypeIdentifier,
 	VoidType,
@@ -242,11 +242,11 @@ export function getType(
 		!(variableType instanceof NativeType) &&
 		variableType !== BigintOrNumberType
 	) {
-		return new NullableType(variableType);
+		return makeNullable(variableType);
 	}
 
 	if ((!parameter.$?.direction || parameter.$.direction === GirDirection.In) && nullable) {
-		return new NullableType(variableType);
+		return makeNullable(variableType);
 	}
 
 	variableType.isPointer = isPointer;

--- a/packages/lib/src/utils/types.ts
+++ b/packages/lib/src/utils/types.ts
@@ -10,10 +10,12 @@ import {
 	NativeType,
 	NeverType,
 	NullableType,
+	NullType,
 	NumberType,
 	ObjectType,
 	OrType,
 	PromiseType,
+	RawPointerType,
 	StringType,
 	ThisType,
 	TupleType,
@@ -188,8 +190,13 @@ export function resolvePrimitiveType(name: string): TypeExpression | null {
 			return BigintOrNumberType;
 		case "gboolean":
 			return BooleanType;
-		case "gpointer": // This is typically used in callbacks to pass data, so we'll allow anything.
-			return AnyType;
+		case "gpointer":
+			// You can't use pointers. Pointer arguments are mostly not exposed
+			// in GJS, but any exposed pointer arguments are always marshalled
+			// as null pointers. If the argument is nullable, this will combine
+			// with `null` to produce `null`, but if the argument isn't nullable
+			// it's impossible to pass a valid parameter to the function.
+			return RawPointerType;
 		case "object": // Support TS "object"
 			return ObjectType;
 		case "va_list":
@@ -251,6 +258,9 @@ export function resolveDirectedType(type: TypeExpression, direction: GirDirectio
 	} else if (type === BigintOrNumberType && direction === GirDirection.Out) {
 		// 64-bit integers accept number or bigint, but only return number to JS
 		return NumberType;
+	} else if (type === RawPointerType && direction === GirDirection.Out) {
+		// Raw pointers are always marshalled as JS null.
+		return NullType;
 	} else if (type instanceof PromiseType) {
 		// Propagate direction into the Promise's inner type so e.g. async
 		// functions returning 64-bit ints resolve to `Promise<number>` rather


### PR DESCRIPTION
## Description

GJS does not handle raw pointers (i.e., `void*` in C).

If a function takes a nullable raw pointer, null is the only accepted value you can pass in JS. If a function takes a non-nullable raw pointer, it's impossible to call it — it will always throw no matter what value you pass.

These behaviours can be represented in TypeScript with the types `null` and `never`, respectively.

Return values are slightly different. Functions that return raw pointers will always return null in JS, even if the C function didn't return null and even if not nullable.

I thought about a few alternatives, as well. One alternative could be to make the TS return type of a function `never` if it takes but does not return a non-nullable raw pointer, to signify that it can never return. Another approach might be to delete such functions from the type declaration altogether.

## Related Issue

N/A

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Type definition update
- [ ] Documentation update

## Validation
<!-- If this PR includes code changes, please describe how they are validated -->

**Test Location:** `examples/glib-2-types/main.ts`

## Checklist
<!-- Please check all that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly 