### PR TITLE
fix(cli): wire __GJS_BUNDLE__ define into build-gjs.mjs

### DIFF
--- a/packages/cli/scripts/build-gjs.mjs
+++ b/packages/cli/scripts/build-gjs.mjs
@@ -14,6 +14,14 @@ import { dirname, join } from 'node:path';
 const here = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf-8'));
 
+// __GJS_BUNDLE__=true: trips the early-return guard in commands that aren't
+// yet supported on the GJS bundle (currently only `create`, which depends on
+// dist-templates/ shipping alongside the binary — install.js downloads the
+// single binary asset only). Without the define, the guard's `typeof !==
+// "undefined"` check is dead code and the command falls through to
+// findTemplatesRoot(), printing a confusing "Could not locate templates
+// directory" error instead of the intended "not yet supported, use Node"
+// message. Track templates-shipping work in CHANGELOG.md.
 const result = spawnSync(
     'gjsify',
     [
@@ -21,6 +29,8 @@ const result = spawnSync(
         'src/start.ts',
         '--define',
         `__TS_FOR_GIR_VERSION__=${JSON.stringify(pkg.version)}`,
+        '--define',
+        '__GJS_BUNDLE__=true',
     ],
     { stdio: 'inherit', cwd: join(here, '..') },
 );


### PR DESCRIPTION
## Summary

- `packages/cli/src/commands/create.ts` already declares + checks `__GJS_BUNDLE__` to short-circuit with a friendly *"not yet supported in the GJS bundle, use Node.js instead"* message.
- But `scripts/build-gjs.mjs` never defined it, so the `typeof !== "undefined"` guard was dead code in shipped GJS builds.
- The handler then fell through to `findTemplatesRoot()`, which throws a confusing path-based error because `dist-templates/` is not shipped alongside the single-file release binary that `install.js` downloads.

## User-reported reproduction

Against the binary that `install.js` (or `gjsify install ts-for-gir`) lands at `~/.local/bin/ts-for-gir`:

```
$ ts-for-gir create test
Could not locate templates directory. Looked in:
  /home/<user>/.local/dist-templates
  /home/<user>/dist-templates
  /home/<user>/templates
If you are running from source, make sure packages/cli/templates/ exists. If you are running the published CLI, make sure dist-templates/ was packed.
```

## After this fix

```
$ ts-for-gir create test
The 'create' command is not yet supported in the GJS bundle.
Use Node.js instead: npx @ts-for-gir/cli create ...
```

(Verified locally by rebuilding `packages/cli/bin/ts-for-gir-gjs` with the patched build script and running it from `/tmp`.)

## Long term

The proper fix is to ship `dist-templates/` alongside the GJS binary so `create` actually works there too — either:

- as a separate release asset (`ts-for-gir-gjs-templates.tar.gz`) that `install.js` extracts to a known XDG location and `findTemplatesRoot()` learns to check, or
- embedded as build-time literals through gjsify's static-read inliner (similar to how the EJS templates are now resolved at runtime via `@gjsify/module`'s PnP-aware `createRequire`).

Out of scope for this PR — the runtime guard already exists, this just enables it so the user sees the actionable message instead of a misleading filesystem error.

## Test plan

- [x] `yarn workspace @ts-for-gir/cli build:gjs` rebuilds `bin/ts-for-gir-gjs`
- [x] `cd /tmp && /…/packages/cli/bin/ts-for-gir-gjs create test-x` prints the *"not yet supported in the GJS bundle"* message and exits cleanly (no scaffolding attempted)
- [x] Pre-existing Node bundle (`bin/ts-for-gir`) and dev bundle (`bin/ts-for-gir-dev`) unaffected — they keep the full `create` flow