### PR TITLE
feat(install.js): fetch full npm tarball + write sh launcher

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -49,13 +49,14 @@ jobs:
     - name: Build GJS bundle
       run: yarn build:app:gjs
 
-    - name: Upload GJS bundle to GitHub Release
-      if: github.event_name == 'release'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        RELEASE_TAG="${{ github.event.release.tag_name }}"
-        gh release upload "$RELEASE_TAG" packages/cli/bin/ts-for-gir-gjs --clobber
+    # The GJS bundle ships inside the npm tarball under bin/ts-for-gir-gjs
+    # (declared via `gjsify.bin` in @ts-for-gir/cli's package.json). Both
+    # `npm i -g`, `gjsify install -g`, and the GJS-native install.js
+    # bootstrapper resolve it from there. The previous "upload the single
+    # binary as a GitHub release asset" step is gone — the asset couldn't
+    # carry `dist-templates/` alongside the bin, so `ts-for-gir create`
+    # failed when launched through the old install.js. This comment is
+    # here so we don't reintroduce the asset-upload by reflex.
 
     - name: Publish app packages to npm
       run: yarn publish:app

--- a/install.js
+++ b/install.js
@@ -5,11 +5,27 @@
  * Usage:
  *   gjs -m install.js               # install or update
  *   gjs -m install.js --force       # reinstall even if already up to date
+ *   gjs -m install.js --tag=next    # install a specific dist-tag (default: latest)
  *   # or, if the shebang is supported:
  *   ./install.js
  *
- * Installs or updates the ts-for-gir GJS binary to ~/.local/bin/ts-for-gir.
- * Set GITHUB_TOKEN environment variable to avoid GitHub API rate limits.
+ * Fetches `@ts-for-gir/cli` from the npm registry (full package tarball, not
+ * just the GJS binary), extracts it to ~/.local/share/ts-for-gir/, and writes
+ * a small POSIX `sh` launcher at ~/.local/bin/ts-for-gir that exec's the GJS
+ * bundle inside the install dir.
+ *
+ * Why the npm tarball + launcher (vs. the previous single-binary download
+ * from a GitHub release): commands like `ts-for-gir create` rely on assets
+ * shipped *next to* the bin (e.g. dist-templates/), which the old
+ * one-asset-only path could not deliver. Going through the published npm
+ * package gives us the whole package tree — same artefact npm/gjsify-install-g
+ * use — so package-relative `__dirname/..` resolution Just Works.
+ *
+ * Test hooks (set in tests/e2e/install/run.mjs):
+ *   TS_FOR_GIR_INSTALL_REGISTRY  override the npm registry origin
+ *   TS_FOR_GIR_INSTALL_DIR       override the launcher dir (~/.local/bin)
+ *   TS_FOR_GIR_INSTALL_DATA_DIR  override the package install dir
+ *                                (XDG_DATA_HOME/ts-for-gir)
  */
 
 import GLib from "gi://GLib";
@@ -17,19 +33,28 @@ import Gio from "gi://Gio";
 import Soup from "gi://Soup?version=3.0";
 import system, { exit } from "system";
 
-// GJS does not auto-promisify libsoup methods; wire it up explicitly so we can
-// `await session.send_and_read_async(...)` with the standard 3-arg signature.
+// GJS does not auto-promisify libsoup methods; wire them up explicitly so
+// `await session.send_and_read_async(...)` uses the standard 3-arg signature.
 Gio._promisify(Soup.Session.prototype, "send_and_read_async");
+Gio._promisify(Gio.Subprocess.prototype, "wait_check_async");
 
-const REPO = "gjsify/ts-for-gir";
-const GJS_ASSET_NAME = "ts-for-gir-gjs";
-// Test hooks: production builds always use the defaults below; the e2e suite
-// overrides these to point at a localhost mock GitHub API and a tmpdir target.
-const INSTALL_DIR =
+const PACKAGE = "@ts-for-gir/cli";
+const DEFAULT_REGISTRY = "https://registry.npmjs.org";
+const DEFAULT_BIN_NAME = "ts-for-gir";
+
+const REGISTRY = (GLib.getenv("TS_FOR_GIR_INSTALL_REGISTRY") || DEFAULT_REGISTRY).replace(/\/+$/, "");
+// `~/.local/bin` style — where the launcher script lives, expected to be on $PATH.
+const BIN_DIR =
 	GLib.getenv("TS_FOR_GIR_INSTALL_DIR") ||
 	GLib.build_filenamev([GLib.get_home_dir(), ".local", "bin"]);
-const INSTALL_PATH = GLib.build_filenamev([INSTALL_DIR, "ts-for-gir"]);
-const GITHUB_API = GLib.getenv("TS_FOR_GIR_INSTALL_GITHUB_API") || "https://api.github.com";
+// `~/.local/share/ts-for-gir/` — the extracted npm package tree (bin/, dist-templates/, …).
+const DATA_DIR =
+	GLib.getenv("TS_FOR_GIR_INSTALL_DATA_DIR") ||
+	GLib.build_filenamev([
+		GLib.getenv("XDG_DATA_HOME") || GLib.build_filenamev([GLib.get_home_dir(), ".local", "share"]),
+		"ts-for-gir",
+	]);
+const LAUNCHER_PATH = GLib.build_filenamev([BIN_DIR, DEFAULT_BIN_NAME]);
 
 function info(msg) {
 	print(`[ts-for-gir] ${msg}`);
@@ -39,46 +64,46 @@ function error(msg) {
 	printerr(`[ts-for-gir] ERROR: ${msg}`);
 }
 
-function getInstalledVersion() {
-	const file = Gio.File.new_for_path(INSTALL_PATH);
+function readJsonFile(path) {
+	const file = Gio.File.new_for_path(path);
 	if (!file.query_exists(null)) return null;
 	try {
-		const [ok, stdout] = GLib.spawn_command_line_sync(`${INSTALL_PATH} --version`);
-		if (!ok) return null;
-		const output = new TextDecoder().decode(stdout).trim();
-		const match = output.match(/(\d+\.\d+\.\d+(?:-\S+)?)/);
-		return match ? match[1] : null;
+		const [, bytes] = file.load_contents(null);
+		return JSON.parse(new TextDecoder().decode(bytes));
 	} catch {
 		return null;
 	}
 }
 
-function ensureInstallDir() {
-	const dir = Gio.File.new_for_path(INSTALL_DIR);
-	if (!dir.query_exists(null)) {
-		dir.make_directory_with_parents(null);
-		info(`Created ${INSTALL_DIR}`);
+function getInstalledVersion() {
+	// Prefer the package.json — single-source-of-truth that doesn't require
+	// spawning the bundle (which can be slow and may itself be broken on a
+	// half-finished install).
+	const pkg = readJsonFile(GLib.build_filenamev([DATA_DIR, "package.json"]));
+	return pkg?.version ?? null;
+}
+
+function ensureDir(dir) {
+	const file = Gio.File.new_for_path(dir);
+	if (!file.query_exists(null)) {
+		file.make_directory_with_parents(null);
 	}
 }
 
 function checkPath() {
 	const pathEnv = GLib.getenv("PATH") ?? "";
-	if (!pathEnv.split(":").includes(INSTALL_DIR)) {
+	if (!pathEnv.split(":").includes(BIN_DIR)) {
 		info("");
-		info(`Note: ${INSTALL_DIR} is not in your PATH.`);
+		info(`Note: ${BIN_DIR} is not in your PATH.`);
 		info("Add the following line to your ~/.bashrc or ~/.profile:");
-		info(`  export PATH="$HOME/.local/bin:$PATH"`);
+		info(`  export PATH="${BIN_DIR}:$PATH"`);
 	}
 }
 
-async function fetchJson(session, url) {
+async function fetchJson(session, url, accept = "application/json") {
 	const message = Soup.Message.new("GET", url);
-	message.request_headers.append("Accept", "application/vnd.github.v3+json");
-	message.request_headers.append("User-Agent", "ts-for-gir-installer/1.0");
-	const token = GLib.getenv("GITHUB_TOKEN");
-	if (token) {
-		message.request_headers.append("Authorization", `token ${token}`);
-	}
+	message.request_headers.append("Accept", accept);
+	message.request_headers.append("User-Agent", "ts-for-gir-installer/2.0");
 	const bytes = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
 	const status = message.get_status();
 	if (status !== Soup.Status.OK) {
@@ -87,56 +112,165 @@ async function fetchJson(session, url) {
 	return JSON.parse(new TextDecoder().decode(bytes.get_data()));
 }
 
-async function downloadToFile(session, url, destPath) {
+async function fetchBytes(session, url) {
 	const message = Soup.Message.new("GET", url);
-	message.request_headers.append("User-Agent", "ts-for-gir-installer/1.0");
+	message.request_headers.append("User-Agent", "ts-for-gir-installer/2.0");
 	const bytes = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
 	const status = message.get_status();
 	if (status !== Soup.Status.OK) {
-		throw new Error(`HTTP ${status} downloading binary`);
+		throw new Error(`HTTP ${status} from ${url}`);
 	}
+	return bytes.get_data();
+}
 
-	// Atomic write: write to tmp then rename
-	const tmpPath = destPath + ".tmp";
-	const tmpFile = Gio.File.new_for_path(tmpPath);
-	tmpFile.replace_contents(bytes.get_data(), null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
+/**
+ * Pick the version that satisfies the requested dist-tag. We deliberately
+ * don't implement full semver-range resolution here — `install.js` is meant
+ * to be a thin bootstrapper, and any user who needs sharper version control
+ * already has a real package manager.
+ */
+function pickVersion(packument, tag) {
+	const distTags = packument["dist-tags"] || {};
+	const version = distTags[tag];
+	if (!version) {
+		const known = Object.keys(distTags).join(", ");
+		throw new Error(`Unknown dist-tag '${tag}' on ${PACKAGE}. Known tags: ${known || "(none)"}`);
+	}
+	const meta = packument.versions?.[version];
+	if (!meta?.dist?.tarball) {
+		throw new Error(`Packument lists version ${version} but has no dist.tarball entry`);
+	}
+	return { version, tarballUrl: meta.dist.tarball };
+}
 
-	// Make executable
+async function extractTarball(tarballPath, destDir) {
+	// Layout note: npm tarballs always nest contents under a leading
+	// `package/` directory. `--strip-components=1` collapses that prefix so
+	// `package/bin/x` lands at `<destDir>/bin/x`.
+	//
+	// Why subprocess instead of a pure-JS tar reader: GJS has no built-in
+	// tarball parser, every Linux distro ships GNU/BSD tar with `-z`, and the
+	// subprocess hop is invisibly cheap next to a network round-trip. This
+	// keeps install.js short and inspectable.
+	const proc = Gio.Subprocess.new(
+		[
+			"tar",
+			"-xzf",
+			tarballPath,
+			"-C",
+			destDir,
+			"--strip-components=1",
+		],
+		Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE,
+	);
+	await proc.wait_check_async(null);
+}
+
+async function downloadTarballToTmp(session, url) {
+	const bytes = await fetchBytes(session, url);
+	// `Gio.File.new_tmp` returns [file, IOStream]; close the stream before
+	// handing the path to `tar` so there's no contention on the fd.
+	const [file, iostream] = Gio.File.new_tmp("ts-for-gir-XXXXXX.tgz");
+	iostream.close(null);
+	file.replace_contents(bytes, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
+	return file.get_path();
+}
+
+function rmRecursive(path) {
+	const file = Gio.File.new_for_path(path);
+	if (!file.query_exists(null)) return;
+	const enumerator = file.enumerate_children(
+		"standard::name,standard::type",
+		Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+		null,
+	);
+	let childInfo;
+	while ((childInfo = enumerator.next_file(null))) {
+		const child = file.resolve_relative_path(childInfo.get_name());
+		if (childInfo.get_file_type() === Gio.FileType.DIRECTORY) {
+			rmRecursive(child.get_path());
+		} else {
+			child.delete(null);
+		}
+	}
+	enumerator.close(null);
+	file.delete(null);
+}
+
+function shQuote(s) {
+	return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function pickLauncherTarget(pkg) {
+	// Prefer `gjsify.bin[<bin-name>]` (GJS bundle), fall back to npm `bin`
+	// (Node script). Only the plain string and `Record<name, target>` shapes
+	// matter here — none of the bins we care about use the npm "single
+	// string" form because @ts-for-gir/cli has multiple bins.
+	const gjsifyBin = pkg?.gjsify?.bin;
+	if (gjsifyBin && typeof gjsifyBin === "object" && gjsifyBin[DEFAULT_BIN_NAME]) {
+		return gjsifyBin[DEFAULT_BIN_NAME];
+	}
+	const npmBin = pkg?.bin;
+	if (npmBin && typeof npmBin === "object" && npmBin[DEFAULT_BIN_NAME]) {
+		return npmBin[DEFAULT_BIN_NAME];
+	}
+	throw new Error(`No '${DEFAULT_BIN_NAME}' bin declared in package.json (looked at gjsify.bin and bin)`);
+}
+
+function writeLauncher(target) {
+	const launcher = `#!/bin/sh\nexec ${shQuote(target)} "$@"\n`;
+	const file = Gio.File.new_for_path(LAUNCHER_PATH);
+	file.replace_contents(
+		new TextEncoder().encode(launcher),
+		null,
+		false,
+		Gio.FileCreateFlags.REPLACE_DESTINATION,
+		null,
+	);
 	const fileInfo = new Gio.FileInfo();
 	fileInfo.set_attribute_uint32("unix::mode", 0o755);
-	tmpFile.set_attributes_from_info(fileInfo, Gio.FileQueryInfoFlags.NONE, null);
+	file.set_attributes_from_info(fileInfo, Gio.FileQueryInfoFlags.NONE, null);
+}
 
-	// Rename to final destination (atomic on Linux)
-	const destFile = Gio.File.new_for_path(destPath);
-	tmpFile.move(destFile, Gio.FileCopyFlags.OVERWRITE, null, null);
+function makeBinExecutable(target) {
+	const file = Gio.File.new_for_path(target);
+	if (!file.query_exists(null)) return;
+	const fileInfo = new Gio.FileInfo();
+	fileInfo.set_attribute_uint32("unix::mode", 0o755);
+	try {
+		file.set_attributes_from_info(fileInfo, Gio.FileQueryInfoFlags.NONE, null);
+	} catch {
+		/* best effort */
+	}
 }
 
 function parseArgs() {
-	// system.programArgs is the canonical GJS API for argv (excludes the
-	// interpreter and script path). Older versions expose programArgs as a
-	// plain array of strings.
 	const argv = system?.programArgs ?? [];
 	const force = argv.includes("--force") || argv.includes("-f");
 	const help = argv.includes("--help") || argv.includes("-h");
-	return { force, help };
+	let tag = "latest";
+	for (const a of argv) {
+		const m = a.match(/^--tag=(.+)$/);
+		if (m) tag = m[1];
+	}
+	return { force, help, tag };
 }
 
 function printUsage() {
-	print("Usage: gjs -m install.js [--force] [--help]");
+	print("Usage: gjs -m install.js [--force] [--tag=<dist-tag>] [--help]");
 	print("");
-	print("Installs or updates the ts-for-gir GJS binary to ~/.local/bin/ts-for-gir.");
+	print(`Installs or updates ${PACKAGE} from the npm registry.`);
+	print(`  package tree → ${DATA_DIR}`);
+	print(`  launcher     → ${LAUNCHER_PATH}`);
 	print("");
 	print("Options:");
-	print("  --force, -f   Reinstall even if the latest version is already installed.");
-	print("                Useful for recovering from a broken local binary when");
-	print("                `ts-for-gir self-update` cannot run.");
-	print("  --help,  -h   Show this message.");
-	print("");
-	print("Set GITHUB_TOKEN to avoid GitHub API rate limits.");
+	print("  --force, -f         Reinstall even if the latest version is already installed.");
+	print("  --tag=<dist-tag>    Install a specific dist-tag (default: latest, e.g. next).");
+	print("  --help,  -h         Show this message.");
 }
 
 async function main() {
-	const { force, help } = parseArgs();
+	const { force, help, tag } = parseArgs();
 	if (help) {
 		printUsage();
 		exit(0);
@@ -144,67 +278,93 @@ async function main() {
 
 	const session = new Soup.Session();
 
-	info("Fetching release information from GitHub...");
-
-	// We scan the recent releases instead of using /releases/latest because the
-	// latter skips prereleases. During the rc cycle the most recent stable may
-	// not yet ship the GJS bundle, so picking the newest release that actually
-	// contains the asset is more robust.
-	let releases;
+	const packumentUrl = `${REGISTRY}/${encodeURIComponent(PACKAGE).replace("%40", "@")}`;
+	info(`Fetching ${packumentUrl} ...`);
+	let packument;
 	try {
-		releases = await fetchJson(session, `${GITHUB_API}/repos/${REPO}/releases?per_page=20`);
+		packument = await fetchJson(session, packumentUrl, "application/vnd.npm.install-v1+json");
 	} catch (err) {
-		error(`Failed to fetch release info: ${err.message}`);
+		error(`Failed to fetch packument: ${err.message}`);
 		exit(1);
 	}
 
-	let release;
-	let asset;
-	for (const candidate of releases) {
-		if (candidate.draft) continue;
-		const match = candidate.assets?.find((a) => a.name === GJS_ASSET_NAME);
-		if (match) {
-			release = candidate;
-			asset = match;
-			break;
-		}
-	}
-
-	if (!release || !asset) {
-		error(`No release with a ${GJS_ASSET_NAME} asset found in the last 20 releases`);
+	let target;
+	try {
+		target = pickVersion(packument, tag);
+	} catch (err) {
+		error(err.message);
 		exit(1);
 	}
 
-	const latestVersion = release.tag_name.replace(/^v/, "");
 	const installedVersion = getInstalledVersion();
-
-	if (installedVersion === latestVersion && !force) {
+	if (installedVersion === target.version && !force) {
 		info(`Already up to date (v${installedVersion})`);
 		info("Run with --force to reinstall anyway.");
 		exit(0);
 	}
 
-	if (installedVersion === latestVersion) {
-		info(`Reinstalling v${installedVersion} (--force)...`);
+	if (installedVersion === target.version) {
+		info(`Reinstalling v${installedVersion} (--force) ...`);
 	} else if (installedVersion) {
-		info(`Updating from v${installedVersion} to v${latestVersion}...`);
+		info(`Updating from v${installedVersion} to v${target.version} ...`);
 	} else {
-		info(`Installing ts-for-gir v${latestVersion}...`);
+		info(`Installing ${PACKAGE}@${target.version} ...`);
 	}
 
-	ensureInstallDir();
-
-	info(`Downloading ${asset.browser_download_url}...`);
+	let tarballPath;
 	try {
-		await downloadToFile(session, asset.browser_download_url, INSTALL_PATH);
+		info(`Downloading ${target.tarballUrl} ...`);
+		tarballPath = await downloadTarballToTmp(session, target.tarballUrl);
 	} catch (err) {
 		error(`Download failed: ${err.message}`);
 		exit(1);
 	}
 
-	info(`Installed to ${INSTALL_PATH}`);
+	try {
+		// Wipe the previous install before extracting so we don't leave stale
+		// files when a release removes something. The launcher is rewritten
+		// below regardless, so a half-finished extract is recoverable by
+		// re-running with --force.
+		rmRecursive(DATA_DIR);
+		ensureDir(DATA_DIR);
+		await extractTarball(tarballPath, DATA_DIR);
+	} catch (err) {
+		error(`Extraction failed: ${err.message}`);
+		exit(1);
+	} finally {
+		try {
+			Gio.File.new_for_path(tarballPath).delete(null);
+		} catch {
+			/* best effort */
+		}
+	}
+
+	// Resolve the launcher target via the freshly-extracted package.json so
+	// the install path stays in sync with whatever the published package
+	// declares (gjsify.bin can change in future releases).
+	const pkg = readJsonFile(GLib.build_filenamev([DATA_DIR, "package.json"]));
+	if (!pkg) {
+		error("Extracted package is missing package.json");
+		exit(1);
+	}
+	let binRel;
+	try {
+		binRel = pickLauncherTarget(pkg);
+	} catch (err) {
+		error(err.message);
+		exit(1);
+	}
+	const binAbs = GLib.build_filenamev([DATA_DIR, binRel]);
+	makeBinExecutable(binAbs);
+
+	ensureDir(BIN_DIR);
+	writeLauncher(binAbs);
+
+	info(`Installed ${PACKAGE}@${target.version}`);
+	info(`  package tree → ${DATA_DIR}`);
+	info(`  launcher     → ${LAUNCHER_PATH}  →  ${binAbs}`);
 	checkPath();
-	info("Done! Run: ts-for-gir --help");
+	info(`Done! Run: ${DEFAULT_BIN_NAME} --help`);
 }
 
 await main();

--- a/tests/e2e/install/run.mjs
+++ b/tests/e2e/install/run.mjs
@@ -1,21 +1,24 @@
 // E2E test for install.js — the GJS-native installer/updater.
 //
-// Spins up an in-process HTTP server that mocks the two GitHub endpoints
-// install.js talks to (`/repos/.../releases?per_page=20` and the asset
-// browser_download_url) and points install.js at it via the
-// TS_FOR_GIR_INSTALL_GITHUB_API and TS_FOR_GIR_INSTALL_DIR env-var test
-// hooks. No external network access, no real GitHub.
+// Spins up an in-process HTTP server that mocks the two npm-registry
+// endpoints install.js talks to (the packument and the tarball URL it
+// resolves to) and points install.js at it via the
+// TS_FOR_GIR_INSTALL_REGISTRY / TS_FOR_GIR_INSTALL_DIR /
+// TS_FOR_GIR_INSTALL_DATA_DIR env-var test hooks. No external network
+// access, no real npm.
 //
-// Validates: fresh install, idempotent re-run ("Already up to date"),
-// --force reinstall, atomic install (binary chmod +x at the destination),
-// the version-detection round-trip via `<binary> --version`, and that an
-// HTTP error from the mock surfaces as a non-zero exit.
+// Validates: fresh install of the full package (binary + dist-templates),
+// idempotent re-run ("Already up to date"), --force reinstall, version
+// detection round-trip via the launcher → bin chain, the `dist-templates/`
+// directory ends up next to the bin (the whole point of moving from the
+// single-asset GitHub-release flow), HTTP errors surface as non-zero exits,
+// and --help works.
 
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
 import { createServer } from "node:http";
-import { mkdtempSync, rmSync, existsSync, statSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, statSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -24,9 +27,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const MONOREPO_ROOT = join(__dirname, "..", "..", "..");
 const INSTALL_JS = join(MONOREPO_ROOT, "install.js");
 
-// A fake "ts-for-gir-gjs" binary we serve as the release asset. install.js
-// chmods it +x and runs `--version` to detect what's installed; a tiny POSIX
-// shell script is enough to satisfy that round-trip.
+const PACKAGE = "@ts-for-gir/cli";
+// install.js encodes the package name except for the leading `@` (npm
+// registry convention). Mirror that exactly so URL routing matches.
+const ENCODED_PACKAGE = `@${encodeURIComponent(PACKAGE.slice(1))}`;
+const FAKE_BIN_REL = "bin/ts-for-gir-gjs";
+
+// A fake "ts-for-gir-gjs" binary we ship inside the tarball. install.js
+// chmods it +x and the launcher exec's it; a tiny POSIX shell script is
+// enough to satisfy the version-detection round-trip.
 function fakeBinary(version) {
 	return `#!/bin/sh
 case "$1" in
@@ -34,6 +43,56 @@ case "$1" in
   *) echo "fake ts-for-gir binary v${version}"; exit 0 ;;
 esac
 `;
+}
+
+/**
+ * Build a real .tgz tarball matching npm's published-package layout
+ * (`package/<files>` prefix). Returns the bytes for the HTTP server to
+ * serve verbatim.
+ */
+function buildTarball(version, opts = {}) {
+	const stage = mkdtempSync(join(tmpdir(), "ts-for-gir-pack-"));
+	try {
+		const root = join(stage, "package");
+		mkdirSync(root, { recursive: true });
+
+		// Minimal package.json that drives:
+		//  - install.js's getInstalledVersion() (reads .version)
+		//  - install.js's pickLauncherTarget() (reads gjsify.bin.ts-for-gir)
+		const pkg = {
+			name: PACKAGE,
+			version,
+			bin: { "ts-for-gir": "bin/ts-for-gir-node" },
+			gjsify: { bin: { "ts-for-gir": FAKE_BIN_REL } },
+			...(opts.extraPkg ?? {}),
+		};
+		writeFileSync(join(root, "package.json"), JSON.stringify(pkg, null, 2));
+
+		mkdirSync(join(root, "bin"), { recursive: true });
+		writeFileSync(join(root, FAKE_BIN_REL), fakeBinary(version));
+		// Tar preserves modes; mark the bin executable in the source so
+		// install.js's chmod is a no-op rather than a load-bearing step.
+		chmodSync(join(root, FAKE_BIN_REL), 0o755);
+
+		// dist-templates/ — the whole reason this rewrite exists. If the
+		// install path can't carry these alongside the bin, downstream
+		// commands like `ts-for-gir create` fail with a confusing
+		// path-not-found. The tests assert the dir survives the round trip.
+		mkdirSync(join(root, "dist-templates", "types-locally"), { recursive: true });
+		writeFileSync(
+			join(root, "dist-templates", "types-locally", "package.json"),
+			JSON.stringify({ name: "tpl-marker", version: "0.0.0" }) + "\n",
+		);
+		writeFileSync(join(root, "dist-templates", "types-locally", "README.md"), "marker\n");
+
+		// Build with `tar -czf` so we exercise the same toolchain install.js
+		// will use to extract — both ends agree on header dialect.
+		const tgzPath = join(stage, "package.tgz");
+		execFileSync("tar", ["-czf", tgzPath, "-C", stage, "package"], { stdio: "pipe" });
+		return readFileSync(tgzPath);
+	} finally {
+		rmSync(stage, { recursive: true, force: true });
+	}
 }
 
 function runGjs({ env, args = [] } = {}) {
@@ -70,11 +129,13 @@ function runGjs({ env, args = [] } = {}) {
 
 describe("install.js E2E", { timeout: 5 * 60 * 1000 }, () => {
 	let server;
-	let apiBase;
+	let registryBase;
+	let tmpRoot;
 	let installDir;
-	let installPath;
-	// Mutable per-test: lets a single `it()` swap in a different release/asset
-	// without having to spin up a new server.
+	let dataDir;
+	let launcherPath;
+	// Mutable per-test: lets a single `it()` swap in a different release
+	// without spinning up a new server.
 	let mockState;
 
 	before(async () => {
@@ -91,50 +152,52 @@ describe("install.js E2E", { timeout: 5 * 60 * 1000 }, () => {
 			throw new Error(`install.js not found at ${INSTALL_JS}`);
 		}
 
-		const tmpRoot = mkdtempSync(join(tmpdir(), "ts-for-gir-install-e2e-"));
+		tmpRoot = mkdtempSync(join(tmpdir(), "ts-for-gir-install-e2e-"));
 		installDir = join(tmpRoot, "bin");
-		installPath = join(installDir, "ts-for-gir");
+		dataDir = join(tmpRoot, "share", "ts-for-gir");
+		launcherPath = join(installDir, "ts-for-gir");
 
 		mockState = {
 			version: "1.0.0-test",
-			binaryContent: fakeBinary("1.0.0-test"),
+			tarball: buildTarball("1.0.0-test"),
 			// Per-test overrides for failure-mode assertions.
-			releasesStatus: 200,
-			assetStatus: 200,
+			packumentStatus: 200,
+			tarballStatus: 200,
 		};
 
 		server = createServer((req, res) => {
 			try {
 				const url = req.url ?? "";
-				if (url.startsWith("/repos/gjsify/ts-for-gir/releases")) {
-					if (mockState.releasesStatus !== 200) {
-						res.writeHead(mockState.releasesStatus).end("mock failure");
+				if (url === `/${ENCODED_PACKAGE}`) {
+					if (mockState.packumentStatus !== 200) {
+						res.writeHead(mockState.packumentStatus).end("mock failure");
 						return;
 					}
 					const port = server.address().port;
-					const body = [
-						{
-							tag_name: `v${mockState.version}`,
-							draft: false,
-							assets: [
-								{
-									name: "ts-for-gir-gjs",
-									browser_download_url: `http://127.0.0.1:${port}/asset/ts-for-gir-gjs`,
+					const body = {
+						name: PACKAGE,
+						"dist-tags": { latest: mockState.version },
+						versions: {
+							[mockState.version]: {
+								name: PACKAGE,
+								version: mockState.version,
+								dist: {
+									tarball: `http://127.0.0.1:${port}/tarball/cli-${mockState.version}.tgz`,
 								},
-							],
+							},
 						},
-					];
+					};
 					res.writeHead(200, { "content-type": "application/json" });
 					res.end(JSON.stringify(body));
 					return;
 				}
-				if (url === "/asset/ts-for-gir-gjs") {
-					if (mockState.assetStatus !== 200) {
-						res.writeHead(mockState.assetStatus).end("mock failure");
+				if (url.startsWith("/tarball/")) {
+					if (mockState.tarballStatus !== 200) {
+						res.writeHead(mockState.tarballStatus).end("mock failure");
 						return;
 					}
 					res.writeHead(200, { "content-type": "application/octet-stream" });
-					res.end(mockState.binaryContent);
+					res.end(mockState.tarball);
 					return;
 				}
 				res.writeHead(404).end("not found");
@@ -143,118 +206,127 @@ describe("install.js E2E", { timeout: 5 * 60 * 1000 }, () => {
 			}
 		});
 		await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-		apiBase = `http://127.0.0.1:${server.address().port}`;
+		registryBase = `http://127.0.0.1:${server.address().port}`;
 	});
 
 	after(() => {
 		if (server) server.close();
-		if (installDir && !process.env.TS_FOR_GIR_E2E_KEEP_TEMP) {
-			rmSync(dirname(installDir), { recursive: true, force: true });
+		if (tmpRoot && !process.env.TS_FOR_GIR_E2E_KEEP_TEMP) {
+			rmSync(tmpRoot, { recursive: true, force: true });
 		}
 	});
 
-	it("fresh install downloads and installs the binary", async () => {
-		// Start from a clean slate: prior tests in the same suite may have
-		// installed a binary into installDir.
-		if (existsSync(installPath)) rmSync(installPath);
+	function envVars() {
+		return {
+			TS_FOR_GIR_INSTALL_REGISTRY: registryBase,
+			TS_FOR_GIR_INSTALL_DIR: installDir,
+			TS_FOR_GIR_INSTALL_DATA_DIR: dataDir,
+		};
+	}
 
-		const result = await runGjs({
-			env: {
-				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
-				TS_FOR_GIR_INSTALL_DIR: installDir,
-			},
-		});
+	it("fresh install fetches the npm tarball, extracts the package tree, writes a launcher", async () => {
+		// Start from a clean slate: prior tests in the same suite may have
+		// installed into the same dirs.
+		if (existsSync(launcherPath)) rmSync(launcherPath);
+		if (existsSync(dataDir)) rmSync(dataDir, { recursive: true });
+
+		const result = await runGjs({ env: envVars() });
 		assert.equal(result.exitCode, 0, `install failed: ${result.stderr}`);
-		assert.match(result.stdout, /Installing ts-for-gir v1\.0\.0-test/);
-		assert.match(result.stdout, /Installed to/);
-		assert.ok(existsSync(installPath), `expected ${installPath} to exist`);
-		// Atomic install path leaves no .tmp dropping behind.
-		assert.ok(!existsSync(`${installPath}.tmp`), "no leftover .tmp file");
-		// Binary content must match what the mock served — proves the asset
-		// URL was actually followed (regression guard against silent-skip
-		// bugs like "Already up to date" firing on a stale cached path).
-		const installed = readFileSync(installPath, "utf8");
-		assert.equal(installed, mockState.binaryContent);
-		// Executable bit on owner — install.js promises 0755 atomic install.
-		const mode = statSync(installPath).mode & 0o777;
-		assert.equal(mode, 0o755, `expected mode 0755 but got 0${mode.toString(8)}`);
+		assert.match(result.stdout, /Installing @ts-for-gir\/cli@1\.0\.0-test/);
+		assert.match(result.stdout, /Installed @ts-for-gir\/cli@1\.0\.0-test/);
+
+		// Package tree under DATA_DIR — proves --strip-components=1 stripped
+		// the `package/` prefix and the whole tarball landed.
+		assert.ok(existsSync(join(dataDir, "package.json")), "package.json present");
+		const installedPkg = JSON.parse(readFileSync(join(dataDir, "package.json"), "utf8"));
+		assert.equal(installedPkg.version, "1.0.0-test");
+
+		assert.ok(
+			existsSync(join(dataDir, FAKE_BIN_REL)),
+			`expected ${FAKE_BIN_REL} under ${dataDir}`,
+		);
+		// Bin is executable (preserved from tar's mode bits).
+		const binMode = statSync(join(dataDir, FAKE_BIN_REL)).mode & 0o777;
+		assert.equal(binMode, 0o755, `expected bin mode 0755, got 0${binMode.toString(8)}`);
+
+		// dist-templates/ survived the round trip — the whole point of this
+		// rewrite. Without these next to the bin, `ts-for-gir create` would
+		// fail with the confusing path-not-found error from rc.13 and earlier.
+		assert.ok(
+			existsSync(join(dataDir, "dist-templates", "types-locally", "package.json")),
+			"dist-templates/ shipped alongside the bin",
+		);
+
+		// Launcher: a tiny POSIX sh script, exec's the absolute bin path.
+		assert.ok(existsSync(launcherPath), `expected launcher at ${launcherPath}`);
+		const launcherMode = statSync(launcherPath).mode & 0o777;
+		assert.equal(launcherMode, 0o755, `expected launcher mode 0755, got 0${launcherMode.toString(8)}`);
+		const launcherText = readFileSync(launcherPath, "utf8");
+		assert.match(launcherText, /^#!\/bin\/sh\n/);
+		assert.match(launcherText, /\bexec /);
+		assert.ok(launcherText.includes(join(dataDir, FAKE_BIN_REL)));
 	});
 
-	it("idempotent re-run reports Already up to date", async () => {
-		const result = await runGjs({
-			env: {
-				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
-				TS_FOR_GIR_INSTALL_DIR: installDir,
-			},
-		});
+	it("the launcher round-trips: invoking it exec's the bin and reports the version", async () => {
+		// Validates the install path actually produces a working CLI:
+		// PATH + launcher + bin chain end-to-end. Regression guard against
+		// a cosmetic-only install (files written, but launcher broken).
+		const stdout = execFileSync(launcherPath, ["--version"], { encoding: "utf8" });
+		assert.equal(stdout.trim(), "1.0.0-test");
+	});
+
+	it("idempotent re-run reports Already up to date and skips the download", async () => {
+		const result = await runGjs({ env: envVars() });
 		assert.equal(result.exitCode, 0, `re-run failed: ${result.stderr}`);
 		assert.match(result.stdout, /Already up to date \(v1\.0\.0-test\)/);
-		// Must not redownload — the "Downloading ..." line is only emitted
-		// when install.js actually fetches the asset.
+		// Must not redownload — "Downloading ..." only fires on actual fetches.
 		assert.doesNotMatch(result.stdout, /Downloading/);
 	});
 
 	it("--force reinstalls the same version", async () => {
-		const result = await runGjs({
-			args: ["--force"],
-			env: {
-				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
-				TS_FOR_GIR_INSTALL_DIR: installDir,
-			},
-		});
+		const result = await runGjs({ args: ["--force"], env: envVars() });
 		assert.equal(result.exitCode, 0, `--force failed: ${result.stderr}`);
 		assert.match(result.stdout, /Reinstalling v1\.0\.0-test \(--force\)/);
 		assert.match(result.stdout, /Downloading/);
 	});
 
-	it("upgrades when the mock advertises a newer version", async () => {
+	it("upgrades when the registry advertises a newer version", async () => {
 		mockState.version = "1.0.1-test";
-		mockState.binaryContent = fakeBinary("1.0.1-test");
+		mockState.tarball = buildTarball("1.0.1-test");
 		try {
-			const result = await runGjs({
-				env: {
-					TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
-					TS_FOR_GIR_INSTALL_DIR: installDir,
-				},
-			});
+			const result = await runGjs({ env: envVars() });
 			assert.equal(result.exitCode, 0, `upgrade failed: ${result.stderr}`);
 			assert.match(result.stdout, /Updating from v1\.0\.0-test to v1\.0\.1-test/);
-			const installed = readFileSync(installPath, "utf8");
-			assert.equal(installed, mockState.binaryContent);
+
+			const installedPkg = JSON.parse(readFileSync(join(dataDir, "package.json"), "utf8"));
+			assert.equal(installedPkg.version, "1.0.1-test");
+
+			const stdout = execFileSync(launcherPath, ["--version"], { encoding: "utf8" });
+			assert.equal(stdout.trim(), "1.0.1-test");
 		} finally {
 			mockState.version = "1.0.0-test";
-			mockState.binaryContent = fakeBinary("1.0.0-test");
+			mockState.tarball = buildTarball("1.0.0-test");
 		}
 	});
 
-	it("exits non-zero when the GitHub API returns a 5xx", async () => {
-		mockState.releasesStatus = 503;
+	it("exits non-zero when the registry returns a 5xx for the packument", async () => {
+		mockState.packumentStatus = 503;
 		try {
-			const result = await runGjs({
-				env: {
-					TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
-					TS_FOR_GIR_INSTALL_DIR: installDir,
-				},
-			});
-			assert.notEqual(result.exitCode, 0, "should fail on 5xx");
+			const result = await runGjs({ env: envVars() });
+			assert.notEqual(result.exitCode, 0, "should fail on 5xx packument");
 			const combined = result.stdout + result.stderr;
-			assert.match(combined, /Failed to fetch release info/);
+			assert.match(combined, /Failed to fetch packument/);
 		} finally {
-			mockState.releasesStatus = 200;
+			mockState.packumentStatus = 200;
 		}
 	});
 
 	it("--help prints usage and exits 0", async () => {
-		const result = await runGjs({
-			args: ["--help"],
-			env: {
-				TS_FOR_GIR_INSTALL_GITHUB_API: apiBase,
-				TS_FOR_GIR_INSTALL_DIR: installDir,
-			},
-		});
+		const result = await runGjs({ args: ["--help"], env: envVars() });
 		assert.equal(result.exitCode, 0, `--help failed: ${result.stderr}`);
 		assert.match(result.stdout, /Usage: gjs -m install\.js/);
 		assert.match(result.stdout, /--force/);
 		assert.match(result.stdout, /--help/);
+		assert.match(result.stdout, /--tag=/);
 	});
 });


### PR DESCRIPTION
## Summary

Replaces the single-asset GitHub-release download with a full `@ts-for-gir/cli` npm tarball install. The `install.js` bootstrapper now produces the same on-disk layout as `npm i -g` and `gjsify install -g` — including `dist-templates/` next to the bin, which was the missing piece behind the user-reported `ts-for-gir create` failure.

## New layout

```
${XDG_DATA_HOME:-~/.local/share}/ts-for-gir/
  package.json
  bin/ts-for-gir-gjs                ← GJS bundle (declared via gjsify.bin)
  dist-templates/                   ← templates next to the bin (the whole point)
  …
~/.local/bin/ts-for-gir             ← POSIX sh launcher → bin/ts-for-gir-gjs
```

## Why move off the GitHub release asset

The previous flow could only carry a single binary file. Anything package-relative (`__dirname/../<asset>`) — `dist-templates/` for `ts-for-gir create`, version-discovery `package.json` reads, gjsify's own `import.meta.url` rewrites — was missing at runtime, producing the user-reported

```
Could not locate templates directory. Looked in:
  /home/<user>/.local/dist-templates
  /home/<user>/dist-templates
  /home/<user>/templates
```

The npm tarball is the same artefact `npm i -g` and `gjsify install -g` use, so a fresh `install.js` run, an `npm i -g`, and a `gjsify install -g` all produce the same on-disk layout.

## Why a launcher, not a symlink

When a GJS bundle is invoked via a `~/.local/bin/<name>` symlink, the kernel passes the symlink path to `gjs -m`, so `import.meta.url` resolves to the symlink dir — and any `<dir>/../<asset>` lookup misses. A `sh` launcher exec's the absolute bin path so the bundle always sees its real install location. (Same rationale as gjsify/gjsify#91's `linkGlobalBins`.)

## Other changes

- `install.js` reads `package.json` to detect the installed version (faster than spawning the bundle, and works on a half-finished install)
- `gjsify.bin` (when declared) is preferred over the npm `bin` field — same semantics as `gjsify install -g`
- New `--tag=<dist-tag>` flag (default `latest`) for tracking the `next` rc channel without checkout-bumps
- Test hooks renamed to match the new flow:
  - `TS_FOR_GIR_INSTALL_REGISTRY` (was `TS_FOR_GIR_INSTALL_GITHUB_API`)
  - `TS_FOR_GIR_INSTALL_DATA_DIR` (new — package tree location)
  - `TS_FOR_GIR_INSTALL_DIR` (unchanged — launcher dir)

## Workflow change

`.github/workflows/release-app.yml` drops the "upload GJS bundle to release" step since nothing reads the asset anymore. The npm tarball is now the single source of truth.

**Heads-up — minor breaking change:** users with a stale local `install.js` from before this PR are pointed at GitHub release assets that future releases won't carry. Re-`curl`ing `install.js` from a recent commit recovers them; production usage typically fetches the script fresh per install anyway.

## Test plan

- [x] New e2e mocks the npm registry (packument + on-the-fly real `.tgz`) and asserts the full chain end-to-end
- [x] `node --test tests/e2e/install/run.mjs` → 7/7 ✓
  - fresh install fetches the tarball, extracts the package tree, writes a launcher
  - **`dist-templates/` ends up next to the bin** (regression guard for the user-reported failure)
  - launcher round-trips: `~/.local/bin/ts-for-gir --version` exec's the bin and prints the version
  - idempotent re-run reports "Already up to date"
  - `--force` reinstalls
  - upgrade detected when registry advertises newer version
  - 5xx packument → non-zero exit
  - `--help` prints usage with `--tag=` flag

## Linked

- Companion to gjsify/gjsify#91 (`gjsify install -g`, merged in v0.3.15)
- Companion to gjsify/ts-for-gir#388 (defensive realpath/missing-package.json patches)
- After all three land: `npm i -g @ts-for-gir/cli`, `gjsify install -g @ts-for-gir/cli`, `gjs -m install.js` all produce the same working install.