### PR TITLE
fix(cli): convert config path to file:// URL for spec-compliant import()

### DIFF
--- a/packages/cli/src/config/config-loader.ts
+++ b/packages/cli/src/config/config-loader.ts
@@ -3,6 +3,7 @@
  */
 
 import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import type { ConfigFlags, OptionsGeneration, UserConfig, UserConfigLoadResult } from "@ts-for-gir/lib";
 import { APP_NAME, isEqual } from "@ts-for-gir/lib";
 import { type Options as ConfigSearchOptions, cosmiconfig } from "cosmiconfig";
@@ -18,9 +19,12 @@ import { docOptions, options } from "./options.ts";
 export async function loadConfigFile(configName?: string): Promise<UserConfigLoadResult | null> {
 	const configSearchOptions: Partial<ConfigSearchOptions> = {
 		loaders: {
-			// ESM loader
+			// ESM loader. cosmiconfig hands us an absolute filesystem path; Node's import()
+			// tolerates that as a non-spec extension, but spec-compliant runtimes (GJS /
+			// SpiderMonkey) reject it with "Module not found: <abs-path>". Convert to a
+			// file:// URL so the loader works in both runtimes.
 			".js": async (filepath) => {
-				const file = await import(filepath);
+				const file = await import(pathToFileURL(filepath).href);
 
 				// Files with `exports.default = { ... }`
 				if (file?.default?.default) {


### PR DESCRIPTION
## Summary

- `cosmiconfig` hands the ESM `.js` loader an absolute filesystem path.
- Node tolerates ``await import('/abs/path.js')`` as a non-spec extension; spec-compliant runtimes (GJS / SpiderMonkey 128) reject it with ``Module not found: <abs-path>``.
- Wrap the path with ``pathToFileURL(filepath).href`` so dynamic import receives a ``file://`` URL — accepted by both Node and SpiderMonkey.

## Context

The `@ts-for-gir/cli` GJS bundle distributed via `@gjsify/cli install ts-for-gir` (`gjsify/gjsify`) cannot load any rc file:

```
$ ts-for-gir list --configName='.ts-for-gir.packages-all.rc.js' --girDirectories='./girs'
Module not found: /home/.../.ts-for-gir.packages-all.rc.js
```

Root cause is `packages/cli/src/config/config-loader.ts`'s `.js` cosmiconfig loader doing `await import(filepath)` on an absolute path — see [GJS internalLoader.js#L111](https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/internal/internalLoader.js#L111) (`resolveSpecifier` requires either a parseable URI or a `./` / `../` relative path).

The fix is correct on Node too: `import('file:///…')` works on both runtimes; the unwrapped absolute path was a Node-only extension.

## Test plan

- [x] `yarn check:app`
- [x] Manual: `yarn ts-for-gir-dev list --configName='.ts-for-gir.packages-all.rc.js' --girDirectories='./girs'` loads the rc and prints modules (Node — already worked, regression-safe)
- [ ] Verified on the GJS bundle once a release with this commit is consumed by `gjsify`'s `tests/integration/ts-for-gir/` regression test (companion PR adds the missing coverage in `gjsify/gjsify`)