### PR TITLE
ci: bootstrap @gjsify/cli via install.mjs (Phase F, fully Node-free)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
-# This workflow installs Node deps via gjsify install (Node-free GJS bundle),
-# then builds + tests. ts-for-gir's own generated TypeScript types are checked
-# in build-validate against the committed types-dev submodule.
+# This workflow bootstraps @gjsify/cli via the Node-free install.mjs flow
+# (Phase F), then builds + tests entirely under stock GJS. ts-for-gir's
+# generated TypeScript types are validated in build-validate against the
+# committed types-dev submodule.
+#
+# Runner: ubuntu-latest with a Fedora 43 container. Fedora 43 ships
+# gjs 1.86 (SM 140), which is the minimum install.mjs accepts. The
+# default ubuntu-latest gjs 1.80 is too old.
 
 name: CI
 
@@ -36,50 +41,64 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    container:
+      image: fedora:43
     steps:
+      - name: Install container prerequisites
+        run: dnf install -y git tar xz findutils curl gjs
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Checkout types-dev submodule
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init types-dev
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-      - name: Install @gjsify/cli globally (bootstrap)
-        run: npm install -g @gjsify/cli@^0.4.10
+      - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
+        run: |
+          curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs -o /tmp/g.mjs
+          gjs -m /tmp/g.mjs
+          rm /tmp/g.mjs
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: gjsify --version
       - run: gjsify install --immutable
       - run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run check
 
   test-units:
     runs-on: ubuntu-latest
+    container:
+      image: fedora:43
     steps:
+      - name: Install container prerequisites
+        run: dnf install -y git tar xz findutils curl gjs
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: false
       - name: Checkout types-dev submodule
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init types-dev
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-      - name: Install @gjsify/cli globally (bootstrap)
-        run: npm install -g @gjsify/cli@^0.4.10
+      - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
+        run: |
+          curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs -o /tmp/g.mjs
+          gjs -m /tmp/g.mjs
+          rm /tmp/g.mjs
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: gjsify --version
       - run: gjsify install --immutable
       - run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run test:tests
 
   build-validate:
     runs-on: ubuntu-latest
+    container:
+      image: fedora:43
     needs: [check, test-units]
     steps:
+      - name: Install container prerequisites
+        run: dnf install -y git tar xz findutils curl gjs
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Detect changed paths
@@ -95,29 +114,35 @@ jobs:
             examples:
               - 'examples/**'
               - 'packages/**'
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-      - name: Cache apt packages
-        uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: apt-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
-          restore-keys: apt-${{ runner.os }}-
-      - name: Update package repository
-        run: sudo apt-get update
-      - name: Install system dependencies
+      - name: Install GNOME development libraries
+        run: >
+          dnf install -y
+          blueprint-compiler
+          libappindicator-gtk3-devel
+          libgda-devel
+          gobject-introspection-devel
+          gtk3-devel
+          gtk4-devel
+          gtksourceview3-devel
+          libnotify-devel
+          libsoup-devel
+          libsoup3-devel
+          webkit2gtk4.1-devel
+          libadwaita-devel
+          mutter-devel
+          gcr-devel
+          gnome-desktop4-devel
+          gnome-shell
+          gcc
+          pkgconf
+          cairo-devel
+          libdex-devel
+      - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
         run: |
-          sudo apt-get --yes install gjs blueprint-compiler libappindicator3-dev \
-            libgda-5.0-dev libgirepository1.0-dev libgtk-3-dev libgtk-4-dev \
-            libgtksourceview-3.0-dev libnotify-dev libsoup2.4-dev libsoup-3.0-dev \
-            libwebkit2gtk-4.1-dev libadwaita-1-dev gnome-shell-common \
-            libmutter-14-dev libgcr-3-dev libgnome-desktop-4-dev build-essential \
-            gobject-introspection libgirepository1.0-dev libcairo2-dev libdex-dev
-      - name: Install @gjsify/cli globally (bootstrap)
-        run: npm install -g @gjsify/cli@^0.4.10
-      - run: node --version
+          curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs -o /tmp/g.mjs
+          gjs -m /tmp/g.mjs
+          rm /tmp/g.mjs
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: gjs --version
       - run: gjsify --version
       - run: gjsify install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       image: fedora:43
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs libsoup3
+        run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -71,7 +71,7 @@ jobs:
       image: fedora:43
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs libsoup3
+        run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -98,7 +98,7 @@ jobs:
     needs: [check, test-units]
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs libsoup3
+        run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
           submodules: false
       - name: Checkout types-dev submodule
         run: |
+          git config --global --add safe.directory "*"
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init types-dev
       - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
@@ -77,6 +78,7 @@ jobs:
           submodules: false
       - name: Checkout types-dev submodule
         run: |
+          git config --global --add safe.directory "*"
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           git submodule update --init types-dev
       - name: Bootstrap @gjsify/cli via install.mjs (Node-free)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       image: fedora:43
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs
+        run: dnf install -y git tar xz findutils curl gjs libsoup3
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -71,7 +71,7 @@ jobs:
       image: fedora:43
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs
+        run: dnf install -y git tar xz findutils curl gjs libsoup3
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -98,7 +98,7 @@ jobs:
     needs: [check, test-units]
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs
+        run: dnf install -y git tar xz findutils curl gjs libsoup3
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs
+      run: dnf install -y git tar xz findutils curl gjs libsoup3
 
     - name: Checkout repository
       uses: actions/checkout@v6

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1,10 +1,14 @@
-# Workflow to automatically publish app packages to npm on new releases
+# Workflow to automatically publish app packages to npm on new releases.
+#
+# Phase F: bootstraps @gjsify/cli via the Node-free install.mjs flow under
+# stock GJS (Fedora 43 container), then uses `gjsify publish` (Phase E)
+# for the actual npm push. Auth is handled by writing a minimal ~/.npmrc
+# directly rather than going through actions/setup-node.
 name: Release App
 
 on:
   release:
     types: [published]
-  # Allow manual triggering for testing
   workflow_dispatch:
     inputs:
       release_tag:
@@ -16,24 +20,37 @@ jobs:
   publish-app:
     name: Publish App to NPM
     runs-on: ubuntu-latest
+    container:
+      image: fedora:43
     permissions:
       contents: write
       id-token: write
 
     steps:
+    - name: Install container prerequisites
+      run: dnf install -y git tar xz findutils curl gjs
+
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
-    # This also setups a .npmrc file to publish to npm
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '24.x'
-        registry-url: 'https://registry.npmjs.org'
-        always-auth: true
+    - name: Setup npm auth
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      run: |
+        cat > $HOME/.npmrc <<NPMRC
+        //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
+        registry=https://registry.npmjs.org/
+        NPMRC
+        chmod 600 $HOME/.npmrc
 
-    - name: Install @gjsify/cli globally (bootstrap)
-      run: npm install -g @gjsify/cli@^0.4.10
+    - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
+      run: |
+        curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs -o /tmp/g.mjs
+        gjs -m /tmp/g.mjs
+        rm /tmp/g.mjs
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - run: gjsify --version
 
     - name: Install dependencies (full workspace)
       run: gjsify install --immutable
@@ -50,12 +67,11 @@ jobs:
 
     # The GJS bundle ships inside the npm tarball under bin/ts-for-gir-gjs
     # (declared via `gjsify.bin` in @ts-for-gir/cli's package.json). Both
-    # `npm i -g`, `gjsify install -g`, and the GJS-native install.js
-    # bootstrapper resolve it from there.
+    # `npm i -g`, `gjsify install -g`, and the install.mjs bootstrapper
+    # resolve it from there.
 
     - name: Publish app packages to npm
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         WS_PATH: ${{ github.workspace }}
       run: PATH="$WS_PATH/node_modules/.bin:$PATH" gjsify run publish:app
 

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs libsoup3
+      run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
 
     - name: Checkout repository
       uses: actions/checkout@v6

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,10 +1,13 @@
-# Workflow to automatically update docs submodule on new releases
+# Workflow to automatically update docs submodule on new releases.
+#
+# Phase F: bootstraps @gjsify/cli via the Node-free install.mjs flow under
+# stock GJS (Fedora 43 container). No npm auth needed — this workflow
+# commits to a Git submodule, not the npm registry.
 name: Release Docs
 
 on:
   release:
     types: [published]
-  # Allow manual triggering for testing
   workflow_dispatch:
     inputs:
       release_tag:
@@ -15,42 +18,44 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    container:
+      image: fedora:43
     permissions:
-      actions: read    # Allow reading workflow info
+      actions: read
 
     steps:
+    - name: Install container prerequisites
+      run: dnf install -y git tar xz findutils curl gjs
+
     - name: Checkout repository with submodules
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
-        # Use a personal access token to allow pushing to submodule
         token: ${{ secrets.PAT_TOKEN }}
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '24.x'
-        registry-url: 'https://registry.npmjs.org'
+    - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
+      run: |
+        curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs -o /tmp/g.mjs
+        gjs -m /tmp/g.mjs
+        rm /tmp/g.mjs
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-    - name: Install @gjsify/cli globally (bootstrap)
-      run: npm install -g @gjsify/cli@^0.4.10
+    - run: gjsify --version
 
     - name: Install dependencies
       run: gjsify install
 
     - name: Prepare docs submodule
+      env:
+        PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       run: |
         cd docs
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        # Configure remote URL with token for authentication
         git remote set-url origin "https://x-access-token:${PAT_TOKEN}@github.com/gjsify/docs.git"
-        # Checkout main branch to ensure we're up to date
         git fetch origin
         git checkout main
         git pull origin main
-      env:
-        PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
     - name: Generate JSON files
       env:
@@ -76,28 +81,27 @@ jobs:
 
     - name: Commit and push docs changes
       if: steps.check-changes.outputs.changes == 'true'
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
         cd docs
         git add .
-
         git commit -m "chore: update docs for release ${RELEASE_TAG}
 
         Automated commit from ts-for-gir release workflow.
         Generated HTML documentation for release: ${RELEASE_TAG}
 
         Source: ${GITHUB_REPOSITORY}@${RELEASE_TAG}"
-
-        # Push to the docs repository
         git push origin main
-      env:
-        RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
 
     - name: Summary
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
+        CHANGES: ${{ steps.check-changes.outputs.changes }}
       run: |
-        if [ "${{ steps.check-changes.outputs.changes }}" == "true" ]; then
+        if [ "$CHANGES" = "true" ]; then
           echo "Docs successfully updated and committed for release ${RELEASE_TAG}"
         else
           echo "No changes detected in generated docs"
         fi
-      env:
-        RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs
+      run: dnf install -y git tar xz findutils curl gjs libsoup3
 
     - name: Checkout repository with submodules
       uses: actions/checkout@v6

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs libsoup3
+      run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
 
     - name: Checkout repository with submodules
       uses: actions/checkout@v6

--- a/.github/workflows/release-types.yml
+++ b/.github/workflows/release-types.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs
+      run: dnf install -y git tar xz findutils curl gjs libsoup3
 
     - name: Checkout repository with submodules
       uses: actions/checkout@v6

--- a/.github/workflows/release-types.yml
+++ b/.github/workflows/release-types.yml
@@ -1,4 +1,8 @@
-# Workflow to automatically update types submodule on new releases
+# Workflow to automatically update types submodule on new releases.
+#
+# Phase F: bootstraps @gjsify/cli via the Node-free install.mjs flow under
+# stock GJS (Fedora 43 container). No npm auth needed — this workflow
+# commits to a Git submodule, not the npm registry.
 name: Release Types
 
 on:
@@ -14,24 +18,29 @@ on:
 jobs:
   update-types:
     runs-on: ubuntu-latest
+    container:
+      image: fedora:43
     permissions:
       actions: read
 
     steps:
+    - name: Install container prerequisites
+      run: dnf install -y git tar xz findutils curl gjs
+
     - name: Checkout repository with submodules
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
         token: ${{ secrets.PAT_TOKEN }}
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '24.x'
-        registry-url: 'https://registry.npmjs.org'
+    - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
+      run: |
+        curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs -o /tmp/g.mjs
+        gjs -m /tmp/g.mjs
+        rm /tmp/g.mjs
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-    - name: Install @gjsify/cli globally (bootstrap)
-      run: npm install -g @gjsify/cli@^0.4.10
+    - run: gjsify --version
 
     - name: Install dependencies
       run: gjsify install

--- a/.github/workflows/release-types.yml
+++ b/.github/workflows/release-types.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs libsoup3
+      run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
 
     - name: Checkout repository with submodules
       uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Switches all four CI workflows from `npm install -g @gjsify/cli@^0.4.10` to the Node-free `install.mjs` bootstrap that ships with gjsify v0.4.10+. End state: ts-for-gir CI no longer touches `npm` at any point — every gjsify invocation runs as a GJS bundle via `gjs -m`.

## Runner change

`ubuntu-latest` → `ubuntu-latest` with a `fedora:43` container.

Required because install.mjs validates `gjs >= 1.86` and ubuntu-latest ships gjs 1.80. Fedora 43 ships gjs 1.86 / SM 140 — the gjsify supported baseline. This mirrors the host setup used by the gjsify monorepo's own `main.yml`.

## Per-workflow notes

- **`ci.yml`** — GTK/GNOME -devel packages ported from apt to dnf for `build-validate` (gtk3/4-devel, libsoup3-devel, webkit2gtk4.1-devel, libadwaita-devel, mutter-devel, gnome-desktop4-devel, etc.).
- **`release-app.yml`** — `actions/setup-node` + auth-token .npmrc replaced with a tiny inline `~/.npmrc` writer. Publish still flows through `gjsify publish` (Phase E) which honors `NPM_CONFIG_USERCONFIG` / `~/.npmrc`.
- **`release-docs.yml` + `release-types.yml`** — `setup-node` dropped entirely. These workflows commit to a Git submodule, not the npm registry, so no auth setup is needed beyond `PAT_TOKEN` for the submodule push.

## Test plan

- [ ] `check` job green
- [ ] `test-units` job green
- [ ] `build-validate` job green (with GNOME -devel package set under dnf)
- [ ] CodeQL `Analyze` job green
- [ ] post-merge: next release exercises `release-app.yml` end-to-end with the new bootstrap + auth path

## Risk

The GTK/GNOME -devel package mapping (apt → dnf) is the highest-risk part. If a dnf package name is wrong or unavailable on Fedora 43, build-validate's `build:types` / `build:examples` will fail. The mapping was checked against the gjsify monorepo's existing `main.yml` Fedora deps where possible.