### PR TITLE
fix: GJS-bundle self-update fetch + install.js --force + gjsify 0.3.14

### DIFF
--- a/examples/gtk-4-template-blueprint-vite/package.json
+++ b/examples/gtk-4-template-blueprint-vite/package.json
@@ -14,7 +14,7 @@
 	"author": "Pascal Garber <pascal@mailfreun.de>",
 	"license": "MIT",
 	"devDependencies": {
-		"@gjsify/vite-plugin-blueprint": "^0.2.9",
+		"@gjsify/vite-plugin-blueprint": "^0.3.14",
 		"typescript": "^6.0.3",
 		"vite": "^8.0.10"
 	},

--- a/install.js
+++ b/install.js
@@ -3,7 +3,8 @@
  * ts-for-gir installer / updater for GJS
  *
  * Usage:
- *   gjs -m install.js
+ *   gjs -m install.js               # install or update
+ *   gjs -m install.js --force       # reinstall even if already up to date
  *   # or, if the shebang is supported:
  *   ./install.js
  *
@@ -14,7 +15,7 @@
 import GLib from "gi://GLib";
 import Gio from "gi://Gio";
 import Soup from "gi://Soup?version=3.0";
-import { exit } from "system";
+import system, { exit } from "system";
 
 // GJS does not auto-promisify libsoup methods; wire it up explicitly so we can
 // `await session.send_and_read_async(...)` with the standard 3-arg signature.
@@ -106,7 +107,37 @@ async function downloadToFile(session, url, destPath) {
 	tmpFile.move(destFile, Gio.FileCopyFlags.OVERWRITE, null, null);
 }
 
+function parseArgs() {
+	// system.programArgs is the canonical GJS API for argv (excludes the
+	// interpreter and script path). Older versions expose programArgs as a
+	// plain array of strings.
+	const argv = system?.programArgs ?? [];
+	const force = argv.includes("--force") || argv.includes("-f");
+	const help = argv.includes("--help") || argv.includes("-h");
+	return { force, help };
+}
+
+function printUsage() {
+	print("Usage: gjs -m install.js [--force] [--help]");
+	print("");
+	print("Installs or updates the ts-for-gir GJS binary to ~/.local/bin/ts-for-gir.");
+	print("");
+	print("Options:");
+	print("  --force, -f   Reinstall even if the latest version is already installed.");
+	print("                Useful for recovering from a broken local binary when");
+	print("                `ts-for-gir self-update` cannot run.");
+	print("  --help,  -h   Show this message.");
+	print("");
+	print("Set GITHUB_TOKEN to avoid GitHub API rate limits.");
+}
+
 async function main() {
+	const { force, help } = parseArgs();
+	if (help) {
+		printUsage();
+		exit(0);
+	}
+
 	const session = new Soup.Session();
 
 	info("Fetching release information from GitHub...");
@@ -143,12 +174,15 @@ async function main() {
 	const latestVersion = release.tag_name.replace(/^v/, "");
 	const installedVersion = getInstalledVersion();
 
-	if (installedVersion === latestVersion) {
+	if (installedVersion === latestVersion && !force) {
 		info(`Already up to date (v${installedVersion})`);
+		info("Run with --force to reinstall anyway.");
 		exit(0);
 	}
 
-	if (installedVersion) {
+	if (installedVersion === latestVersion) {
+		info(`Reinstalling v${installedVersion} (--force)...`);
+	} else if (installedVersion) {
 		info(`Updating from v${installedVersion} to v${latestVersion}...`);
 	} else {
 		info(`Installing ts-for-gir v${latestVersion}...`);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,14 +16,12 @@
 			"ts-for-gir": "bin/ts-for-gir-gjs"
 		},
 		"shebang": true,
-		"esbuild": {
-			"outfile": "bin/ts-for-gir-gjs"
+		"bundler": {
+			"output": {
+				"file": "bin/ts-for-gir-gjs"
+			}
 		},
 		"excludeGlobals": [
-			"fetch",
-			"Headers",
-			"Request",
-			"Response",
 			"XMLHttpRequest",
 			"XMLHttpRequestUpload"
 		]
@@ -75,7 +73,7 @@
 	},
 	"devDependencies": {
 		"@gi.ts/parser": "workspace:^",
-		"@gjsify/cli": "^0.3.13",
+		"@gjsify/cli": "^0.3.14",
 		"@ts-for-gir/generator-base": "workspace:^",
 		"@ts-for-gir/generator-html-doc": "workspace:^",
 		"@ts-for-gir/generator-json": "workspace:^",

--- a/tests/e2e/cli-gjs/run.mjs
+++ b/tests/e2e/cli-gjs/run.mjs
@@ -132,14 +132,36 @@ describe('ts-for-gir GJS bundle E2E', { timeout: 10 * 60 * 1000 }, () => {
   });
 
   it('self-update --check reports version status', () => {
-    // Network may not be available in all CI environments — accept network errors gracefully
+    // Network may not be available in all CI environments — tolerate HTTP /
+    // network errors, but reject runtime errors that indicate the GJS bundle
+    // is missing a required global. The original failure mode was
+    // `Failed to fetch release information: fetch is not defined`, which the
+    // previous lenient assertion (matching `Failed to fetch`) accepted as a
+    // pass — masking the missing @gjsify/fetch polyfill for an entire release.
     const result = runGjs(['self-update', '--check']);
     const combined = result.stdout + result.stderr;
+
+    const runtimeFailureSignals = [
+      'is not defined',     // ReferenceError (e.g. `fetch is not defined`)
+      'is not a function',  // TypeError when a global is wrong shape
+      'ReferenceError',
+    ];
+    for (const signal of runtimeFailureSignals) {
+      assert.ok(
+        !combined.includes(signal),
+        `self-update --check hit a runtime error (${signal}): ${combined}`,
+      );
+    }
+
+    // Success path or network/HTTP error — both acceptable.
     const hasExpectedOutput =
       combined.includes('up to date') ||
       combined.includes('version available') ||
-      combined.includes('Checking for updates') ||
-      combined.includes('Failed to fetch');
+      // `Checking for updates` is printed before the network call; an HTTP /
+      // socket error is then reported via `Failed to fetch release information`
+      // followed by an HTTP status or libsoup error message.
+      (combined.includes('Checking for updates') &&
+        (combined.includes('HTTP ') || combined.includes('Failed to fetch')));
     assert.ok(hasExpectedOutput, `Unexpected output from self-update --check: ${combined}`);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4539,7 +4539,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@girs/gda-6.0@npm:^6.0.0-4.0.0-rc.9, @girs/gda-6.0@workspace:^, @girs/gda-6.0@workspace:types-dev/gda-6.0":
+"@girs/gda-6.0@npm:6.0.0-4.0.0-rc.9, @girs/gda-6.0@workspace:^, @girs/gda-6.0@workspace:types-dev/gda-6.0":
   version: 0.0.0-use.local
   resolution: "@girs/gda-6.0@workspace:types-dev/gda-6.0"
   dependencies:
@@ -5216,7 +5216,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@girs/gio-2.0@npm:^2.88.0-4.0.0-rc.9, @girs/gio-2.0@workspace:*, @girs/gio-2.0@workspace:^, @girs/gio-2.0@workspace:types-dev/gio-2.0":
+"@girs/gio-2.0@npm:2.88.0-4.0.0-rc.9, @girs/gio-2.0@workspace:*, @girs/gio-2.0@workspace:^, @girs/gio-2.0@workspace:types-dev/gio-2.0":
   version: 0.0.0-use.local
   resolution: "@girs/gio-2.0@workspace:types-dev/gio-2.0"
   dependencies:
@@ -5228,7 +5228,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@girs/giounix-2.0@npm:^2.0.0-4.0.0-rc.9, @girs/giounix-2.0@workspace:^, @girs/giounix-2.0@workspace:types-dev/giounix-2.0":
+"@girs/giounix-2.0@npm:2.0.0-4.0.0-rc.9, @girs/giounix-2.0@workspace:^, @girs/giounix-2.0@workspace:types-dev/giounix-2.0":
   version: 0.0.0-use.local
   resolution: "@girs/giounix-2.0@workspace:types-dev/giounix-2.0"
   dependencies:
@@ -5327,7 +5327,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@girs/gjs@npm:^4.0.0-rc.9, @girs/gjs@workspace:*, @girs/gjs@workspace:^, @girs/gjs@workspace:types-dev/gjs":
+"@girs/gjs@npm:4.0.0-rc.9, @girs/gjs@workspace:*, @girs/gjs@workspace:^, @girs/gjs@workspace:types-dev/gjs":
   version: 0.0.0-use.local
   resolution: "@girs/gjs@workspace:types-dev/gjs"
   dependencies:
@@ -5420,7 +5420,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@girs/glib-2.0@npm:^2.88.0-4.0.0-rc.9, @girs/glib-2.0@workspace:*, @girs/glib-2.0@workspace:^, @girs/glib-2.0@workspace:types-dev/glib-2.0":
+"@girs/glib-2.0@npm:2.88.0-4.0.0-rc.9, @girs/glib-2.0@workspace:*, @girs/glib-2.0@workspace:^, @girs/glib-2.0@workspace:types-dev/glib-2.0":
   version: 0.0.0-use.local
   resolution: "@girs/glib-2.0@workspace:types-dev/glib-2.0"
   dependencies:
@@ -5795,7 +5795,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@girs/gobject-2.0@npm:^2.88.0-4.0.0-rc.9, @girs/gobject-2.0@workspace:^, @girs/gobject-2.0@workspace:types-dev/gobject-2.0":
+"@girs/gobject-2.0@npm:2.88.0-4.0.0-rc.9, @girs/gobject-2.0@workspace:^, @girs/gobject-2.0@workspace:types-dev/gobject-2.0":
   version: 0.0.0-use.local
   resolution: "@girs/gobject-2.0@workspace:types-dev/gobject-2.0"
   dependencies:
@@ -11669,7 +11669,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@girs/soup-3.0@npm:^3.6.6-4.0.0-rc.9, @girs/soup-3.0@workspace:^, @girs/soup-3.0@workspace:types-dev/soup-3.0":
+"@girs/soup-3.0@npm:3.6.6-4.0.0-rc.9, @girs/soup-3.0@workspace:^, @girs/soup-3.0@workspace:types-dev/soup-3.0":
   version: 0.0.0-use.local
   resolution: "@girs/soup-3.0@workspace:types-dev/soup-3.0"
   dependencies:
@@ -13461,824 +13461,814 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/abort-controller@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/abort-controller@npm:0.3.13"
+"@gjsify/abort-controller@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/abort-controller@npm:0.3.14"
   dependencies:
-    "@gjsify/dom-events": "npm:^0.3.13"
-  checksum: 10/ecc717376d126499fd3ea51e5c080d0bf3a18bea897aa14134fd78458c7e39c27a4fe8870f970e8b85cf932b9c426a8b3c7fe4574a3492eb643f1d2aedd8707b
+    "@gjsify/dom-events": "npm:^0.3.14"
+  checksum: 10/9bd0cb391de8385656f21bbb2a0dfa300b1420cc63483eb1f35b69da69cf5f4727403d9cafad150b1a76787d3f157e7648326ae556d13350eec0f5235e47abcd
   languageName: node
   linkType: hard
 
-"@gjsify/assert@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/assert@npm:0.3.13"
-  checksum: 10/b3ce6d45aac4349e782d281212551c38edf35f9b83972ebf2976fb3407b61b4be825f3eb60e25be28d83dca1e1a5f2a4b50fc9f5b5db77650f0c10be75a638b5
+"@gjsify/assert@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/assert@npm:0.3.14"
+  checksum: 10/bbcbb8a2e9cfa0dbabfddf4442125728249e0af0308778d5bfffd0b12bf4d51eec0ee486bbcea6e81401de4414daaf5e3c961d2d4aa986f504abaee405e47282
   languageName: node
   linkType: hard
 
-"@gjsify/async_hooks@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/async_hooks@npm:0.3.13"
+"@gjsify/async_hooks@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/async_hooks@npm:0.3.14"
   dependencies:
-    "@gjsify/events": "npm:^0.3.13"
-  checksum: 10/7ec87c8113d1ac9ad143757b38b5d17a2df962289b14da642c1e0ea2c35d580aee43a6e148a976c9938ca60cc436cc8ed5486b29847dbb3fd763a8c54bdec856
+    "@gjsify/events": "npm:^0.3.14"
+  checksum: 10/92c118c4319ae31e87ca1c86710c03d24200f94651bd01161ffb2f4495e2fd50e033b41e3df35bd691fca354144ac2f3a3cccd687529ea14a222bc8c258925d4
   languageName: node
   linkType: hard
 
-"@gjsify/buffer@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/buffer@npm:0.3.13"
+"@gjsify/buffer@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/buffer@npm:0.3.14"
   dependencies:
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/3bec837300082f2c389727028d4f0bf61410dcc0d201a45ced78bdac987007f24fbd58ead2c74b6eff68b481b39bdc0f2091fa4703cd19904846f2aede37484c
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/d51773c85bf53191632672effaeed1a2fc93a6531ca3a70c89ffa09e78c7dd1d6f109c4c934bebd40743e312d6c41156b616c380e9b19c387511deda07f7f1d6
   languageName: node
   linkType: hard
 
-"@gjsify/child_process@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/child_process@npm:0.3.13"
+"@gjsify/child_process@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/child_process@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/27ae0b6a10bab84cd61cfb933282a4abc0988b939c92825fbbf89f0675d22745c9ca0a3fd7a864f1e0542133d0caa645d9538c1cbdbaf1100262dee46f830ed0
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/8379982439d7fbace9143b1d3da8a13760cf3e7335c53b037048d6d96a5138846a1fcf79b7135b2208f3c4d1b5633016559774be6e7649ec28553fa8639ba28b
   languageName: node
   linkType: hard
 
-"@gjsify/cli@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/cli@npm:0.3.13"
+"@gjsify/cli@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/cli@npm:0.3.14"
   dependencies:
-    "@gjsify/create-app": "npm:^0.3.13"
-    "@gjsify/esbuild-plugin-gjsify": "npm:^0.3.13"
-    "@gjsify/node-polyfills": "npm:^0.3.13"
-    "@gjsify/npm-registry": "npm:^0.3.13"
-    "@gjsify/resolve-npm": "npm:^0.3.13"
-    "@gjsify/semver": "npm:^0.3.13"
-    "@gjsify/tar": "npm:^0.3.13"
-    "@gjsify/web-polyfills": "npm:^0.3.13"
-    "@yarnpkg/esbuild-plugin-pnp": "npm:^3.0.0-rc.15"
+    "@gjsify/create-app": "npm:^0.3.14"
+    "@gjsify/node-polyfills": "npm:^0.3.14"
+    "@gjsify/npm-registry": "npm:^0.3.14"
+    "@gjsify/resolve-npm": "npm:^0.3.14"
+    "@gjsify/rolldown-plugin-gjsify": "npm:^0.3.14"
+    "@gjsify/rolldown-plugin-pnp": "npm:^0.3.14"
+    "@gjsify/semver": "npm:^0.3.14"
+    "@gjsify/tar": "npm:^0.3.14"
+    "@gjsify/web-polyfills": "npm:^0.3.14"
     cosmiconfig: "npm:^9.0.1"
-    esbuild: "npm:^0.28.0"
     get-tsconfig: "npm:^4.14.0"
     pkg-types: "npm:^2.3.1"
+    rolldown: "npm:^1.0.0-rc.18"
     yargs: "npm:^18.0.0"
   bin:
     gjsify: ./lib/index.js
-  checksum: 10/e5402ac01756f7cb984c7726b6571605a6fb28cf61a4efa7b6343c2e8a4e5a7c3c20a387e71888d5bc88c22fa9b39cc575c450fb1417b272a4e64c877832da5f
+  checksum: 10/2a252d31ed070668c4df1a50e7cd7d9cb97a48202551258181463a57634c1423c5e780cf1d4fdc95afef751d1ded9367b2254bdf7d2f619a05bb0026ec27f542
   languageName: node
   linkType: hard
 
-"@gjsify/cluster@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/cluster@npm:0.3.13"
+"@gjsify/cluster@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/cluster@npm:0.3.14"
   dependencies:
-    "@gjsify/events": "npm:^0.3.13"
-  checksum: 10/d0fbb086c78744059f12a5c4ec504895f25bef69ad0c5f2fb0e87d92083baf00462da16b4502bc2f222288527ffcf34e2f8641908a87f5341b6b79e9c405cab8
+    "@gjsify/events": "npm:^0.3.14"
+  checksum: 10/8e50210eaff9d806673070fe2e7a0789492888b0a36e85c80f82113c223eeaf1784f45efc7daf6ced2e72343a43b5003edba123addacbb78a25b992413c28d87
   languageName: node
   linkType: hard
 
-"@gjsify/compression-streams@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/compression-streams@npm:0.3.13"
+"@gjsify/compression-streams@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/compression-streams@npm:0.3.14"
   dependencies:
-    "@gjsify/web-streams": "npm:^0.3.13"
-  checksum: 10/db6428dd204a78571663a8df71d13d1f39dd09d5fb8b0527bae0110d29976cf9cf5a92a0e05921f2f7be25574c17faea338f2a4f652514d040c961d1d2ffd9e0
+    "@gjsify/web-streams": "npm:^0.3.14"
+  checksum: 10/d5d7c037fa0f0e4c112eed001f28f43abd99b1dc985ae2c504ab7e1dcef82f379cf4cf1263a179bd6244aa9b5cf945f6ede6a964d5b0ac3e6419a3297d084b48
   languageName: node
   linkType: hard
 
-"@gjsify/console@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/console@npm:0.3.13"
-  checksum: 10/e672bbd3b6780e794c774410804f7cca9aad0b0fcd646974d5bee2f571caa90ebf5796f980fcc94b5621d0618284c05db21e1c0c4eff9eaa808a39c522a7460a
+"@gjsify/console@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/console@npm:0.3.14"
+  checksum: 10/b61140f29f630c7bc441d6978a55db64bca0f05cadd79233643c041719f57de593370ac3521cbdab2eb1d2bf6fb38e26adea2d0f5802c8291d6b97ef24490730
   languageName: node
   linkType: hard
 
-"@gjsify/constants@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/constants@npm:0.3.13"
+"@gjsify/constants@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/constants@npm:0.3.14"
   dependencies:
-    "@gjsify/crypto": "npm:^0.3.13"
-    "@gjsify/fs": "npm:^0.3.13"
-    "@gjsify/os": "npm:^0.3.13"
-  checksum: 10/61326f359b0cfeee2c8b0520239bae583b2253d6e43f1b6173c60aa0d13888f1eb315f6ce9a20bb0a2f928e9e736e92397cf24515b28ebb05caa946545d52765
+    "@gjsify/crypto": "npm:^0.3.14"
+    "@gjsify/fs": "npm:^0.3.14"
+    "@gjsify/os": "npm:^0.3.14"
+  checksum: 10/6aa2f2aad27bdd69a4d38cd84cab2736daa6eb00c918675a3b714bd26c6324a97d2613c718cbe93cc724851d975a3e3dc8cdf5dbda78f563ad093646c92c78f7
   languageName: node
   linkType: hard
 
-"@gjsify/create-app@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/create-app@npm:0.3.13"
+"@gjsify/create-app@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/create-app@npm:0.3.14"
   dependencies:
     yargs: "npm:^18.0.0"
   bin:
     create-app: ./lib/index.js
-  checksum: 10/448c16a0541d10fa1052b25361a7c88ebe453aca312894b5b20f19ce5006eddac9753a4950deade8c8ac61866318e7d3c59fd70089bfee88b6731b2309c7deee
+  checksum: 10/333e1225d4e5c8d49ac951aa886334d2924ec8460854049babb7c0000e79f1dd6ab912641fcde2ab745ba0d4f46fd5f78a68ed68113bac5c7f40908296d20146
   languageName: node
   linkType: hard
 
-"@gjsify/crypto@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/crypto@npm:0.3.13"
+"@gjsify/crypto@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/crypto@npm:0.3.14"
   dependencies:
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/stream": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/83e02b3a40673fd353f42737fda0d8f7c01c277f19f9e4d6b7d8989ea82720f5b619aab07586761ccc83d1953decf1234e8f747cb49107b5cbec7f2082cce409
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/stream": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/00933aeecded019efd831ce94a394eff5d77592dd148dd569361681943f6f8815aea27810f49c1d0b5d75782d1a15aa708687f4fdfdabc4c60db903f06e7cb26
   languageName: node
   linkType: hard
 
-"@gjsify/dgram@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/dgram@npm:0.3.13"
+"@gjsify/dgram@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/dgram@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/17461427552ab020c47586e0a76b0c0e826f1058a01c28874e36583f245c51eaabd11c5c7214ebb98a6761972aebbc3d770613a848f6a5e24bbe0f283ad7a235
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/f84288cee72ab6230546555246ad9ee2094b352d1e7c8545fbe5ee06ed00af6ad4635452a31f85c5bbde72a2a364e158e5d94a67337236ee73408237d2e464e5
   languageName: node
   linkType: hard
 
-"@gjsify/diagnostics_channel@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/diagnostics_channel@npm:0.3.13"
-  checksum: 10/873181b43adc559c84d6308027f313d49c9e21db0769b4e7ec66521d881206efd3333edea0ee93c5b2caa8840ebebfa4cfac8f043409ffdb16277d42475c6154
+"@gjsify/diagnostics_channel@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/diagnostics_channel@npm:0.3.14"
+  checksum: 10/a7c271de0386f391208c161de546c329e19e8bf140338b0772085734c51ddecd5f02dfdf17ecb708f27ccedfac79dff0c080f274f2743ac67e201acd7b3a2ea5
   languageName: node
   linkType: hard
 
-"@gjsify/dns@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/dns@npm:0.3.13"
+"@gjsify/dns@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/dns@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/net": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/3b5c2e31665c8b1c68ba0034bb27c2ee2f6b90d3f55c71364576b986455fb71c2ecc13adf376a9a03584fc86d9c268e94220642ba6aab603ff03f53031d45aa8
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/net": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/cac8cd9f9f9802363904fd1e6b738960b3995199b6d2740ef00a76fe388b1545cf41fbf1e2c9e3708c0441c53a28ca4e10e4922e3617dc04d04e2f15660a3632
   languageName: node
   linkType: hard
 
-"@gjsify/dom-events@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/dom-events@npm:0.3.13"
+"@gjsify/dom-events@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/dom-events@npm:0.3.14"
   dependencies:
-    "@gjsify/dom-exception": "npm:^0.3.13"
-  checksum: 10/478124c92f7450d07017857c4dcfa088de1ffbaf2d3e8bf0d8a22a0c0292de33e81917aef259225eb31df33756225cbccc527881306b0e192a0203d2f132ac49
+    "@gjsify/dom-exception": "npm:^0.3.14"
+  checksum: 10/dd82ee39841c163d5a2a94bc33ae193baeb5378cbf336168090f06b1c7fe6cc17cb2f3c47c8e43192b9f8a1d64d1da4c54c219857ca1032d57ad33491847bb33
   languageName: node
   linkType: hard
 
-"@gjsify/dom-exception@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/dom-exception@npm:0.3.13"
-  checksum: 10/833ee1b2ea50c1a706905dba3f8f72a209e002144722782cf00f452ceef6e48ebc0fe4dfeb57fd12b5c1fab71455d46bc787fccae2f0ee5b8e3811c0ddddedfc
+"@gjsify/dom-exception@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/dom-exception@npm:0.3.14"
+  checksum: 10/99dc1a21ca52f8512e2582e5740c231149339225adad1cf123c6fbfe05b5fc76e5c7a5f0e3135a46a751b7989e4755ac04aac1590c5d42d8860dd257fe992205
   languageName: node
   linkType: hard
 
-"@gjsify/domain@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/domain@npm:0.3.13"
+"@gjsify/domain@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/domain@npm:0.3.14"
   dependencies:
-    "@gjsify/events": "npm:^0.3.13"
-  checksum: 10/4a21f55c3a62a465ebd959b3988e96dc865557971d400fa5a9b9237598928707256f773d978cd57684a78c8b633f777e092399d1a71fd584128ed05f86c8040d
+    "@gjsify/events": "npm:^0.3.14"
+  checksum: 10/e9a710d4012763e8568e3b3c1b1dd9d70435ee89a1ba3c91052d0671d4da49785520d4b518c2b0e34402dc24503b0f97e60a5a4a6733aeeef1d75a6e80435ee6
   languageName: node
   linkType: hard
 
-"@gjsify/domparser@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/domparser@npm:0.3.13"
-  checksum: 10/b666a93010957b58c337e0e1716ebdf03d5000c126d47310ff74e091b662c902553f61c41c7ba2cacbca31e18485a07725ef403ead77665968227734e50bcd10
+"@gjsify/domparser@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/domparser@npm:0.3.14"
+  checksum: 10/463ac2fd096d39b8d4cce1f08b32ed6b7edad9f6a9c201cf9378586358489bbb973eb3beb5712243ebc2e9bdfe3d6d3c16b5e622541d8f6fee7b0824c3b29eed
   languageName: node
   linkType: hard
 
-"@gjsify/esbuild-plugin-alias@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/esbuild-plugin-alias@npm:0.3.13"
-  checksum: 10/e54fc44e3e0dc6454573c4bf1543e15d4dcd1b78adcb1af75e7a826c665831a67f7003eb09358a4ba5e224d1c66472a7f156e2e9309c968f25170e75070fea4d
-  languageName: node
-  linkType: hard
-
-"@gjsify/esbuild-plugin-blueprint@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/esbuild-plugin-blueprint@npm:0.3.13"
+"@gjsify/events@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/events@npm:0.3.14"
   dependencies:
-    execa: "npm:^9.6.1"
-  checksum: 10/eb5932c7bf10e0ae20e3aca07380659ce30e1bd996215cd1d983b82ffdf5a5e134ca5b1a94b1d5dba952a38720cc2e979dd6f33e9c2e3eeb586688dbf4c5a6cf
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/1129ca2ff4fcbcea8a2c2e5c03d066b2ee33ac1eef2463123be561bb1f2b36d37cc13ab38aa3d738a4fc09a4dc37e5df449dcc64bb62ffda1dbdf4d6f2dd6476
   languageName: node
   linkType: hard
 
-"@gjsify/esbuild-plugin-css@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/esbuild-plugin-css@npm:0.3.13"
-  peerDependencies:
-    esbuild: ^0.28.0
-  checksum: 10/6e853c8f61632fd17da3f538076fe87e13a1feb1992aec01f9b4503c242d268e987fb075d2add229c21b4570fc040bfd42f2ef1aa317687c368bdcacc924ddb8
+"@gjsify/eventsource@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/eventsource@npm:0.3.14"
+  dependencies:
+    "@gjsify/dom-events": "npm:^0.3.14"
+    "@gjsify/web-streams": "npm:^0.3.14"
+  checksum: 10/44fb63e4598e113c794e4b69822248eaa157ad3f779858c94206d512d6bff2fab070ae05e66ad0b371231875dfa48e72790868715caae4e646c10586649cfecc
   languageName: node
   linkType: hard
 
-"@gjsify/esbuild-plugin-deepkit@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/esbuild-plugin-deepkit@npm:0.3.13"
+"@gjsify/fetch@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/fetch@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gjs": "npm:4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/soup-3.0": "npm:3.6.6-4.0.0-rc.9"
+    "@gjsify/formdata": "npm:^0.3.14"
+    "@gjsify/http": "npm:^0.3.14"
+    "@gjsify/url": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/1da6e172c40659f723cb806cc18880fc02d9a4084117169cac0f276c7de5bc287ad0a68b1f3c9d81c790fe503b54bf96a4539d74cc5db5a27ab0049e895a672a
+  languageName: node
+  linkType: hard
+
+"@gjsify/formdata@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/formdata@npm:0.3.14"
+  checksum: 10/d2277ab4289dca075af080be7cc896951d18213819990ce7b0f850d953833c3e5b426d5495a347a180708c39910e6f407a86596751b340ae4d531a55c8daac6e
+  languageName: node
+  linkType: hard
+
+"@gjsify/fs@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/fs@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/stream": "npm:^0.3.14"
+    "@gjsify/url": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/d857a7e5bd39ddff1877cce862c237165c7ea968802482322f364111c6518d723c4036e0089ba0f42da807c0c419cd785743147992356a6247d2eedfb195c5bc
+  languageName: node
+  linkType: hard
+
+"@gjsify/gamepad@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/gamepad@npm:0.3.14"
+  dependencies:
+    "@gjsify/dom-events": "npm:^0.3.14"
+  checksum: 10/742e47dc68a066c5213980423dbc149254a58b20609fedcb3dc4c7bf5fd639865dd1e88cb9c7a409704e269b88a8a8be150b6498f322bc88a3252fef2b38f38f
+  languageName: node
+  linkType: hard
+
+"@gjsify/http-soup-bridge@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/http-soup-bridge@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gjs": "npm:4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gobject-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/soup-3.0": "npm:3.6.6-4.0.0-rc.9"
+  checksum: 10/1f6bba173d906ee0c3ab901c51c37b1c5fd6997444956c041d2a8c919b228a14fc545ff73143b5268c0bac44726f1d584ba2bd66cc5b7edc1034c4b3a1c84e0f
+  languageName: node
+  linkType: hard
+
+"@gjsify/http2@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/http2@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gobject-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/soup-3.0": "npm:3.6.6-4.0.0-rc.9"
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/fb05ffa4535500121eabc1895a5fe1b5b45779c33579bc7eda31b35782c4506aaf604dc42aa8db579b0aa83efd343988da3742c1f28181158c346048d7008571
+  languageName: node
+  linkType: hard
+
+"@gjsify/http@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/http@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/soup-3.0": "npm:3.6.6-4.0.0-rc.9"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/http-soup-bridge": "npm:^0.3.14"
+    "@gjsify/net": "npm:^0.3.14"
+    "@gjsify/stream": "npm:^0.3.14"
+    "@gjsify/url": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/a132334b6e8ca13380c245b7ce0a512971df3413d7311ed8fabb2e6d3bd8768cbc83e8b7bc8d1506b56d13457c36f16aa2380738c89417aeffe227010cf4b83d
+  languageName: node
+  linkType: hard
+
+"@gjsify/https@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/https@npm:0.3.14"
+  dependencies:
+    "@gjsify/http": "npm:^0.3.14"
+    "@gjsify/tls": "npm:^0.3.14"
+  checksum: 10/c5f2a9b4274ddb3328ddb88174508399ccbb5d355b68105cdf36945c5f628fc8c74cd192d899b5f2499300b7c0bc35cb5be34b575b32dabc3fbcb7b9694eb4a7
+  languageName: node
+  linkType: hard
+
+"@gjsify/inspector@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/inspector@npm:0.3.14"
+  checksum: 10/035f8de2b533b9a0f0e2f4e072c895929d80ff578bc7efa2f81028f417d47719e360b1383234dc76d3f8817723f9869ddad2ce8cf9373945cc0b7f04f9324c1b
+  languageName: node
+  linkType: hard
+
+"@gjsify/module@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/module@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gjs": "npm:4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/e7f7557b29ea9e2ea4307b4eeff676f4829ac339b929956649864710abb3e3346281baae19df375f64d25dbc9eb5fd59d893fe7f944212c0caf71acaebacca9f
+  languageName: node
+  linkType: hard
+
+"@gjsify/net@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/net@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/stream": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/8cabcb55fa1f089d606cbe3bb937b2697d5a1f1c0ee83466b6510d242c1ea447a426f4eb839e3c700ada55e254d0acf9812e359088d8c9050be558ac24a418b0
+  languageName: node
+  linkType: hard
+
+"@gjsify/node-globals@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/node-globals@npm:0.3.14"
+  dependencies:
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/process": "npm:^0.3.14"
+    "@gjsify/url": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/cb00859998d8093880dcda8be07d145903c224af6292cb3d4618700cdf983a4063a0a43bfcb9a0bfc13c9d570f426d23a7f73522774a37a9773700f29d29b3d2
+  languageName: node
+  linkType: hard
+
+"@gjsify/node-polyfills@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/node-polyfills@npm:0.3.14"
+  dependencies:
+    "@gjsify/assert": "npm:^0.3.14"
+    "@gjsify/async_hooks": "npm:^0.3.14"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/child_process": "npm:^0.3.14"
+    "@gjsify/cluster": "npm:^0.3.14"
+    "@gjsify/console": "npm:^0.3.14"
+    "@gjsify/constants": "npm:^0.3.14"
+    "@gjsify/crypto": "npm:^0.3.14"
+    "@gjsify/dgram": "npm:^0.3.14"
+    "@gjsify/diagnostics_channel": "npm:^0.3.14"
+    "@gjsify/dns": "npm:^0.3.14"
+    "@gjsify/domain": "npm:^0.3.14"
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/fs": "npm:^0.3.14"
+    "@gjsify/http": "npm:^0.3.14"
+    "@gjsify/http2": "npm:^0.3.14"
+    "@gjsify/https": "npm:^0.3.14"
+    "@gjsify/inspector": "npm:^0.3.14"
+    "@gjsify/module": "npm:^0.3.14"
+    "@gjsify/net": "npm:^0.3.14"
+    "@gjsify/node-globals": "npm:^0.3.14"
+    "@gjsify/os": "npm:^0.3.14"
+    "@gjsify/path": "npm:^0.3.14"
+    "@gjsify/perf_hooks": "npm:^0.3.14"
+    "@gjsify/process": "npm:^0.3.14"
+    "@gjsify/querystring": "npm:^0.3.14"
+    "@gjsify/readline": "npm:^0.3.14"
+    "@gjsify/sqlite": "npm:^0.3.14"
+    "@gjsify/stream": "npm:^0.3.14"
+    "@gjsify/string_decoder": "npm:^0.3.14"
+    "@gjsify/sys": "npm:^0.3.14"
+    "@gjsify/timers": "npm:^0.3.14"
+    "@gjsify/tls": "npm:^0.3.14"
+    "@gjsify/tty": "npm:^0.3.14"
+    "@gjsify/url": "npm:^0.3.14"
+    "@gjsify/util": "npm:^0.3.14"
+    "@gjsify/v8": "npm:^0.3.14"
+    "@gjsify/vm": "npm:^0.3.14"
+    "@gjsify/worker_threads": "npm:^0.3.14"
+    "@gjsify/zlib": "npm:^0.3.14"
+  checksum: 10/e9a027a5739ec1c2dfe60fd23f8e4753bc3bb9fd20392ece7965721c816facba81682df1dc3074a879eed00a6799f571208a57b2ce7cb6ff7b1e2e3179e5dc4d
+  languageName: node
+  linkType: hard
+
+"@gjsify/npm-registry@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/npm-registry@npm:0.3.14"
+  checksum: 10/a1eae5fb1aced9507c9e3722b1870f6ca4771e06f4bfd292ab68221e59cd75740c549f8c6e883eccbe3cda106222f9782c0a29ff1e70bd76e9f2a7add78603bb
+  languageName: node
+  linkType: hard
+
+"@gjsify/os@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/os@npm:0.3.14"
+  dependencies:
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/f7adb66fcc3ccef1b5ba8511f63b343bc5a001a90ae995344665c6b05bed9bd09e26405ed779eb829c5f3d644c30d9db524595fda4db8f244ee6d8eee51f1b2e
+  languageName: node
+  linkType: hard
+
+"@gjsify/path@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/path@npm:0.3.14"
+  checksum: 10/e24c407d30dd87a8458cd4af24f38597ea6a03073c94695f21821d5e320f3feb17a02acb874203c8000990ed05e6cf3eb0074637c404a7bfeae1c89e8eabb704
+  languageName: node
+  linkType: hard
+
+"@gjsify/perf_hooks@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/perf_hooks@npm:0.3.14"
+  checksum: 10/66d70245f32b678c9781f96fac2d5467d54cba0f873e244a1556b88b609ac8720b9be963d21b9ccb8ca73af8c3e916b52205115a55292acd60c53dce2bedd888
+  languageName: node
+  linkType: hard
+
+"@gjsify/process@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/process@npm:0.3.14"
+  dependencies:
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/terminal-native": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/c9de492ce758bebb298678c60046be01349057e6ba97ac62415e60071109d211661bf9673e082f3d5cebb531635092ff99e5390d1b0b590d2d4d8c819ea5a44f
+  languageName: node
+  linkType: hard
+
+"@gjsify/querystring@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/querystring@npm:0.3.14"
+  checksum: 10/abe9a891d34044b42dccec78a4c8a4739553c079ca98a725fa9d51a2078af8a7e27d9202e52e3154a4e4b3d456aaa42cbab4b4ef85c8646d2ec43941deb9e715
+  languageName: node
+  linkType: hard
+
+"@gjsify/readline@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/readline@npm:0.3.14"
+  dependencies:
+    "@gjsify/events": "npm:^0.3.14"
+  checksum: 10/6b5ebbe69186d2c6ca327cd15e09be49a6fad9664cdab4d556cf31e739b8466f33c4139b05b71953fe78025401c3316f39162bda3309846d30d1ddea1c1cae03
+  languageName: node
+  linkType: hard
+
+"@gjsify/resolve-npm@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/resolve-npm@npm:0.3.14"
+  checksum: 10/27660d2e73c80562fc3f71035a817866802be968f28b7e9086290760afc395d8645f723af4aa03a70fa747b9b470ea3c1e1bb02866337fe7bcef853ee7e50c58
+  languageName: node
+  linkType: hard
+
+"@gjsify/rolldown-plugin-deepkit@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/rolldown-plugin-deepkit@npm:0.3.14"
   dependencies:
     "@deepkit/type-compiler": "npm:^1.0.19"
     typescript: "npm:^6.0.3"
   peerDependencies:
-    esbuild: "*"
-  checksum: 10/1a1f9138d0e6bfdae085e6660ea8ad6f3f59fd0f0378d0d2454872756e99a312b56eb36fd32e8b25ac9878e706b34bca2ca05985e3e568c2cd875eec05b84cb7
+    rolldown: ^1.0.0-rc.18
+  peerDependenciesMeta:
+    rolldown:
+      optional: true
+  checksum: 10/4ba58140400a6366e54134b75081b15b65e6f6924d2c50fad5e5a35555aa9d67a51b374fbbd4fe12212663660556d48c974ae899fdec3c401b04d08633d7416d
   languageName: node
   linkType: hard
 
-"@gjsify/esbuild-plugin-gjsify@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/esbuild-plugin-gjsify@npm:0.3.13"
+"@gjsify/rolldown-plugin-gjsify@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/rolldown-plugin-gjsify@npm:0.3.14"
   dependencies:
-    "@gjsify/esbuild-plugin-alias": "npm:^0.3.13"
-    "@gjsify/esbuild-plugin-blueprint": "npm:^0.3.13"
-    "@gjsify/esbuild-plugin-css": "npm:^0.3.13"
-    "@gjsify/esbuild-plugin-deepkit": "npm:^0.3.13"
-    "@gjsify/esbuild-plugin-transform-ext": "npm:^0.3.13"
-    "@gjsify/resolve-npm": "npm:^0.3.13"
-    acorn: "npm:^8.16.0"
-    acorn-walk: "npm:^8.3.5"
+    "@gjsify/resolve-npm": "npm:^0.3.14"
+    "@gjsify/rolldown-plugin-deepkit": "npm:^0.3.14"
+    "@gjsify/rolldown-plugin-pnp": "npm:^0.3.14"
+    "@gjsify/vite-plugin-blueprint": "npm:^0.3.14"
+    "@rollup/pluginutils": "npm:^5.1.4"
+    acorn: "npm:^8.14.0"
+    acorn-walk: "npm:^8.3.4"
     fast-glob: "npm:^3.3.3"
+    lightningcss: "npm:^1.32.0"
   peerDependencies:
-    esbuild: "*"
-  checksum: 10/bee92b2de9a41c3072d1dc12698986529361f4cb7a26f33860003512ea198b046e7b9512fc8498033686f832abea63bde651051b6af5f89f578114c8dcc58edf
+    rolldown: ^1.0.0-rc.18
+  peerDependenciesMeta:
+    rolldown:
+      optional: true
+  checksum: 10/5049928390d3516164817b7eeef8052ec8f97ece2b6250b69948d776e3e4058d325253f28c77a0ec7568f3bc811df1ce5103e47a6c426dd2db9af3959f76e61a
   languageName: node
   linkType: hard
 
-"@gjsify/esbuild-plugin-transform-ext@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/esbuild-plugin-transform-ext@npm:0.3.13"
-  checksum: 10/762e3bfdcbde16846ab1133f110a753c64fc4daf25547227c69118bc7b1bb71810aef8b600b9bf7a622f301310008e8c76ea2f975bf20f3fd1c26aec4ecf7c63
+"@gjsify/rolldown-plugin-pnp@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/rolldown-plugin-pnp@npm:0.3.14"
+  peerDependencies:
+    rolldown: ^1.0.0-rc.18
+  peerDependenciesMeta:
+    rolldown:
+      optional: true
+  checksum: 10/72fcb2dba11c4ef41e8ccf9cfb59bb54562cca2f248f68f23653d95077cb2788fd91006fdad92647de26979d5cab6a5b73cfdffc96118e1fd03301129ed87696
   languageName: node
   linkType: hard
 
-"@gjsify/events@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/events@npm:0.3.13"
+"@gjsify/semver@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/semver@npm:0.3.14"
+  checksum: 10/d5f81619954c5a561432995ad615c256a1cec01fab9fd35c4f11c57c3d244c00fdb09d8aad8e524c7ee85f83af6512ec49ea3b0827f007db4ef392c557b7f6e8
+  languageName: node
+  linkType: hard
+
+"@gjsify/sqlite@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/sqlite@npm:0.3.14"
   dependencies:
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/e5e7e3f4891db8591c9115d81ca0fc9762337a694063cc806c6c40d5ab559bd1222d4700483b2737250feb641fc61a541b7977baa667a6578bb14272231e7fc1
+    "@girs/gda-6.0": "npm:6.0.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gobject-2.0": "npm:2.88.0-4.0.0-rc.9"
+  checksum: 10/fd1ca587cd08c32250b71682439c97a7f81c1e5434b6de3ed20e785ad3d5ad4dfbe2531f53d795e3226195099bcbeb617dad0fe38287c8b963871401599410d9
   languageName: node
   linkType: hard
 
-"@gjsify/eventsource@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/eventsource@npm:0.3.13"
+"@gjsify/stream@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/stream@npm:0.3.14"
   dependencies:
-    "@gjsify/dom-events": "npm:^0.3.13"
-    "@gjsify/web-streams": "npm:^0.3.13"
-  checksum: 10/80d8e3eaae090cedb51b4eae6631772cec24c9d08778c0f7c95f4ac862cc5eff87a76d97446c707c0a1a83bd0f9e35d98dbd39dca5dace46d4a0307a01c94cac
+    "@gjsify/events": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+    "@gjsify/web-streams": "npm:^0.3.14"
+  checksum: 10/244e36fe32e09ec8b605b298a0daed73ed7444f93e5d820267f4af995ce62702275d7c66c4da9d36a3a6f03405325dfbd041df5ad3cd241b82c62b29e79fcb25
   languageName: node
   linkType: hard
 
-"@gjsify/fetch@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/fetch@npm:0.3.13"
+"@gjsify/string_decoder@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/string_decoder@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gjs": "npm:^4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/soup-3.0": "npm:^3.6.6-4.0.0-rc.9"
-    "@gjsify/formdata": "npm:^0.3.13"
-    "@gjsify/http": "npm:^0.3.13"
-    "@gjsify/url": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/591baec8bfa825015e89119f61c1f026f52e07430dad112c7825fd18714184f3f50fbbbe2bbb01d6d4c18ad3264e6a6ff47cdbef85b7e21dabb24d80f01ac480
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/d29aa71b9754b939e198bb3be032c7254505b0b69af3dad3610a4e76c16370b8bcc6a5bdae3d49cc936e82be609b512463e30d94c964271d8800e8bee88ca336
   languageName: node
   linkType: hard
 
-"@gjsify/formdata@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/formdata@npm:0.3.13"
-  checksum: 10/d9f52bee29b0160436c44b6ade889fa76185f437e0819dac21301c36e41ff6aa609a33d487650d132df435c4696e1b7789f42d64af86165e772ccae0bb723581
-  languageName: node
-  linkType: hard
-
-"@gjsify/fs@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/fs@npm:0.3.13"
+"@gjsify/sys@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/sys@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/stream": "npm:^0.3.13"
-    "@gjsify/url": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/6ab128b6c3e45a8e1c2750a84a6e1070db714adc4375c369c12ef7e23a26cb4802f2235e9e47d9688d08ec252d71f6b6f83ac89f92a24cc408977862db40384d
+    "@gjsify/util": "npm:^0.3.14"
+  checksum: 10/086d77c6f46f072efe5c81882ff037d31077543ccd011a019bc294fe6a1eadab9418c973f2e5a96d91c2173d28374820689a3ba40e2456c0a36c9e58d018f8de
   languageName: node
   linkType: hard
 
-"@gjsify/gamepad@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/gamepad@npm:0.3.13"
+"@gjsify/tar@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/tar@npm:0.3.14"
+  checksum: 10/b8f9ddb4cccb15e9f0eae314e35d8bd24d6efd7922d62f4bbc993fd620669d650bad2efe8f88628f0029ac3672afb6785259f189ba791eae32b9dcd706ebb278
+  languageName: node
+  linkType: hard
+
+"@gjsify/terminal-native@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/terminal-native@npm:0.3.14"
   dependencies:
-    "@gjsify/dom-events": "npm:^0.3.13"
-  checksum: 10/e51bbb17a6b070039aec46207fc8dc41ba29daf99552a1bbd2cc02d4033a3cf50afd39708b5be87293aa0e80d60557b6db179af50bf98852c9607067309dccf4
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gobject-2.0": "npm:2.88.0-4.0.0-rc.9"
+  checksum: 10/a7db6b2a2562504b0a8c39832d5198aa75d0ed4f177e7350b3bfffc4176258effebbc1e4768e269dfd35dd6d3ef3c552583ba5f93320320fab4112b3d7d8d62b
   languageName: node
   linkType: hard
 
-"@gjsify/http-soup-bridge@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/http-soup-bridge@npm:0.3.13"
+"@gjsify/timers@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/timers@npm:0.3.14"
+  checksum: 10/e67360972bbdd04208c12a60830acd40183fec52cb7cb27a5d327ee88bab949f171343dcf4c0dc36a73e1288f617ff093f2dc65f39c079c0ad1855c59292f662
+  languageName: node
+  linkType: hard
+
+"@gjsify/tls@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/tls@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gjs": "npm:^4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gobject-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/soup-3.0": "npm:^3.6.6-4.0.0-rc.9"
-  checksum: 10/1933d5318ef79b29866d1496f1206e55f8138e2d200519e7f63f851fe9131188c13b37ef3d0ba34ce5b1e10e0c4d5a3cb7d307ab1193cc7aa0ce8e61d5f941c2
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/net": "npm:^0.3.14"
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/36541cddc87c0ac8915e11217726638b740fcd14467ac3a8dc225535bf792ac3591de18166f31e938204963705f1af175377e50501a1170961080b79d8c5fddd
   languageName: node
   linkType: hard
 
-"@gjsify/http2@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/http2@npm:0.3.13"
+"@gjsify/tty@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/tty@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gobject-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/soup-3.0": "npm:^3.6.6-4.0.0-rc.9"
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/72a4f25b7a76ca3b8fac8d2016503a9444f400e2dd2dd75e6fe678c949be72d13a851d0c38e3c37f48e105ebb2d826d1e79142e819ed33b229e58e02016c6375
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/stream": "npm:^0.3.14"
+    "@gjsify/terminal-native": "npm:^0.3.14"
+  checksum: 10/2f81c2b81543e3f6ceda38194655e25d8e4fbfe36986c6f40ff2d0c177c6389e43792602c09bfa87534a3bb4048e3b2bad16a216b7f6409f1f5e12fef1a5c52d
   languageName: node
   linkType: hard
 
-"@gjsify/http@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/http@npm:0.3.13"
+"@gjsify/url@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/url@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/soup-3.0": "npm:^3.6.6-4.0.0-rc.9"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/http-soup-bridge": "npm:^0.3.13"
-    "@gjsify/net": "npm:^0.3.13"
-    "@gjsify/stream": "npm:^0.3.13"
-    "@gjsify/url": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/b555815885874d01442195b24dc924f39cee05aeb72250ab33cbd2a65faf0971ae43095b56223bbedab4f8113ba47055aa0830ea23852cb42d134a6227b5db36
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+  checksum: 10/4f51f98dae69454e747c3b3f71031b7414e0da559024a40297ac56598156f37f103c043c4dfdb7e8a1a455545314b0281896e50d1d717dcdb931277431dc5c0f
   languageName: node
   linkType: hard
 
-"@gjsify/https@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/https@npm:0.3.13"
+"@gjsify/util@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/util@npm:0.3.14"
+  checksum: 10/d69006b4f9806db5241ef97f08140691d3d9875026639fc1672e0f52e3aca40f46c6a16c75aac7ecad03f78b4a8ae19f9822ae4cc666552cd1314242d867e963
+  languageName: node
+  linkType: hard
+
+"@gjsify/utils@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/utils@npm:0.3.14"
   dependencies:
-    "@gjsify/http": "npm:^0.3.13"
-    "@gjsify/tls": "npm:^0.3.13"
-  checksum: 10/e44238d3d773624249afa28e5177a4e62fc4644082ed3d17b28c46a382063008ef3c96707f00665244f37741e62a65bd7a69afc9806109ca0dd77a98461010e8
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/giounix-2.0": "npm:2.0.0-4.0.0-rc.9"
+    "@girs/gjs": "npm:4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+  checksum: 10/8929ba494b39d3f062839e19e4b61764321a63721f347a786354ca0b4bd0d5db3fd69ab467a5eb998b94cf941ddd1eb37e6ab504d710415cf23d5de43095b0fe
   languageName: node
   linkType: hard
 
-"@gjsify/inspector@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/inspector@npm:0.3.13"
-  checksum: 10/ed62f1d0679bc686f47fc2bbbd6f20b14356eb61000e713f472506b4da0fec5ef91aac17ee88b7634eac5315ca8e3b32d8095f22f3bed4fabf4613be1e45f104
+"@gjsify/v8@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/v8@npm:0.3.14"
+  checksum: 10/b4ef24f5dad446ab955bb11adb43542b97b9164e586696cb4c7f6e304878f4a4a3211c3bceefa493848148dd5a9b428f3a307ec7887cc530094e3a92d003ca96
   languageName: node
   linkType: hard
 
-"@gjsify/module@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/module@npm:0.3.13"
-  dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gjs": "npm:^4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/5606ff20e15dafa1c59ee0c98ea07589bbbc0b39eeaecc4c5b3c9cc224a378c0be115dbfb4782d028e5fff2c9ec7237b5b8c3ec323946104074a0e724e13e027
-  languageName: node
-  linkType: hard
-
-"@gjsify/net@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/net@npm:0.3.13"
-  dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/stream": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/77812f04ea8dae5d390c92d8577e396b788df691d0f1ca808fde85fb067f16f3096ee120b8ee9e975916d9f25ad01a7e7e34976d0a3ae11e88c1782c45d18082
-  languageName: node
-  linkType: hard
-
-"@gjsify/node-globals@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/node-globals@npm:0.3.13"
-  dependencies:
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/process": "npm:^0.3.13"
-    "@gjsify/url": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/11d97500c4fc423270714ad734d6d1aac7b4bd462797ee0daef0584f65272d1dda48b2c744cb9043cf4e96f27cfa2574868fa6ebb2f185d4bc8bf599c04dfb37
-  languageName: node
-  linkType: hard
-
-"@gjsify/node-polyfills@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/node-polyfills@npm:0.3.13"
-  dependencies:
-    "@gjsify/assert": "npm:^0.3.13"
-    "@gjsify/async_hooks": "npm:^0.3.13"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/child_process": "npm:^0.3.13"
-    "@gjsify/cluster": "npm:^0.3.13"
-    "@gjsify/console": "npm:^0.3.13"
-    "@gjsify/constants": "npm:^0.3.13"
-    "@gjsify/crypto": "npm:^0.3.13"
-    "@gjsify/dgram": "npm:^0.3.13"
-    "@gjsify/diagnostics_channel": "npm:^0.3.13"
-    "@gjsify/dns": "npm:^0.3.13"
-    "@gjsify/domain": "npm:^0.3.13"
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/fs": "npm:^0.3.13"
-    "@gjsify/http": "npm:^0.3.13"
-    "@gjsify/http2": "npm:^0.3.13"
-    "@gjsify/https": "npm:^0.3.13"
-    "@gjsify/inspector": "npm:^0.3.13"
-    "@gjsify/module": "npm:^0.3.13"
-    "@gjsify/net": "npm:^0.3.13"
-    "@gjsify/node-globals": "npm:^0.3.13"
-    "@gjsify/os": "npm:^0.3.13"
-    "@gjsify/path": "npm:^0.3.13"
-    "@gjsify/perf_hooks": "npm:^0.3.13"
-    "@gjsify/process": "npm:^0.3.13"
-    "@gjsify/querystring": "npm:^0.3.13"
-    "@gjsify/readline": "npm:^0.3.13"
-    "@gjsify/sqlite": "npm:^0.3.13"
-    "@gjsify/stream": "npm:^0.3.13"
-    "@gjsify/string_decoder": "npm:^0.3.13"
-    "@gjsify/sys": "npm:^0.3.13"
-    "@gjsify/timers": "npm:^0.3.13"
-    "@gjsify/tls": "npm:^0.3.13"
-    "@gjsify/tty": "npm:^0.3.13"
-    "@gjsify/url": "npm:^0.3.13"
-    "@gjsify/util": "npm:^0.3.13"
-    "@gjsify/v8": "npm:^0.3.13"
-    "@gjsify/vm": "npm:^0.3.13"
-    "@gjsify/worker_threads": "npm:^0.3.13"
-    "@gjsify/zlib": "npm:^0.3.13"
-  checksum: 10/2553607bcfd3bb3f2d0004d2dcb1e4be8a2c04dcead2c9fe9aeaf56e871daf2c59c3ec60ab07e1172567435853213a4a416b4322600d051268cb13ad5d2ce2ad
-  languageName: node
-  linkType: hard
-
-"@gjsify/npm-registry@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/npm-registry@npm:0.3.13"
-  checksum: 10/5cb3a15e92bd736913a9bab9ec4e22967ba9d742bc86147f3a2b8b30c7818da82715258901fe0c2539f3bcb6ab1ae0251a1a2b91c80ac732e3abc74cea3e1603
-  languageName: node
-  linkType: hard
-
-"@gjsify/os@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/os@npm:0.3.13"
-  dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/f498f70ce7cebe2ac0c804b6134075fe919d6d37b9d2b274eb26507202e6f1fc3d8e3065e96c6a199f4d41ba5e4e20a13bb6b6ad980b3523e83242cb36273cdf
-  languageName: node
-  linkType: hard
-
-"@gjsify/path@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/path@npm:0.3.13"
-  checksum: 10/de915db9447a5fc8baa843417eb0975a51dd539a8947f1f55f75aeb7ef135fb9aa14397f7ad1eb66f39842fafaa3c44bec1c48ef8f534e82c94601a885fbc564
-  languageName: node
-  linkType: hard
-
-"@gjsify/perf_hooks@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/perf_hooks@npm:0.3.13"
-  checksum: 10/156ff2ccd303ade8f67ad2c02e05475bff0d189db56776e80999fb329462f160cec6ec7d3fc24f3a9d43dc4e9d76e3eff3b4bd618dcd783e39f37469cb5d8678
-  languageName: node
-  linkType: hard
-
-"@gjsify/process@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/process@npm:0.3.13"
-  dependencies:
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/terminal-native": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/6af25823567d35dcc7c96bc89c9a44c821e9010cb34cb3dd26b7d51e8b7773c6141d953974f2f39513b971cf49074df51409f4329d2936ff9ba112f93b743082
-  languageName: node
-  linkType: hard
-
-"@gjsify/querystring@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/querystring@npm:0.3.13"
-  checksum: 10/fda1985373262a6b7760519899e97a53fe7b1858c229cfdb703e63cac6b6238e3f459b4a6abe3a0e98d8a0710049d2891d6d937f664f97664c007c55ca95bd2f
-  languageName: node
-  linkType: hard
-
-"@gjsify/readline@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/readline@npm:0.3.13"
-  dependencies:
-    "@gjsify/events": "npm:^0.3.13"
-  checksum: 10/954660a87ab9243993b8c7f369899fb1d7e7c34e8140e9a0f1757e418e1d331b02e65f8d9a15be112dffbb319ac6da3738a80066f31b1023b55de2d63a1e78dc
-  languageName: node
-  linkType: hard
-
-"@gjsify/resolve-npm@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/resolve-npm@npm:0.3.13"
-  dependencies:
-    "@yarnpkg/esbuild-plugin-pnp": "npm:^3.0.0-rc.15"
-  checksum: 10/8569584b66be285e6c43b4641fcd69f195ff1c64e86533470cdcbcf4af209cbc1b39791830e74f7d9644ec76a9ee201b0bcc9f01eeabab00f3eecf4b70905bad
-  languageName: node
-  linkType: hard
-
-"@gjsify/semver@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/semver@npm:0.3.13"
-  checksum: 10/93b08d03f175c0c83f470921e410e5aaf5f9a89d2ee86ee25bb92adf9ce555beb8b21abaa3cc131d599ae02c51d69988988c120e1f287b384cd0baab0110724f
-  languageName: node
-  linkType: hard
-
-"@gjsify/sqlite@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/sqlite@npm:0.3.13"
-  dependencies:
-    "@girs/gda-6.0": "npm:^6.0.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gobject-2.0": "npm:^2.88.0-4.0.0-rc.9"
-  checksum: 10/0073230c6ef9c8081cd2b64ca0fa2e39fe19e806f5f25885a75345210631cc2234d33cfe5cda6ebde3708a6007a9108b07ba76072f926e274b42fd5924220786
-  languageName: node
-  linkType: hard
-
-"@gjsify/stream@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/stream@npm:0.3.13"
-  dependencies:
-    "@gjsify/events": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-    "@gjsify/web-streams": "npm:^0.3.13"
-  checksum: 10/d3cf7398f6efeb59f11d5117b19ab3345397e4aab3e326aafa22163486b7e3b3e425f7b826a63fe17e34abbba1306b62f673bdd1a5a419a6382e170579ad38b0
-  languageName: node
-  linkType: hard
-
-"@gjsify/string_decoder@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/string_decoder@npm:0.3.13"
-  dependencies:
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/c8c850a7b2f659f4bf53411c0222782c4f4f88450f745ea67fb30997bc305ce5dd914a0eb9c69afb44f5ba1a52a03538c6c18f50f3891bf43845e1458d58d8dc
-  languageName: node
-  linkType: hard
-
-"@gjsify/sys@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/sys@npm:0.3.13"
-  dependencies:
-    "@gjsify/util": "npm:^0.3.13"
-  checksum: 10/bc72813450c98feaa6b0cb682f3d8f394c182140e9195360accb7a0c878f403d5eafbfb59405cf3263210a5d709eae6e1b2a0c3146a86d881309850c93d26248
-  languageName: node
-  linkType: hard
-
-"@gjsify/tar@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/tar@npm:0.3.13"
-  checksum: 10/9c779f98896668af90c59b0b394467b03b7cf4d06da4a2b4a7370bcadb696d96fc36f5386effd1659d50b8f6a57c1ce98f2beeeb7baf034a3b6db88aac94014f
-  languageName: node
-  linkType: hard
-
-"@gjsify/terminal-native@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/terminal-native@npm:0.3.13"
-  dependencies:
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gobject-2.0": "npm:^2.88.0-4.0.0-rc.9"
-  checksum: 10/ac4b23c623c6b1c623139f61909ee0442526121a5f39ca01e08e72efc273dfb956793e4ea4d6065cc7f42761a7bb879b91702f24fc1c6b8cbdb4ee4250966d97
-  languageName: node
-  linkType: hard
-
-"@gjsify/timers@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/timers@npm:0.3.13"
-  checksum: 10/f6a97665e886c731dda5eda61a6675678db77c7279a74c1569427fb10690cd62674fa59199996ea5f6381b04d173c7aaf450378fd503c57a64d18ef4419c603e
-  languageName: node
-  linkType: hard
-
-"@gjsify/tls@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/tls@npm:0.3.13"
-  dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/net": "npm:^0.3.13"
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/50170caea5c229aaddca7d698239415201c5f313beb6f358fbda63c730089e78a4c03f205557615c9188d5b8d42a4fffaa5185c511b41f8f84efcf74317a2d6a
-  languageName: node
-  linkType: hard
-
-"@gjsify/tty@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/tty@npm:0.3.13"
-  dependencies:
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/stream": "npm:^0.3.13"
-    "@gjsify/terminal-native": "npm:^0.3.13"
-  checksum: 10/f49f6fdc936aa74456ca4d17a6cd20074ae0d0c0704d4920f85b1eb5b3600638fbef0e326fd5f45aa28feb8aad3f4755fb102275084449ca493929d93846e1bb
-  languageName: node
-  linkType: hard
-
-"@gjsify/url@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/url@npm:0.3.13"
-  dependencies:
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-  checksum: 10/774da223ba1a51f77f1b71c266bfee7d8c8871b19d775010dd6fbbcdd9e1421ea4237fca0483b4f1609c2d4fc8fff20236951f589cdafa598d5ca0c12fbd6965
-  languageName: node
-  linkType: hard
-
-"@gjsify/util@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/util@npm:0.3.13"
-  checksum: 10/5a8b9eeee46b856fa3bc1202cdfa3e1d15e7b90c718c43ce79dfbcb7f6cb08a8bb22cb5c7324f2850f362130ad3b61ca9ea48516c63f7b110897567dfb563d88
-  languageName: node
-  linkType: hard
-
-"@gjsify/utils@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/utils@npm:0.3.13"
-  dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/giounix-2.0": "npm:^2.0.0-4.0.0-rc.9"
-    "@girs/gjs": "npm:^4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-  checksum: 10/4c287abccd86381b30bb70515a375c69c02c7060c344527516fe8361c3a6ea60a863ced30420131206a22406f1470973b6c533a04306f561e2345a831903df9b
-  languageName: node
-  linkType: hard
-
-"@gjsify/v8@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/v8@npm:0.3.13"
-  checksum: 10/f14d365fa3084db8cb2fb05c83846ef4467e8e04b323a27cd6fb0335d9300933afadeaef4798451c27ce326cb00e230a120f7d7d678f251653c44f1822991d85
-  languageName: node
-  linkType: hard
-
-"@gjsify/vite-plugin-blueprint@npm:^0.2.9":
-  version: 0.2.9
-  resolution: "@gjsify/vite-plugin-blueprint@npm:0.2.9"
+"@gjsify/vite-plugin-blueprint@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/vite-plugin-blueprint@npm:0.3.14"
   dependencies:
     execa: "npm:^9.6.0"
     minify-xml: "npm:^4.5.2"
   peerDependencies:
-    vite: "*"
-  checksum: 10/06e07d9c2462a01844b17a1c0bbe31c5b361bb64c68f0e16e552b058a83d2d3a9ede60b92af0a854eb13761f298adf73938731d2f23e1536121538b04b90fb11
+    rolldown: ^1.0.0-rc.18
+    vite: ^8.0.0
+  peerDependenciesMeta:
+    rolldown:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10/1db07893a4047ff2af604aa68786fcdb4d6386b45938c9aa6341f72ef985e2c9937d378dadb3c927bfa83f9805d8e634430d15c0b1c75082ebeac4776bce0dcf
   languageName: node
   linkType: hard
 
-"@gjsify/vm@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/vm@npm:0.3.13"
-  checksum: 10/4e1d664352f0f4b4eb17afa125d79863749977e03103f0c60f4aee8ad56a580d5d315cf84c1fcb89de1d0582efe0cda790d784b65556cc52b8ddb1d68eec0d76
+"@gjsify/vm@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/vm@npm:0.3.14"
+  checksum: 10/5ab237b4ad4b26cd398706536cfc02f3f4ce9be8558158afda3d75a4755d6ed68f4a4bd6e3cbc019388e4c11f75628e1061df9e507f43f00ea334eb4e8a8519f
   languageName: node
   linkType: hard
 
-"@gjsify/web-globals@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/web-globals@npm:0.3.13"
+"@gjsify/web-globals@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/web-globals@npm:0.3.14"
   dependencies:
-    "@gjsify/abort-controller": "npm:^0.3.13"
-    "@gjsify/buffer": "npm:^0.3.13"
-    "@gjsify/compression-streams": "npm:^0.3.13"
-    "@gjsify/dom-events": "npm:^0.3.13"
-    "@gjsify/dom-exception": "npm:^0.3.13"
-    "@gjsify/eventsource": "npm:^0.3.13"
-    "@gjsify/formdata": "npm:^0.3.13"
-    "@gjsify/gamepad": "npm:^0.3.13"
-    "@gjsify/perf_hooks": "npm:^0.3.13"
-    "@gjsify/url": "npm:^0.3.13"
-    "@gjsify/web-streams": "npm:^0.3.13"
-    "@gjsify/webaudio": "npm:^0.3.13"
-    "@gjsify/webcrypto": "npm:^0.3.13"
-  checksum: 10/2b00478e7e852720ee0dcb5ec4da8c179184f2d839cab8f17f42768cd801d24ed15b845841e27add911164ff01cc05192a249c7ca2f1cdc536d83af6ec790cfb
+    "@gjsify/abort-controller": "npm:^0.3.14"
+    "@gjsify/buffer": "npm:^0.3.14"
+    "@gjsify/compression-streams": "npm:^0.3.14"
+    "@gjsify/dom-events": "npm:^0.3.14"
+    "@gjsify/dom-exception": "npm:^0.3.14"
+    "@gjsify/eventsource": "npm:^0.3.14"
+    "@gjsify/formdata": "npm:^0.3.14"
+    "@gjsify/gamepad": "npm:^0.3.14"
+    "@gjsify/perf_hooks": "npm:^0.3.14"
+    "@gjsify/url": "npm:^0.3.14"
+    "@gjsify/web-streams": "npm:^0.3.14"
+    "@gjsify/webaudio": "npm:^0.3.14"
+    "@gjsify/webcrypto": "npm:^0.3.14"
+  checksum: 10/dd32e58b156df997c0d41a0839cfdddcdedd7c80397fe94a49ca0c0e0319b685c812b0bfc98b4ee7f40b41cd558f8a316acbca5dd01c5187ddc426aa567b5c70
   languageName: node
   linkType: hard
 
-"@gjsify/web-polyfills@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/web-polyfills@npm:0.3.13"
+"@gjsify/web-polyfills@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/web-polyfills@npm:0.3.14"
   dependencies:
-    "@gjsify/abort-controller": "npm:^0.3.13"
-    "@gjsify/compression-streams": "npm:^0.3.13"
-    "@gjsify/dom-events": "npm:^0.3.13"
-    "@gjsify/dom-exception": "npm:^0.3.13"
-    "@gjsify/domparser": "npm:^0.3.13"
-    "@gjsify/eventsource": "npm:^0.3.13"
-    "@gjsify/fetch": "npm:^0.3.13"
-    "@gjsify/formdata": "npm:^0.3.13"
-    "@gjsify/gamepad": "npm:^0.3.13"
-    "@gjsify/web-globals": "npm:^0.3.13"
-    "@gjsify/web-streams": "npm:^0.3.13"
-    "@gjsify/webassembly": "npm:^0.3.13"
-    "@gjsify/webaudio": "npm:^0.3.13"
-    "@gjsify/webcrypto": "npm:^0.3.13"
-    "@gjsify/websocket": "npm:^0.3.13"
-    "@gjsify/webstorage": "npm:^0.3.13"
-    "@gjsify/xmlhttprequest": "npm:^0.3.13"
-  checksum: 10/ec9485c6e18aa9b73213fcadc89e3b3586c50b5dc5cfbe1ee4cc573d77cab42dde068007dbe20bbba4dd288c77a14324ec496cb2be5e1edc483e635542b29d8e
+    "@gjsify/abort-controller": "npm:^0.3.14"
+    "@gjsify/compression-streams": "npm:^0.3.14"
+    "@gjsify/dom-events": "npm:^0.3.14"
+    "@gjsify/dom-exception": "npm:^0.3.14"
+    "@gjsify/domparser": "npm:^0.3.14"
+    "@gjsify/eventsource": "npm:^0.3.14"
+    "@gjsify/fetch": "npm:^0.3.14"
+    "@gjsify/formdata": "npm:^0.3.14"
+    "@gjsify/gamepad": "npm:^0.3.14"
+    "@gjsify/web-globals": "npm:^0.3.14"
+    "@gjsify/web-streams": "npm:^0.3.14"
+    "@gjsify/webassembly": "npm:^0.3.14"
+    "@gjsify/webaudio": "npm:^0.3.14"
+    "@gjsify/webcrypto": "npm:^0.3.14"
+    "@gjsify/websocket": "npm:^0.3.14"
+    "@gjsify/webstorage": "npm:^0.3.14"
+    "@gjsify/xmlhttprequest": "npm:^0.3.14"
+  checksum: 10/a1d0ef1f3965dc3d3c73b7e2b170c1725eef1def6770e4a081487895f225d5b2ed680088e4cf1702295f6edd49114cdc59b3edc1cb54761f526d968b3b922e4f
   languageName: node
   linkType: hard
 
-"@gjsify/web-streams@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/web-streams@npm:0.3.13"
+"@gjsify/web-streams@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/web-streams@npm:0.3.14"
   dependencies:
-    "@gjsify/utils": "npm:^0.3.13"
-  checksum: 10/aa1e7de851ae99f54003ba70b1e50a461d38f2ba9ee6d062806808eafbd196fc302dbfe4be285e64aec6a39c42e72b4795acb7d2af9a9ca08c635a3a56ce7acc
+    "@gjsify/utils": "npm:^0.3.14"
+  checksum: 10/97bb8d90c338f56575fdc4b05a833a22f0f2c73031c4aec44c9799b7ff055dfb151b97f405ce7c13cae8bde087eabe879083dbc041011faee24fe07b2c1676cd
   languageName: node
   linkType: hard
 
-"@gjsify/webassembly@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/webassembly@npm:0.3.13"
-  checksum: 10/51d6c22eecf89117754375bca36d4392c7786656013aafe29aaa150695afc110f04aacd77744dd4995049f562ae6e05ad6f648e3dd56a640190090ed12817f40
+"@gjsify/webassembly@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/webassembly@npm:0.3.14"
+  checksum: 10/9eae8535e9646ebc0345ec2c2c20d1570764da8b55011128ecdbfcf03a334dbe09e3d035122c3f302f65b8398a363a1bd13fcbe36b59bf4ab89b2eec6d393d5e
   languageName: node
   linkType: hard
 
-"@gjsify/webaudio@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/webaudio@npm:0.3.13"
+"@gjsify/webaudio@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/webaudio@npm:0.3.14"
   dependencies:
-    "@gjsify/dom-events": "npm:^0.3.13"
-  checksum: 10/8cc7430ed1ac9de6f162304d17cfe142888ab6fa0cc5c2b50908ee5f93831be9688960a2d4e70eb81ab1c10f472c781e83b3d770f7bc9ef14de28b6d6f5846e6
+    "@gjsify/dom-events": "npm:^0.3.14"
+  checksum: 10/8a8823f51517e2def8690d335bec17be4f29c4964357ad1ad62da1fb0fb27bad6b454e0e190df970510d43ccd057c485c0c328805a721ee56ae286d66c03b874
   languageName: node
   linkType: hard
 
-"@gjsify/webcrypto@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/webcrypto@npm:0.3.13"
+"@gjsify/webcrypto@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/webcrypto@npm:0.3.14"
   dependencies:
-    "@gjsify/dom-exception": "npm:^0.3.13"
-  checksum: 10/a268e7a664a7add608740067089ce103dac11e02bdd0ef256644bd6fd2a1a1cd068a325facddc38012968c74d93c7704f665f9a12c0e08f4e686bbcae581f36d
+    "@gjsify/dom-exception": "npm:^0.3.14"
+  checksum: 10/1d471becb00248c8bfe8dd77aaccce678c82f1d20e0db9f787c6face73779a83022413df054fcdea56ffe7cf53d749cef6d28fd7604ba42092c82961be8fb988
   languageName: node
   linkType: hard
 
-"@gjsify/websocket@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/websocket@npm:0.3.13"
+"@gjsify/websocket@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/websocket@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gjs": "npm:^4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/soup-3.0": "npm:^3.6.6-4.0.0-rc.9"
-    "@gjsify/dom-events": "npm:^0.3.13"
-  checksum: 10/b6dce912614e4c4d5dc88c28f2377a652d9de4546482b5fa6df3a4088648538cb86f39d6dcf8037d323f6e2b7ecf92edf8928216222ee9a7b1afb41590f7787a
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gjs": "npm:4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/soup-3.0": "npm:3.6.6-4.0.0-rc.9"
+    "@gjsify/dom-events": "npm:^0.3.14"
+  checksum: 10/e6d903ea151fc38633f34f83333129d94737957176eb4b07bb3bceb913c8d58b2fd10a8364897072ab74748f65d42aebaeb1c7bde075c34bcccf54996bfddf59
   languageName: node
   linkType: hard
 
-"@gjsify/webstorage@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/webstorage@npm:0.3.13"
-  checksum: 10/55b6b5ea7126bf6abf5aea56ca1e6c899282d28a8f5b3b3ea7f9e189b3177ac302bcfbe854b8e60e1edf8a8e6e44a6afa5078ca31d8922862cb928363051b26d
+"@gjsify/webstorage@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/webstorage@npm:0.3.14"
+  checksum: 10/345471043c0d31fa67f702d2dd7b66c7de25c41e36988102d6993424776910032e2c17d17718377ebe7504e1caf20b94d0cd7e8ba299baea72387d9ced9d4979
   languageName: node
   linkType: hard
 
-"@gjsify/worker_threads@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/worker_threads@npm:0.3.13"
+"@gjsify/worker_threads@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/worker_threads@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/events": "npm:^0.3.13"
-  checksum: 10/eb1c55969f3a69ebe17042f8a89cba7993a49d101b5858bcba99e8bad9677db88b435393c0891e35fb7c8161da39cf6771d4570947dd204b375a71cb05d363a3
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/events": "npm:^0.3.14"
+  checksum: 10/9a01c4f83298fd506205e3c9cb04959ddbbaebf05dce8e9465a172363e70fe032e2cc057fa909f25253eee7448ab118636159db7aeae5e5f84e0631c21246d26
   languageName: node
   linkType: hard
 
-"@gjsify/xmlhttprequest@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/xmlhttprequest@npm:0.3.13"
+"@gjsify/xmlhttprequest@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/xmlhttprequest@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/gjs": "npm:^4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@gjsify/fetch": "npm:^0.3.13"
-  checksum: 10/82c4e729cd995d662580adc29e3f01fbee15ead8436cc2278b6706ad28bb18ae04af90b4452039658ecd6ca2d4ccb959a2d6670b5b4ee9568da51c311175a124
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/gjs": "npm:4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@gjsify/fetch": "npm:^0.3.14"
+  checksum: 10/2f731a2b8f975f4cce6d2243b4906c4616b1e87bad954f90efceacd8ba3eddb25e92a5bf64c606fcc1d248428f217bede8f68f02f4f1a8d520e752758b58fcf1
   languageName: node
   linkType: hard
 
-"@gjsify/zlib@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@gjsify/zlib@npm:0.3.13"
+"@gjsify/zlib@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@gjsify/zlib@npm:0.3.14"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.9"
-    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.9"
-  checksum: 10/8b9aa4b76a015d59636f108db0d5744a4c32cb31f81fe05f40d748aa8b51207c7f95e8524591273f720c1d2e2dcae6dc8c766308498079bbabab9be601ecb0ea
+    "@girs/gio-2.0": "npm:2.88.0-4.0.0-rc.9"
+    "@girs/glib-2.0": "npm:2.88.0-4.0.0-rc.9"
+  checksum: 10/e74bf76cecf71440e6cce68718e4c355ce269a4fc79f54491d7ea78c3ada8dd5e539e860bfa0a980f623eb6b1caecce8993583512f0e298f9132bf710198aa02
   languageName: node
   linkType: hard
 
@@ -14885,6 +14875,13 @@ __metadata:
   version: 0.128.0
   resolution: "@oxc-project/types@npm:0.128.0"
   checksum: 10/cf1479772d22902ee5a0a6fda74f71cce2a569d084f9e26b524972f3145439b2e514ffc92de518757c0502bf5d2d26cb1de99e4c56bd2c57f54fcd4179e9c730
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.129.0":
+  version: 0.129.0
+  resolution: "@oxc-project/types@npm:0.129.0"
+  checksum: 10/a778eb3bd9997265ebcb9738fa4ac0ab0c2465853e6eacc7a70697a374c0bfd0ae0f894a159359445ad036fddbff25d5dec863ab3f2fda63eec2180e4c737481
   languageName: node
   linkType: hard
 
@@ -15878,10 +15875,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.18"
   conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0"
+  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -15892,10 +15903,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-x64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-darwin-x64@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.18"
   conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0"
+  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -15906,10 +15931,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.18"
   conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -15920,10 +15959,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.18"
   conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -15934,10 +15987,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.18"
   conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -15948,6 +16015,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-musl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.18"
@@ -15955,10 +16029,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-openharmony-arm64@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.18"
   conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0"
+  dependencies:
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
@@ -15973,6 +16065,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.18"
@@ -15980,10 +16079,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.18":
   version: 1.0.0-rc.18
   resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.18"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@rolldown/pluginutils@npm:1.0.0"
+  checksum: 10/2a2b795ab991cad4bab3e35571ecefc120d9a146019e8ec3d27b1ea1e03269de13def192b22bd12ec439cbc36177da6f080118299fc9d01cd1252f05204e79a7
   languageName: node
   linkType: hard
 
@@ -16012,7 +16125,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^5.0.1, @rollup/pluginutils@npm:^5.1.0":
+"@rollup/pluginutils@npm:^5.0.1, @rollup/pluginutils@npm:^5.1.0, @rollup/pluginutils@npm:^5.1.4":
   version: 5.3.0
   resolution: "@rollup/pluginutils@npm:5.3.0"
   dependencies:
@@ -16914,7 +17027,7 @@ __metadata:
     "@girs/gjs": "workspace:^"
     "@girs/glib-2.0": "workspace:^"
     "@girs/gtk-4.0": "workspace:^"
-    "@gjsify/vite-plugin-blueprint": "npm:^0.2.9"
+    "@gjsify/vite-plugin-blueprint": "npm:^0.3.14"
     typescript: "npm:^6.0.3"
     vite: "npm:^8.0.10"
   languageName: unknown
@@ -17096,7 +17209,7 @@ __metadata:
   resolution: "@ts-for-gir/cli@workspace:packages/cli"
   dependencies:
     "@gi.ts/parser": "workspace:^"
-    "@gjsify/cli": "npm:^0.3.13"
+    "@gjsify/cli": "npm:^0.3.14"
     "@inquirer/prompts": "npm:^8.4.2"
     "@ts-for-gir/generator-base": "workspace:^"
     "@ts-for-gir/generator-html-doc": "workspace:^"
@@ -17703,17 +17816,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/esbuild-plugin-pnp@npm:^3.0.0-rc.15":
-  version: 3.0.0-rc.15
-  resolution: "@yarnpkg/esbuild-plugin-pnp@npm:3.0.0-rc.15"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    esbuild: ">=0.10.0"
-  checksum: 10/454f521088c1fa24fda51f83ca4a50ba6e3bd147e5dee8c899e6bf24a7196186532c3abb18480e83395708ffb7238c9cac5b82595c3985ce93593b5afbd0a9f0
-  languageName: node
-  linkType: hard
-
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -17730,7 +17832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.3.5":
+"acorn-walk@npm:^8.3.4":
   version: 8.3.5
   resolution: "acorn-walk@npm:8.3.5"
   dependencies:
@@ -17739,7 +17841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0":
+"acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -18975,7 +19077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^9.6.0, execa@npm:^9.6.1":
+"execa@npm:^9.6.0":
   version: 9.6.1
   resolution: "execa@npm:9.6.1"
   dependencies:
@@ -21224,6 +21326,64 @@ __metadata:
   bin:
     rolldown: bin/cli.mjs
   checksum: 10/43a3cea928039291de3b2ba8c64424a22c17bd403b8f260cf1a4b3f3e6bb2ccdcf895f133e768479753ab37544a28a7f062a93f2eebb90217f0cdf0054a5bdc3
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:^1.0.0-rc.18":
+  version: 1.0.0
+  resolution: "rolldown@npm:1.0.0"
+  dependencies:
+    "@oxc-project/types": "npm:=0.129.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.0"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.0"
+    "@rolldown/binding-darwin-x64": "npm:1.0.0"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.0"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.0"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.0"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.0"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0"
+    "@rolldown/pluginutils": "npm:1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: bin/cli.mjs
+  checksum: 10/d7bf0e215ee10933544192c483e9f0790278c69823dd9bdf30eeddcbe7aef3122bd4c0397118f17a3fb02acf4fce2dbcfaccbdd4c9eb481b4ee0f5b891d0249a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

The published `ts-for-gir-gjs` v4.0.0-rc.10 binary aborts on `self-update --check` with `Failed to fetch release information: fetch is not defined`. This PR fixes that, plus two related gaps surfaced while investigating.

### 1. Real bug — fetch missing in the GJS bundle

`packages/cli/package.json` lists `fetch`, `Headers`, `Request`, `Response` in `gjsify.excludeGlobals`. That tells `gjsify build --globals auto` to *skip* injecting `@gjsify/fetch/register/fetch` — the Soup-backed `fetch()` polyfill. `src/commands/self-update.ts` calls `fetch()` directly, so the GJS bundle has no implementation at runtime. The exclusion was added in #378 with a follow-up note in the commit message — this is that follow-up. Removed the four entries; kept `XMLHttpRequest`/`XMLHttpRequestUpload` excluded (false positives from npm dep browser-compat code, never called).

### 2. gjsify 0.3.14 (Rolldown engine)

Bumped `@gjsify/cli` `^0.3.13` → `^0.3.14`. That release migrates the bundler engine from esbuild to Rolldown and renames the `gjsify.esbuild` package.json field to `gjsify.bundler` (`RolldownOptions` shape: `output.file` instead of `outfile`). The legacy field still works for one release with a deprecation warning, but migrating now avoids the warning. Also bumped `@gjsify/vite-plugin-blueprint` `^0.2.9` → `^0.3.14` in `examples/gtk-4-template-blueprint-vite/`.

Bundle size: 24.3 MB → 22.2 MB.

### 3. Recovery path for users on the broken rc.10 binary — `install.js --force`

Anyone currently on the broken rc.10 cannot use `self-update` to recover (that's the bug we're fixing). Their alternative is `install.js`, but the installer short-circuits with `Already up to date` whenever the local version matches the latest release — which it does, because rc.10 is still the latest until this PR ships. Net effect: users stuck on the broken binary had to manually `rm ~/.local/bin/ts-for-gir` to get unstuck.

Added `--force/-f` to `install.js` that skips the same-version check and reinstalls via the existing atomic-overwrite path (`tmpFile.move(..., Gio.FileCopyFlags.OVERWRITE)`). The "already up to date" message now hints at the flag. Also added `--help/-h`.

### 4. Regression guard

`tests/e2e/cli-gjs/run.mjs` had a lenient assertion for `self-update --check` that accepted `Failed to fetch` as a valid outcome — which the buggy error (`Failed to fetch release information: fetch is not defined`) satisfied. Tightened the assertion to reject `is not defined` / `ReferenceError` / `is not a function` while still tolerating real network errors.

## Related Issue

Follow-up to #378 (the original "feat(cli): add GJS bundle" PR explicitly flagged this in its commit message: *"fetch not yet available in GJS, follow-up needed to add @gjsify/fetch polyfill"*).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

```sh
yarn check         # check:lint + check:app                     ✓
yarn test:tests    # unit suite                                  ✓
yarn build:app:gjs # rebuild via gjsify 0.3.14 (Rolldown)         ✓ (22.2 MB)
yarn workspace @ts-for-gir-test/e2e run test:cli:gjs              5/7 pass *
gjs -m packages/cli/bin/ts-for-gir-gjs self-update --check        # → Already up to date (v4.0.0-rc.10)
gjs -m install.js                                                 # → "Already up to date... Run with --force to reinstall anyway."
gjs -m install.js --force                                         # → "Reinstalling v4.0.0-rc.10 (--force)..." + atomic overwrite ✓
gjs -m install.js --help                                          # → usage info ✓
```

\* The 2 e2e failures (`doc`, `json`) are **pre-existing on main** — verified by running the published rc.10 release binary, which fails the same commands with `Template 'module.d.ts' not found`. They are not part of CI's `yarn test:tests` job. Tracking them is out of scope for this PR.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tightened the e2e regression guard for the fetch fix
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly — n/a, no public API change beyond `install.js --force/--help` which is self-documenting