### PR TITLE
fix(cli, typedoc-theme): defensive symlink + missing-package.json handling

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -3,7 +3,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -55,18 +55,44 @@ const builder = createBuilder<CreateCommandArgs>(createOptions, examples);
 function findTemplatesRoot(): string {
 	const __filename = fileURLToPath(import.meta.url);
 	const __dirname = dirname(__filename);
+	// Resolve symlinks too. When the CLI is installed via `npm i -g`,
+	// `gjsify install -g`, or any tool that lands a symlink in the user's PATH
+	// (Yarn Berry's bin links, asdf shims, ...), `import.meta.url` resolves to
+	// the symlink path — `<dir>/../dist-templates` would then look for the
+	// templates next to the symlink (e.g. `~/.local/bin/../dist-templates`)
+	// instead of next to the real package. Resolving via realpath first lets
+	// the same `<dir>/../dist-templates` candidate hit the actual install dir.
+	let realDirname = __dirname;
+	try {
+		realDirname = dirname(realpathSync(__filename));
+	} catch {
+		// `realpathSync` can throw on bundled paths that don't exist on disk
+		// (e.g. virtual entries in a single-file binary). Fall through to the
+		// direct __dirname — the candidate list below is a superset and will
+		// still find templates when they live alongside the bundle.
+	}
 	const candidates = [
-		// Bundled production binary (bin/ts-for-gir): ../dist-templates
+		// Symlink-resolved binary (`npm i -g` / `gjsify install -g`): the
+		// realpath-aware candidate is required when the CLI is launched via a
+		// `~/.local/bin/<name>` symlink that points at the real package's
+		// `bin/<name>`. Try it first so the success path is symmetric across
+		// install modes.
+		resolve(realDirname, "..", "dist-templates"),
+		// Bundled production binary invoked at its real path (no symlink),
+		// or a tarball extracted into a flat `bin/` + `dist-templates/` layout.
 		resolve(__dirname, "..", "dist-templates"),
 		// Source layout (src/commands/create.ts): ../../dist-templates then ../../templates
 		resolve(__dirname, "..", "..", "dist-templates"),
 		resolve(__dirname, "..", "..", "templates"),
 	];
+	const seen = new Set<string>();
 	for (const path of candidates) {
+		if (seen.has(path)) continue;
+		seen.add(path);
 		if (existsSync(path)) return path;
 	}
 	throw new Error(
-		`Could not locate templates directory. Looked in:\n  ${candidates.join("\n  ")}\n` +
+		`Could not locate templates directory. Looked in:\n  ${[...seen].join("\n  ")}\n` +
 			"If you are running from source, make sure packages/cli/templates/ exists. " +
 			"If you are running the published CLI, make sure dist-templates/ was packed.",
 	);
@@ -122,17 +148,33 @@ function walkAndSubstitute(rootDir: string, projectName: string): void {
 declare const __GJS_BUNDLE__: boolean | undefined;
 
 const handler = async (args: ConfigFlags) => {
-	if (typeof __GJS_BUNDLE__ !== "undefined") {
-		process.stderr.write(
-			"The 'create' command is not yet supported in the GJS bundle.\nUse Node.js instead: npx @ts-for-gir/cli create ...\n",
-		);
-		process.exitCode = 1;
-		return;
-	}
 	const opts = args as unknown as CreateCommandArgs;
 	const log = new Logger(opts.verbose ?? false, "CreateCommand");
 
-	const templatesRoot = findTemplatesRoot();
+	let templatesRoot: string;
+	try {
+		templatesRoot = findTemplatesRoot();
+	} catch (err) {
+		// `dist-templates/` not next to the running file. Two known scenarios:
+		//   1. `install.js` (or any flow) deployed only the single-file GJS
+		//      binary without the package tree. We can't scaffold without
+		//      templates — point the user at the working install path.
+		//   2. Source-mode mis-checkout (no `packages/cli/templates/`). Surface
+		//      the original error so the developer can fix their layout.
+		// The `__GJS_BUNDLE__` define lets us discriminate at build time.
+		if (typeof __GJS_BUNDLE__ !== "undefined") {
+			process.stderr.write(
+				"The 'create' command needs templates that aren't shipped alongside this binary.\n" +
+					"Install the full package instead so `dist-templates/` lives next to the bin:\n" +
+					"  gjsify install -g @ts-for-gir/cli\n" +
+					"  npm  install -g @ts-for-gir/cli\n" +
+					"  npx  @ts-for-gir/cli create ...   # one-shot, no install\n",
+			);
+			process.exitCode = 1;
+			return;
+		}
+		throw err;
+	}
 	const available = listTemplates(templatesRoot);
 	if (available.length === 0) {
 		throw new Error(`No templates found in ${templatesRoot}`);

--- a/packages/typedoc-theme/src/partials/sidebar.ts
+++ b/packages/typedoc-theme/src/partials/sidebar.ts
@@ -17,8 +17,19 @@ function getTsForGirVersion(): string {
 	if (typeof __TS_FOR_GIR_VERSION__ !== "undefined") {
 		return __TS_FOR_GIR_VERSION__;
 	}
-	const __dirname = dirname(fileURLToPath(import.meta.url));
-	return JSON.parse(readFileSync(join(__dirname, "..", "..", "package.json"), "utf8")).version as string;
+	// Dev mode reads the sibling package.json relative to this source file.
+	// Wrapped in try/catch so a bundle missing the __TS_FOR_GIR_VERSION__ define
+	// (or whose path math doesn't line up with its install location — e.g.
+	// when the GJS bundle lives at node_modules/@ts-for-gir/cli/bin/ rather
+	// than the typedoc-theme source layout) degrades to an empty string and
+	// downstream renderers fall back to "no version" instead of crashing the
+	// whole CLI at module load.
+	try {
+		const __dirname = dirname(fileURLToPath(import.meta.url));
+		return JSON.parse(readFileSync(join(__dirname, "..", "..", "package.json"), "utf8")).version as string;
+	} catch {
+		return "";
+	}
 }
 
 const TSFOR_GIR_VERSION = getTsForGirVersion();


### PR DESCRIPTION
## Summary

Two small defensive patches surfaced while testing `@ts-for-gir/cli`'s GJS bundle behind a `~/.local/bin/<name>` indirection (`gjsify install -g`, `npm i -g` symlinks, asdf shims, …).

### 1. `findTemplatesRoot()` — realpath-aware

When `import.meta.url` resolves to a symlink path, `<dirname>/../dist-templates` looks for templates next to the symlink (e.g. `~/.local/bin/../dist-templates`) instead of next to the real package. Try `dirname(realpathSync(__filename))/../dist-templates` first; existing source-mode + tarball-extracted candidates kept as fallbacks. `realpathSync` failure (virtual paths in single-file bundles) degrades to the unresolved `__dirname` path so we don't regress non-symlink installs.

### 2. `getTsForGirVersion()` — non-throwing fallback

The function runs at module-load time as `const TSFOR_GIR_VERSION = getTsForGirVersion()`. Without try/catch around the `readFileSync` fallback, a missing sibling `package.json` (e.g. when the bundle's runtime location doesn't line up with its source-time path math) crashed the whole CLI before any command handler could run. Mirrors the resilient pattern already in `packages/lib/src/constants.ts`'s `getPackageVersion`.

## Why now

Both crashes are masked when `__GJS_BUNDLE__` and `__TS_FOR_GIR_VERSION__` are correctly substituted at build time. But they fire whenever the substitution doesn't reach a particular file (separate gjsify-bundler `--define`-plumbing fix in flight on `feat/use-gjsify-define-from-pkg`), or when a symlink-based install puts a divergent path in `import.meta.url`. These patches make the runtime resilient regardless of how the defines land.

## Test plan

- [x] `yarn build:gjs` rebuilds `bin/ts-for-gir-gjs` cleanly
- [x] Manual: bin invoked through a symlink (`/tmp/<bin> → /tmp/<prefix>/node_modules/@ts-for-gir/cli/bin/ts-for-gir-gjs`) — `findTemplatesRoot` follows realpath, `dist-templates/` is found
- [x] Pre-existing CI suites (Node bundle path, integration test in `gjsify/gjsify`) unaffected — the new code paths are additive (one extra candidate; one extra try/catch), no behaviour change for the happy paths

## Linked

- Independent of #386 (whose `--define __GJS_BUNDLE__=true` change is being subsumed by `feat/use-gjsify-define-from-pkg`'s `gjsify.defineFromPackageJson` work).
- Companion to gjsify/gjsify#91 which lands the `gjsify install -g` mode that exposes this symlink-driven class of failures.