### PR TITLE
ci(fedora): set safe.directory globally in container prereqs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,11 @@ jobs:
       image: fedora:43
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+        run: |
+
+          dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+
+          git config --global --add safe.directory "*"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -71,7 +75,11 @@ jobs:
       image: fedora:43
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+        run: |
+
+          dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+
+          git config --global --add safe.directory "*"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -98,7 +106,11 @@ jobs:
     needs: [check, test-units]
     steps:
       - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+        run: |
+
+          dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+
+          git config --global --add safe.directory "*"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -28,7 +28,11 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+      run: |
+
+        dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+
+        git config --global --add safe.directory "*"
 
     - name: Checkout repository
       uses: actions/checkout@v6

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -25,7 +25,11 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+      run: |
+
+        dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+
+        git config --global --add safe.directory "*"
 
     - name: Checkout repository with submodules
       uses: actions/checkout@v6

--- a/.github/workflows/release-types.yml
+++ b/.github/workflows/release-types.yml
@@ -25,7 +25,11 @@ jobs:
 
     steps:
     - name: Install container prerequisites
-      run: dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+      run: |
+
+        dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+
+        git config --global --add safe.directory "*"
 
     - name: Checkout repository with submodules
       uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

After the Phase F install.mjs CI migration ([#395](https://github.com/gjsify/ts-for-gir/pull/395)) landed, the first push-on-main run for \`build-validate\` failed with:

\`\`\`
fatal: detected dubious ownership in repository at '/__w/ts-for-gir/ts-for-gir'
\`\`\`

The fedora:43 container runs git as root, but the checkout directory is owned by a non-root uid (GitHub Actions runner uid). \`actions/checkout\` itself handles this transparently; \`dorny/paths-filter\` (which build-validate uses to decide what to rebuild) calls \`git\` directly and trips the safeguard.

## Fix

Move the existing \`safe.directory\` workaround out of the per-step \"Checkout types-dev submodule\" block (where #395 originally added it) and into the shared \"Install container prerequisites\" step. Covers every subsequent git invocation in any of the four workflows.

## Test plan

- [ ] CI green (check + test-units + build-validate)
- [ ] follow-up: next release exercises release-*.yml workflows end-to-end