### PR TITLE
fix: Output formatting improvements

### DIFF
--- a/packages/generator-typescript/src/generators/signal-generator.ts
+++ b/packages/generator-typescript/src/generators/signal-generator.ts
@@ -84,14 +84,14 @@ export class SignalGenerator {
 
 		parentSignatures.push(...interfaceSignatures);
 
-		let signatureHead: string;
+		let signatureDecl: string;
 		if (parentSignatures.length > 0) {
-			signatureHead = `${indent}interface SignalSignatures extends ${parentSignatures.join(", ")} {`;
+			signatureDecl = `interface SignalSignatures extends ${parentSignatures.join(", ")}`;
 		} else {
 			const isGObjectObject = girClass.name === "Object" && girClass.namespace.namespace === "GObject";
 
 			if (isGObjectObject) {
-				signatureHead = `${indent}interface SignalSignatures {`;
+				signatureDecl = `interface SignalSignatures`;
 			} else {
 				const gobjectNamespace = this.namespace.assertInstalledImport("GObject");
 				const gobjectObjectClass = gobjectNamespace.assertClass("Object");
@@ -101,13 +101,18 @@ export class SignalGenerator {
 					?.print(this.namespace, this.config);
 
 				const fallbackRef = gobjectRef ? `${gobjectRef}.SignalSignatures` : "GObject.Object.SignalSignatures";
-				signatureHead = `${indent}interface SignalSignatures extends ${fallbackRef} {`;
+				signatureDecl = `interface SignalSignatures extends ${fallbackRef}`;
 			}
 		}
-		def.push(signatureHead);
 
 		const allSignals = girClass.getAllSignals();
 
+		if (allSignals.length === 0) {
+			def.push(`${indent}${signatureDecl} {}`);
+			return def;
+		}
+
+		def.push(`${indent}${signatureDecl} {`);
 		allSignals.forEach((signalInfo) => {
 			let cbType: string;
 

--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -281,6 +281,11 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 	}
 	generateDirectAllocationConstructor(node: IntrospectedDirectAllocationConstructor, indentCount = 1): string[] {
 		const indent = generateIndent(indentCount);
+
+		if (node.parameters.length === 0) {
+			return [`${indent}constructor(properties?: Partial<{}>);`];
+		}
+
 		const fieldIndent = generateIndent(indentCount + 1);
 		// `param.asField().asString(this)` already includes a trailing newline
 		// for some flavours of fields; strip leading whitespace per line and
@@ -1214,6 +1219,11 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 			.flatMap((v) => v.asString(this, true))
 			.map((m) => `${memberIndent}${m}`)
 			.join("\n");
+
+		if (constructorPropMembers.length === 0) {
+			def.push(`${indent}${exp}interface ${constructPropInterfaceName}${genericTypes} ${ext} {}`);
+			return def;
+		}
 
 		def.push(`${indent}${exp}interface ${constructPropInterfaceName}${genericTypes} ${ext} {`);
 		def.push(constructorPropMembers);

--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -42,6 +42,7 @@ import {
 	IntrospectedStaticClassFunction,
 	IntrospectedVirtualClassFunction,
 	isInvalid,
+	makeUnion,
 	NativeType,
 	type NSRegistry,
 	type OptionsGeneration,
@@ -512,32 +513,32 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 				case ConflictType.FIELD_NAME_CONFLICT:
 					getterSetterAnnotation = setterAnnotation =
 						"// This accessor conflicts with a field or function name in a parent class or interface.\n";
-					type = new BinaryType(type.unwrap(), AnyType);
+					type = makeUnion(type.unwrap(), AnyType);
 					// A child class cannot have an accessor declared if the parent has a function
 					printAsProperty = true;
 					break;
 				case ConflictType.ACCESSOR_PROPERTY_CONFLICT:
 					getterSetterAnnotation = getterAnnotation =
 						"// This accessor conflicts with a property or field in a parent class or interface.\n";
-					type = new BinaryType(type.unwrap(), AnyType);
+					type = makeUnion(type.unwrap(), AnyType);
 					// A child class cannot have an accessor declared if the parent has a property
 					printAsProperty = true;
 					break;
 				case ConflictType.PROPERTY_ACCESSOR_CONFLICT:
-					type = new BinaryType(type.unwrap(), AnyType);
+					type = makeUnion(type.unwrap(), AnyType);
 					break;
 				case ConflictType.PROPERTY_NAME_CONFLICT:
 					getterSetterAnnotation =
 						setterAnnotation =
 						getterAnnotation =
 							"// This accessor conflicts with another accessor's type in a parent class or interface.\n";
-					type = new BinaryType(type.unwrap(), AnyType);
+					type = makeUnion(type.unwrap(), AnyType);
 					break;
 			}
 
 			if (construct && !(type instanceof BinaryType)) {
 				// For constructor properties we just convert to any.
-				type = new BinaryType(type instanceof TypeConflict ? type.unwrap() : type, AnyType);
+				type = makeUnion(type instanceof TypeConflict ? type.unwrap() : type, AnyType);
 			}
 		}
 
@@ -603,7 +604,7 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 			} else if (type.conflictType === ConflictType.FUNCTION_NAME_CONFLICT) {
 				commentOut = "\n// This field conflicts with a function in a parent class or interface.\n";
 
-				type = new BinaryType(type.unwrap(), AnyType);
+				type = makeUnion(type.unwrap(), AnyType);
 			} else {
 				type = type.unwrap();
 			}

--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -418,7 +418,7 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 
 		clazz.superType = GLibError.getType();
 
-		// GJS GError constructor expects one object: { message: string, code: number }
+		// GJS GError constructor expects one object: { message: string; code: number }
 		// The domain is automatically derived from the error enum type.
 		// See: gjs/gi/gerror.cpp ErrorInstance::constructor_impl
 		clazz.mainConstructor = new IntrospectedConstructor({
@@ -427,7 +427,7 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 			parameters: [
 				new IntrospectedFunctionParameter({
 					name: "options",
-					type: NativeType.of("{ message: string, code: number }"),
+					type: NativeType.of("{ message: string; code: number }"),
 					direction: GirDirection.In,
 				}),
 			],

--- a/packages/lib/src/gir.ts
+++ b/packages/lib/src/gir.ts
@@ -348,9 +348,9 @@ export class NativeType extends TypeExpression {
 export class OrType extends TypeExpression {
 	readonly types: ReadonlyArray<TypeExpression>;
 
-	constructor(type: TypeExpression, ...types: TypeExpression[]) {
+	constructor(...types: TypeExpression[]) {
 		super();
-		this.types = [type, ...types];
+		this.types = [...types];
 	}
 
 	rewrap(type: TypeExpression): TypeExpression {
@@ -362,17 +362,15 @@ export class OrType extends TypeExpression {
 	}
 
 	resolve(namespace: IntrospectedNamespace, options: OptionsGeneration): TypeExpression {
-		const [type, ...types] = this.types;
-
-		return new OrType(type.resolve(namespace, options), ...types.map((t) => t.resolve(namespace, options)));
+		return makeUnion(...this.types.map((t) => t.resolve(namespace, options)));
 	}
 
 	print(namespace: IntrospectedNamespace, options: OptionsGeneration): string {
-		return `(${this.types.map((t) => t.print(namespace, options)).join(" | ")})`;
+		return `${this.types.map((t) => t.print(namespace, options)).join(" | ")}`;
 	}
 
 	rootPrint(namespace: IntrospectedNamespace, options: OptionsGeneration): string {
-		return `${this.types.map((t) => t.print(namespace, options)).join(" | ")}`;
+		return this.print(namespace, options);
 	}
 
 	equals(type: TypeExpression) {
@@ -382,6 +380,36 @@ export class OrType extends TypeExpression {
 			return false;
 		}
 	}
+}
+
+export function makeUnion(...inputTypes: TypeExpression[]) {
+	const types: Set<TypeExpression> = new Set();
+	for (const type of inputTypes) {
+		if (type instanceof BinaryType) {
+			types.add(type.a);
+			types.add(type.b);
+		} else if (type instanceof OrType && !(type instanceof TupleType)) {
+			for (const t of type.types) {
+				types.add(t);
+			}
+		} else {
+			types.add(type);
+		}
+	}
+	if (types.size === 1) {
+		return [...types][0];
+	}
+	if (types.size === 2) {
+		const typesArray = [...types];
+		if (typesArray[0] === NullType) {
+			return new NullableType(typesArray[1]);
+		}
+		if (typesArray[1] === NullType) {
+			return new NullableType(typesArray[0]);
+		}
+		return new BinaryType(...typesArray);
+	}
+	return new OrType(...types);
 }
 
 export class TupleType extends OrType {
@@ -633,9 +661,10 @@ export class NullableType extends BinaryType {
 }
 
 export function makeNullable(type: TypeExpression) {
+	if (type instanceof NullableType) return type;
 	if (type === RawPointerType) return NullType;
 	if (type === AnyType) return AnyType;
-	return new NullableType(type);
+	return makeUnion(type, NullType);
 }
 
 export class PromiseType extends TypeExpression {
@@ -834,6 +863,8 @@ export class ArrayType extends TypeExpression {
 			typeSuffix = "".padStart(2 * depth, "[]");
 		}
 
+		if (this.type instanceof OrType && !(this.type instanceof TupleType))
+			return `(${this.type.print(namespace, options)})${typeSuffix}`;
 		return `${this.type.print(namespace, options)}${typeSuffix}`;
 	}
 

--- a/packages/lib/src/gir/namespace.ts
+++ b/packages/lib/src/gir/namespace.ts
@@ -1,4 +1,4 @@
-import { BinaryType, BooleanType, ClosureType, PromiseType, TupleType, TypeIdentifier, VoidType } from "../gir.ts";
+import { BooleanType, ClosureType, makeUnion, PromiseType, TupleType, TypeIdentifier, VoidType } from "../gir.ts";
 
 import type { GirModule } from "../gir-module.ts";
 import type { IntrospectedAlias } from "./alias.ts";
@@ -65,7 +65,7 @@ export function promisifyNamespaceFunctions(namespace: GirModule) {
 						parameters: sync_parameters,
 					}),
 					node.copy({
-						return_type: new BinaryType(async_return, node.return()),
+						return_type: makeUnion(async_return, node.return()),
 					}),
 				]);
 			}

--- a/packages/lib/src/gir/promisify.ts
+++ b/packages/lib/src/gir/promisify.ts
@@ -1,4 +1,4 @@
-import { BinaryType, BooleanType, ClosureType, PromiseType, TupleType, TypeIdentifier, VoidType } from "../gir.ts";
+import { BooleanType, ClosureType, makeUnion, PromiseType, TupleType, TypeIdentifier, VoidType } from "../gir.ts";
 import { IntrospectedConstructor } from "./constructor.ts";
 import type { IntrospectedClassFunction } from "./introspected-classes.ts";
 import {
@@ -42,7 +42,7 @@ function generatePromisifyOverloadedSignatures(
 	// Union overload (with optional callback)
 	const unionOverload = node.copy({
 		parameters: [...async_parameters, sync_parameters[sync_parameters.length - 1].copy({ isOptional: true })],
-		returnType: new BinaryType(async_return, VoidType),
+		returnType: makeUnion(async_return, VoidType),
 	});
 
 	return [promiseOverload, callbackOverload, unionOverload];

--- a/packages/lib/src/injections/shell.ts
+++ b/packages/lib/src/injections/shell.ts
@@ -1,6 +1,6 @@
 import type { IntrospectedNamespace } from "../gir/namespace.ts";
 import type { NSRegistry } from "../gir/registry.ts";
-import { NullableType, OrType, TypeIdentifier } from "../gir.ts";
+import { makeUnion, NullType, TypeIdentifier } from "../gir.ts";
 
 const shellTemplate = (version: string) => ({
 	namespace: "Shell",
@@ -24,8 +24,10 @@ const shellTemplate = (version: string) => ({
 		if (addGlslSnippet) {
 			// Create a new parameter with updated type using copy()
 			const updatedParameter = addGlslSnippet.parameters[0].copy({
-				type: new NullableType(
-					new OrType(new TypeIdentifier("SnippetHook", "Shell"), new TypeIdentifier("SnippetHook", "Cogl")),
+				type: makeUnion(
+					new TypeIdentifier("SnippetHook", "Shell"),
+					new TypeIdentifier("SnippetHook", "Cogl"),
+					NullType,
 				),
 			});
 

--- a/packages/lib/src/utils/types.ts
+++ b/packages/lib/src/utils/types.ts
@@ -7,18 +7,17 @@ import {
 	BigintOrNumberType,
 	BinaryType,
 	BooleanType,
+	makeUnion,
 	NativeType,
 	NeverType,
 	NullableType,
 	NullType,
 	NumberType,
 	ObjectType,
-	OrType,
 	PromiseType,
 	RawPointerType,
 	StringType,
 	ThisType,
-	TupleType,
 	type TypeExpression,
 	TypeIdentifier,
 	Uint8ArrayType,
@@ -231,17 +230,17 @@ export function resolveDirectedType(type: TypeExpression, direction: GirDirectio
 			type.type.equals(Uint8ArrayType) &&
 			type.arrayDepth === 0
 		) {
-			return new BinaryType(type, StringType);
+			return makeUnion(type, StringType);
 		} else {
 			// Rewrap arrays if they have directional types
 			return type.rewrap(resolveDirectedType(type.type, direction) ?? type.type);
 		}
 	} else if (type instanceof TypeIdentifier) {
 		if ((direction === GirDirection.In || direction === GirDirection.Inout) && type.is("GLib", "Bytes")) {
-			return new BinaryType(type, Uint8ArrayType);
+			return makeUnion(type, Uint8ArrayType);
 		} else if (type.is("GObject", "Value")) {
 			if (direction === GirDirection.In || direction === GirDirection.Inout) {
-				return new BinaryType(type, AnyType);
+				return makeUnion(type, AnyType);
 			} else {
 				// GJS converts GObject.Value out parameters to their unboxed type, which we don't know,
 				// so type as `unknown`
@@ -273,12 +272,7 @@ export function resolveDirectedType(type: TypeExpression, direction: GirDirectio
 		// NullableType is skipped to preserve its subclass behaviour.
 		const a = resolveDirectedType(type.a, direction) ?? type.a;
 		const b = resolveDirectedType(type.b, direction) ?? type.b;
-		if (a !== type.a || b !== type.b) return new BinaryType(a, b);
-	} else if (type instanceof OrType && !(type instanceof BinaryType || type instanceof TupleType)) {
-		// flatten "bigint | number" out of another OR-type
-		const types = type.types.map((t) => resolveDirectedType(t, direction) ?? t);
-		if (types.length === 1) return types[0];
-		return new OrType(types[0], ...types.slice(1));
+		if (a !== type.a || b !== type.b) return makeUnion(a, b);
 	}
 
 	return null;


### PR DESCRIPTION
## Description

Three commits to make the output formatting of the .d.ts files nicer.

- Format record passed to GError constructor with `;`
- Avoid empty bodies on separate lines (output `{}` instead of `{\n\n}`
- Avoid extra parentheses in union types

I didn't actually fix the single vs double quotes that I mentioned in the issue, because I realized they are consistent after all; just consistently the opposite of what prettier rendered. So I left that as-is.

## Related Issue

Fixes #379

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation

Validated by inspection of GLib-2.0.d.ts, GObject-2.0.d.ts, Gio-2.0.d.ts and running the test suite.

## Checklist
<!-- Please check all that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly 