### PR TITLE
ci: enforce Conventional Commits on PR titles + backfill #380

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,17 @@
+<!--
+  PR title must follow Conventional Commits: <type>(<optional-scope>): <subject>
+
+  PRs are squash-merged, so the PR title becomes the commit message that
+  release-it parses to build the changelog. Titles that don't match the
+  spec are silently dropped from release notes (the PR Lint check enforces
+  this on every PR).
+
+  Allowed types: feat, fix, docs, refactor, perf, test, build, ci, chore, revert
+  Examples:
+    feat(cli): add --external-deps mode
+    fix(lib): handle raw pointers (void*) like GJS
+-->
+
 ## Description
 <!-- Describe your changes in detail -->
 

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,41 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false
+          subjectPattern: ^[A-Za-z`].+$
+          subjectPatternError: |
+            The subject (after the type and optional scope) must start with a
+            letter or backtick. Examples:
+              feat(cli): add --external-deps mode
+              fix(lib): handle raw pointers (void*) like GJS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **cli:** add GJS bundle — run ts-for-gir without Node.js ([#378](https://github.com/gjsify/ts-for-gir/issues/378)) ([6e5a8aa](https://github.com/gjsify/ts-for-gir/commit/6e5a8aa015c919f2a55b6ce01f8410be41f404ec)), closes [gjsify/gjsify#60](https://github.com/gjsify/gjsify/issues/60) [#3](https://github.com/gjsify/ts-for-gir/issues/3) [gjsify/gjsify#67](https://github.com/gjsify/gjsify/issues/67) [#68](https://github.com/gjsify/ts-for-gir/issues/68) [package.json#version](https://github.com/gjsify/package.json/issues/version) [#70](https://github.com/gjsify/ts-for-gir/issues/70) [gjsify#79](https://github.com/gjsify/gjsify/issues/79)
+* **lib:** handle raw pointers (`void*`) like GJS ([#380](https://github.com/gjsify/ts-for-gir/pull/380)) ([1de6bc0](https://github.com/gjsify/ts-for-gir/commit/1de6bc0457ddd4c5285fedcbbd6032f8de691716))
 
 ## [4.0.0-rc.9](https://github.com/gjsify/ts-for-gir/compare/v4.0.0-rc.8...v4.0.0-rc.9) (2026-05-01)
 


### PR DESCRIPTION
## Summary

- Add a `PR Lint` GitHub Action that fails CI when a PR title doesn't follow Conventional Commits.
- Add Conventional Commits guidance to `PULL_REQUEST_TEMPLATE.md`.
- Backfill #380 into `CHANGELOG.md` and the `v4.0.0-rc.10` GitHub release notes.

## Why

PRs in this repo are squash-merged, so the **PR title** becomes the commit message that release-it (`@release-it/conventional-changelog` with the `conventionalcommits` preset) parses to build release notes. Titles without a Conventional Commits prefix get silently dropped from the changelog.

That happened to #380 ("Make raw pointer (`void*`) handling more like GJS") — a real user-visible feature that ended up missing from the v4.0.0-rc.10 release notes despite being included in the released code.

## What's in this PR

### 1. PR Lint workflow (`.github/workflows/pr-lint.yml`)

Validates the PR title on every `opened`/`edited`/`reopened`/`synchronize` event using [`amannn/action-semantic-pull-request@v6.1.1`](https://github.com/amannn/action-semantic-pull-request) (pinned to its commit SHA). Allowed types match the project's existing changelog history:

```
feat, fix, docs, refactor, perf, test, build, ci, chore, revert
```

A non-conformant title now fails CI with a clear message — the silent-drop failure mode is gone.

### 2. PR template note (`.github/PULL_REQUEST_TEMPLATE.md`)

Adds a leading HTML comment so contributors see the requirement and the consequence (silent changelog drop, lint failure) directly in the PR composer, before they pick a title.

### 3. Backfill for #380

- `CHANGELOG.md` — adds a Features bullet under `[4.0.0-rc.10]`:

  ```
  * **lib:** handle raw pointers (`void*`) like GJS (#380) (1de6bc0)
  ```

- `v4.0.0-rc.10` GitHub release notes — already updated via `gh release edit` (https://github.com/gjsify/ts-for-gir/releases/tag/v4.0.0-rc.10).

## Test plan

- [x] Workflow syntax: workflow loads via `actionlint`-style rules — no `run:` blocks, `GITHUB_TOKEN` only via secrets, action SHA-pinned.
- [ ] After merge, open a follow-up PR with a non-conventional title and confirm `PR Lint` fails.
- [ ] Open a follow-up PR with a conventional title (`fix: …`) and confirm `PR Lint` passes.