### PR TITLE
fix(cli): declare source-map-support so the GJS-bundle release builds

### DIFF
--- a/install.js
+++ b/install.js
@@ -23,9 +23,13 @@ Gio._promisify(Soup.Session.prototype, "send_and_read_async");
 
 const REPO = "gjsify/ts-for-gir";
 const GJS_ASSET_NAME = "ts-for-gir-gjs";
-const INSTALL_DIR = GLib.build_filenamev([GLib.get_home_dir(), ".local", "bin"]);
+// Test hooks: production builds always use the defaults below; the e2e suite
+// overrides these to point at a localhost mock GitHub API and a tmpdir target.
+const INSTALL_DIR =
+	GLib.getenv("TS_FOR_GIR_INSTALL_DIR") ||
+	GLib.build_filenamev([GLib.get_home_dir(), ".local", "bin"]);
 const INSTALL_PATH = GLib.build_filenamev([INSTALL_DIR, "ts-for-gir"]);
-const GITHUB_API = "https://api.github.com";
+const GITHUB_API = GLib.getenv("TS_FOR_GIR_INSTALL_GITHUB_API") || "https://api.github.com";
 
 function info(msg) {
 	print(`[ts-for-gir] ${msg}`);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -86,6 +86,7 @@
 		"@types/node": "^25.6.0",
 		"@types/yargs": "^17.0.35",
 		"esbuild": "^0.28.0",
+		"source-map-support": "^0.5.21",
 		"typescript": "^6.0.3"
 	},
 	"dependencies": {

--- a/tests/e2e/install/run.mjs
+++ b/tests/e2e/install/run.mjs
@@ -1,0 +1,270 @@
+// E2E test for install.js — the GJS-native installer/updater.
+//
+// Spins up an in-process HTTP server that mocks the two GitHub endpoints
+// install.js talks to (`/repos/.../releases?per_page=20` and the asset
+// browser_download_url) and points install.js at it via the
+// TS_FOR_GIR_INSTALL_GITHUB_API and TS_FOR_GIR_INSTALL_DIR env-var test
+// hooks. No external network access, no real GitHub.
+//
+// Validates: fresh install, idempotent re-run ("Already up to date"),
+// --force reinstall, atomic install (binary chmod +x at the destination),
+// the version-detection round-trip via `<binary> --version`, and that an
+// HTTP error from the mock surfaces as a non-zero exit.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtempSync, rmSync, existsSync, statSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MONOREPO_ROOT = join(__dirname, "..", "..", "..");
+const INSTALL_JS = join(MONOREPO_ROOT, "install.js");
+
+// A fake "ts-for-gir-gjs" binary we serve as the release asset. install.js
+// chmods it +x and runs `--version` to detect what's installed; a tiny POSIX
+// shell script is enough to satisfy that round-trip.
+function fakeBinary(version) {
+	return `#!/bin/sh
+case "$1" in
+  --version) echo "${version}" ;;
+  *) echo "fake ts-for-gir binary v${version}"; exit 0 ;;
+esac
+`;
+}
+
+function gjsAvailable() {
+	try {
+		const { execFileSync } = require("node:child_process");
+		execFileSync("gjs", ["--version"], { stdio: "pipe" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function runGjs({ env, args = [] } = {}) {
+	return new Promise((resolve, reject) => {
+		const child = spawn("gjs", ["-m", INSTALL_JS, ...args], {
+			env: { ...process.env, ...env },
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (c) => {
+			stdout += c;
+		});
+		child.stderr.on("data", (c) => {
+			stderr += c;
+		});
+		const killTimer = setTimeout(() => {
+			try {
+				child.kill("SIGKILL");
+			} catch {}
+		}, 60_000);
+		child.on("close", (code) => {
+			clearTimeout(killTimer);
+			resolve({ exitCode: code, stdout, stderr });
+		});
+		child.on("error", (e) => {
+			clearTimeout(killTimer);
+			reject(e);
+		});
+	});
+}
+
+describe("install.js E2E", { timeout: 5 * 60 * 1000 }, () => {
+	let server;
+	let apiBase;
+	let installDir;
+	let installPath;
+	// Mutable per-test: lets a single `it()` swap in a different release/asset
+	// without having to spin up a new server.
+	let mockState;
+
+	before(async () => {
+		// Skip cleanly when gjs is not available — same pattern the cli-gjs
+		// e2e suite uses, so this test is a soft-fail on Node-only sandboxes.
+		const { execFileSync } = await import("node:child_process");
+		try {
+			execFileSync("gjs", ["--version"], { stdio: "pipe" });
+		} catch {
+			throw new Error("gjs is not installed; install with: sudo apt-get install gjs");
+		}
+
+		if (!existsSync(INSTALL_JS)) {
+			throw new Error(`install.js not found at ${INSTALL_JS}`);
+		}
+
+		const tmpRoot = mkdtempSync(join(tmpdir(), "ts-for-gir-install-e2e-"));
+		installDir = join(tmpRoot, "bin");
+		installPath = join(installDir, "ts-for-gir");
+
+		mockState = {
+			version: "1.0.0-test",
+			binaryContent: fakeBinary("1.0.0-test"),
+			// Per-test overrides for failure-mode assertions.
+			releasesStatus: 200,
+			assetStatus: 200,
+		};
+
+		server = createServer((req, res) => {
+			try {
+				const url = req.url ?? "";
+				if (url.startsWith("/repos/gjsify/ts-for-gir/releases")) {
+					if (mockState.releasesStatus !== 200) {
+						res.writeHead(mockState.releasesStatus).end("mock failure");
+						return;
+					}
+					const port = server.address().port;
+					const body = [
+						{
+							tag_name: `v${mockState.version}`,
+							draft: false,
+							assets: [
+								{
+									name: "ts-for-gir-gjs",
+									browser_download_url: `http://127.0.0.1:${port}/asset/ts-for-gir-gjs`,
+								},
+							],
+						},
+					];
+					res.writeHead(200, { "content-type": "application/json" });
+					res.end(JSON.stringify(body));
+					return;
+				}
+				if (url === "/asset/ts-for-gir-gjs") {
+					if (mockState.assetStatus !== 200) {
+						res.writeHead(mockState.assetStatus).end("mock failure");
+						return;
+					}
+					res.writeHead(200, { "content-type": "application/octet-stream" });
+					res.end(mockState.binaryContent);
+					return;
+				}
+				res.writeHead(404).end("not found");
+			} catch (e) {
+				res.writeHead(500).end(String(e));
+			}
+		});
+		await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+		apiBase = `http://127.0.0.1:${server.address().port}`;
+	});
+
+	after(() => {
+		if (server) server.close();
+		if (installDir && !process.env.TS_FOR_GIR_E2E_KEEP_TEMP) {
+			rmSync(dirname(installDir), { recursive: true, force: true });
+		}
+	});
+
+	it("fresh install downloads and installs the binary", async () => {
+		// Start from a clean slate: prior tests in the same suite may have
+		// installed a binary into installDir.
+		if (existsSync(installPath)) rmSync(installPath);
+
+		const result = await runGjs({
+			env: {
+				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
+				TS_FOR_GIR_INSTALL_DIR: installDir,
+			},
+		});
+		assert.equal(result.exitCode, 0, `install failed: ${result.stderr}`);
+		assert.match(result.stdout, /Installing ts-for-gir v1\.0\.0-test/);
+		assert.match(result.stdout, /Installed to/);
+		assert.ok(existsSync(installPath), `expected ${installPath} to exist`);
+		// Atomic install path leaves no .tmp dropping behind.
+		assert.ok(!existsSync(`${installPath}.tmp`), "no leftover .tmp file");
+		// Binary content must match what the mock served — proves the asset
+		// URL was actually followed (regression guard against silent-skip
+		// bugs like "Already up to date" firing on a stale cached path).
+		const installed = readFileSync(installPath, "utf8");
+		assert.equal(installed, mockState.binaryContent);
+		// Executable bit on owner — install.js promises 0755 atomic install.
+		const mode = statSync(installPath).mode & 0o777;
+		assert.equal(mode, 0o755, `expected mode 0755 but got 0${mode.toString(8)}`);
+	});
+
+	it("idempotent re-run reports Already up to date", async () => {
+		const result = await runGjs({
+			env: {
+				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
+				TS_FOR_GIR_INSTALL_DIR: installDir,
+			},
+		});
+		assert.equal(result.exitCode, 0, `re-run failed: ${result.stderr}`);
+		assert.match(result.stdout, /Already up to date \(v1\.0\.0-test\)/);
+		// Must not redownload — the "Downloading ..." line is only emitted
+		// when install.js actually fetches the asset.
+		assert.doesNotMatch(result.stdout, /Downloading/);
+	});
+
+	it("--force reinstalls the same version", async () => {
+		const result = await runGjs({
+			args: ["--force"],
+			env: {
+				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
+				TS_FOR_GIR_INSTALL_DIR: installDir,
+			},
+		});
+		assert.equal(result.exitCode, 0, `--force failed: ${result.stderr}`);
+		assert.match(result.stdout, /Reinstalling v1\.0\.0-test \(--force\)/);
+		assert.match(result.stdout, /Downloading/);
+	});
+
+	it("upgrades when the mock advertises a newer version", async () => {
+		mockState.version = "1.0.1-test";
+		mockState.binaryContent = fakeBinary("1.0.1-test");
+		try {
+			const result = await runGjs({
+				env: {
+					TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
+					TS_FOR_GIR_INSTALL_DIR: installDir,
+				},
+			});
+			assert.equal(result.exitCode, 0, `upgrade failed: ${result.stderr}`);
+			assert.match(result.stdout, /Updating from v1\.0\.0-test to v1\.0\.1-test/);
+			const installed = readFileSync(installPath, "utf8");
+			assert.equal(installed, mockState.binaryContent);
+		} finally {
+			mockState.version = "1.0.0-test";
+			mockState.binaryContent = fakeBinary("1.0.0-test");
+		}
+	});
+
+	it("exits non-zero when the GitHub API returns a 5xx", async () => {
+		mockState.releasesStatus = 503;
+		try {
+			const result = await runGjs({
+				env: {
+					TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
+					TS_FOR_GIR_INSTALL_DIR: installDir,
+				},
+			});
+			assert.notEqual(result.exitCode, 0, "should fail on 5xx");
+			const combined = result.stdout + result.stderr;
+			assert.match(combined, /Failed to fetch release info/);
+		} finally {
+			mockState.releasesStatus = 200;
+		}
+	});
+
+	it("--help prints usage and exits 0", async () => {
+		const result = await runGjs({
+			args: ["--help"],
+			env: {
+				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
+				TS_FOR_GIR_INSTALL_DIR: installDir,
+			},
+		});
+		assert.equal(result.exitCode, 0, `--help failed: ${result.stderr}`);
+		assert.match(result.stdout, /Usage: gjs -m install\.js/);
+		assert.match(result.stdout, /--force/);
+		assert.match(result.stdout, /--help/);
+	});
+});

--- a/tests/e2e/install/run.mjs
+++ b/tests/e2e/install/run.mjs
@@ -13,7 +13,7 @@
 
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { createServer } from "node:http";
 import { mkdtempSync, rmSync, existsSync, statSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -34,16 +34,6 @@ case "$1" in
   *) echo "fake ts-for-gir binary v${version}"; exit 0 ;;
 esac
 `;
-}
-
-function gjsAvailable() {
-	try {
-		const { execFileSync } = require("node:child_process");
-		execFileSync("gjs", ["--version"], { stdio: "pipe" });
-		return true;
-	} catch {
-		return false;
-	}
 }
 
 function runGjs({ env, args = [] } = {}) {
@@ -88,9 +78,9 @@ describe("install.js E2E", { timeout: 5 * 60 * 1000 }, () => {
 	let mockState;
 
 	before(async () => {
-		// Skip cleanly when gjs is not available — same pattern the cli-gjs
-		// e2e suite uses, so this test is a soft-fail on Node-only sandboxes.
-		const { execFileSync } = await import("node:child_process");
+		// Same precondition pattern the cli-gjs e2e suite uses: hard-fail with
+		// an actionable message rather than silently passing on Node-only
+		// sandboxes.
 		try {
 			execFileSync("gjs", ["--version"], { stdio: "pipe" });
 		} catch {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"test:cli": "node --test --test-timeout=600000 cli/run.mjs",
 		"test:cli:gjs": "node --test --test-timeout=300000 cli-gjs/run.mjs",
+		"test:install": "node --test --test-timeout=300000 install/run.mjs",
 		"test:create": "node --test --test-timeout=1200000 create/run.mjs",
-		"test": "yarn test:cli && yarn test:create && yarn test:cli:gjs"
+		"test": "yarn test:cli && yarn test:create && yarn test:cli:gjs && yarn test:install"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17229,6 +17229,7 @@ __metadata:
     esbuild: "npm:^0.28.0"
     glob: "npm:^13.0.6"
     inquirer: "npm:^13.4.2"
+    source-map-support: "npm:^0.5.21"
     typedoc: "npm:^0.28.19"
     typescript: "npm:^6.0.3"
     yargs: "npm:^18.0.0"
@@ -21650,7 +21651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.21, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:


### PR DESCRIPTION
## Description

v4.0.0-rc.11 was tagged on GitHub but the release contains **no `ts-for-gir-gjs` asset** and `@ts-for-gir/cli@4.0.0-rc.11` was **never published to npm**. The `release-app.yml` workflow ([run](https://github.com/gjsify/ts-for-gir/actions/runs/25500369133)) failed at the *Build GJS bundle* step:

```
[RESOLVE_ERROR] Could not resolve 'source-map-support' in
  typescript/lib/typescript.js
typescript tried to access source-map-support, but it isn't declared
in its dependencies; this makes the require call ambiguous and unsound.
```

### Why CI fails but local builds succeed

- TypeScript 6 calls `require("source-map-support").install()` at `typescript/lib/typescript.js:8386` but does NOT declare `source-map-support` in its own dependencies.
- In the full workspace, `source-map-support` is pulled in transitively via `terser-webpack-plugin` → `terser` (a webpack-stack dep, *not* reachable from `@ts-for-gir/cli`).
- The PR CI's `check` job uses `yarn install --immutable` and gets it for free.
- `release-app.yml` uses `yarn workspaces focus @ts-for-gir/cli` for speed (and because `types-dev/` is a separate submodule not checked out in that workflow). The focused install only fetches deps reachable from `@ts-for-gir/cli` — `source-map-support` is dropped → gjsify 0.3.14's Rolldown/PnP plugin errors out.

### Fix

Declare `source-map-support` directly as a devDependency of `@ts-for-gir/cli`. The focus install picks it up; full install behaviour is unchanged.

Reproduced locally with `yarn workspaces focus @ts-for-gir/cli && yarn build:app:gjs` — build now succeeds (22.2 MB bundle, identical to the full-install case).

### Recovery for rc.11

Once this PR is merged we need either:

1. Cut a fresh `v4.0.0-rc.12` (clean, but loses the rc.11 tag), or
2. Manually re-run `release-app.yml` for the `v4.0.0-rc.11` tag — currently the upload step is gated on `if: github.event_name == 'release'` (line 53), so a `workflow_dispatch` re-run wouldn't upload the asset. A small follow-up to relax that condition would let us recover existing tags without bumping versions. Out of scope here.

## E2E coverage for install.js (added in this PR)

Followup to in-flight discussion: this PR also adds an end-to-end test suite for `install.js` so future regressions in the GJS-native installer get caught locally (and in CI) without having to ship a release.

`tests/e2e/install/run.mjs` drives `install.js` end-to-end against a localhost mock GitHub API. Validates:

- Fresh install fetches the asset and chmods 0755 atomically.
- Idempotent re-run reports "Already up to date" without redownloading.
- `--force` reinstalls.
- Upgrade path triggers when the mock advertises a newer version.
- HTTP 5xx from the API surfaces as a non-zero exit (regression guard against silent-failure modes like the original `fetch is not defined`).
- `--help` prints usage.

To make `install.js` testable without monkey-patching at runtime, two narrowly-scoped env-var test hooks are added:

- `TS_FOR_GIR_INSTALL_GITHUB_API` — overrides the GitHub API base URL.
- `TS_FOR_GIR_INSTALL_DIR` — overrides the install directory.

Both default to production values when unset, so end-user behaviour is unchanged. The hooks are documented inline in `install.js`.

Local run:

```
$ yarn workspace @ts-for-gir-test/e2e run test:install
✔ install.js E2E (270.4ms)
ℹ tests 6
ℹ pass 6
ℹ fail 0
```

> **Note** — `tests/e2e/cli-gjs/run.mjs` currently fails on `doc` and `json` (`too much recursion` in the GJS bundle). Reproduced on `main` without my changes; this is a pre-existing regression introduced by the rc.11 Rolldown migration, **not** caused by this PR. Worth its own dedicated bug.

## Related Issue

Follow-up to #383, which bumped `@gjsify/cli` to 0.3.14 (Rolldown engine). The new resolver is stricter than the previous esbuild-based one for undeclared transitive requires.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (e2e test for install.js)

## Validation

```sh
# Reproduce CI release path locally:
yarn workspaces focus @ts-for-gir/cli
yarn build:app:gjs
# → packages/cli/bin/ts-for-gir-gjs (22.2 MB) ✓

# Sanity:
yarn check:lint   # ✓

# New install.js e2e:
yarn workspace @ts-for-gir-test/e2e run test:install   # 6/6 ✓ in <500ms
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Reproduced the failing scenario locally before and after the fix
- [x] New and existing tests pass locally with my changes (caveat above re: pre-existing cli-gjs `doc`/`json` failures)