### PR TITLE
docs: replace yarn refs with gjsify + add types-gjsify template

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn format
+gjsify run format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,17 +24,17 @@ Core packages: `cli` | `parser(@gi.ts)` | `lib` | `reporter` | `generator-base` 
 ## Commands
 
 ```
-yarn start                 # Run CLI (no build)
-yarn build:{types,examples}
-yarn copy:girs             # Copy system GIR files
-yarn test                  # Full suite
-yarn test:tests            # Quick local
-yarn check                 # Full type check (SLOW!)
-yarn check:{app,lint}      # Fast check / lint only
-yarn format
-yarn ts-for-gir-dev generate Gtk-4.0 [--reporter --verbose]
-yarn ts-for-gir-dev analyze -f ./report.json [--severity critical --category type_resolution --namespace Gtk --format table]
-yarn ts-for-gir-dev list
+gjsify run start                 # Run CLI (no build)
+gjsify run build:{types,examples}
+gjsify run copy:girs             # Copy system GIR files
+gjsify run test                  # Full suite
+gjsify run test:tests            # Quick local
+gjsify run check                 # Full type check (SLOW!)
+gjsify run check:{app,lint}      # Fast check / lint only
+gjsify format                    # Biome via @gjsify/cli wrapper
+gjsify run ts-for-gir-dev generate Gtk-4.0 [--reporter --verbose]
+gjsify run ts-for-gir-dev analyze -f ./report.json [--severity critical --category type_resolution --namespace Gtk --format table]
+gjsify run ts-for-gir-dev list
 ```
 
 ## Generation Flow
@@ -69,14 +69,14 @@ Custom `--outdir=./test-types-*`: fresh generation for dev/testing
 
 When modifying generators, templates, injections, or lib code that affects generated output:
 
-1. `yarn build:types` — regenerates all types into `/types-dev/`
+1. `gjsify run build:types` — regenerates all types into `/types-dev/`
 2. `cd types-dev && git diff` — inspect generated changes, verify correctness
-3. `yarn build:examples` — rebuild examples (they depend on `/types-dev/`)
-4. `yarn check` — full type check including examples and generated types
+3. `gjsify run build:examples` — rebuild examples (they depend on `/types-dev/`)
+4. `gjsify run check` — full type check including examples and generated types
 
-`yarn build` chains all steps: `build:app → build:types → build:examples → build:json → build:doc`
+`gjsify run build` chains all steps: `build:app → build:types → build:examples → build:json → build:doc`
 
-**Important:** Examples import from `@girs/*` packages which resolve to `/types-dev/`. Generator changes will NOT be reflected in examples or `yarn check` until `yarn build:types` has been run.
+**Important:** Examples import from `@girs/*` packages which resolve to `/types-dev/`. Generator changes will NOT be reflected in examples or `gjsify run check` until `gjsify run build:types` has been run.
 
 ### GIR → TS Mapping
 
@@ -87,7 +87,7 @@ Parameter `direction` affects signatures. `nullable` → optional (`?`). Array s
 ## GIR Sources
 
 `/girs/` — local copies | `/vala-girs/` — submodule | System: `/usr/share/gir-1.0/`
-Add new: install pkg → `yarn copy:girs` → `yarn ts-for-gir-dev generate ModuleName-Version`
+Add new: install pkg → `gjsify run copy:girs` → `gjsify run ts-for-gir-dev generate ModuleName-Version`
 
 ## GIR XML Reference (`**/*.gir`)
 
@@ -113,7 +113,7 @@ Quality: generic parser (no hardcoded tuples) | concrete overloads first+last, g
 
 Files: template=`packages/templates/templates/glib-2.0.d.ts` | upstream=`gjs/installed-tests/js/testGLib.js` | example=`examples/glib-2-variant/main.ts` | tests=`tests/language-server-validation/src/gvariant-validation.test.ts`
 
-Acceptance: `yarn workspace @ts-for-gir-test/language-server-validation run test` + `yarn workspace @ts-for-gir-example/glib-2-variant run check` pass deterministically
+Acceptance: `gjsify workspace @ts-for-gir-test/language-server-validation run test` + `gjsify workspace @ts-for-gir-example/glib-2-variant run check` pass deterministically
 
 ## TypeScript (`**/*.ts`)
 
@@ -155,13 +155,13 @@ When changing tests, add: `// Rationale: <reason referencing spec>`
 Format: `<type>[scope]: <description>` (feat|fix|docs|refactor|test|chore) | imperative mood | <50 char subject
 Atomic commits, working code only. Match existing patterns via `git log --oneline -10`.
 
-Pre-commit validation: `yarn check:app` + `yarn test:tests` + `yarn format` (regular) | `yarn check` (major changes, slow)
+Pre-commit validation: `gjsify run check:app` + `gjsify run test:tests` + `gjsify format` (regular) | `gjsify run check` (major changes, slow)
 
 ## Fixing Generated Type Errors
 
 Req: error message, affected package(s), context, usage pattern
-Workflow: generate with `--reporter` → `yarn ts-for-gir-dev analyze` → examine `cd types && git diff` → review commits in `packages/{generator-typescript,parser,lib,templates}/`
-Validate: baseline report → fix → `yarn test:types` → `yarn workspace @girs/[pkg] run test` → `yarn check:types`
+Workflow: generate with `--reporter` → `gjsify run ts-for-gir-dev analyze` → examine `cd types && git diff` → review commits in `packages/{generator-typescript,parser,lib,templates}/`
+Validate: baseline report → fix → `gjsify run test:types` → `gjsify workspace @girs/[pkg] run test` → `gjsify run check:types`
 
 ## GJS Examples (`examples/**/*`)
 
@@ -175,7 +175,7 @@ All examples built+validated in CI; create/adapt examples when type issues are f
 
 Structure: `packages/[name]/{src/index.ts, package.json, tsconfig.json(opt)}`
 Naming: `@ts-for-gir/[name]` | `@gi.ts/[name]` | `@ts-for-gir-example/[name]` | `@ts-for-gir-test/[name]`
-Rules: no build (export TS directly) | main/module/exports → `src/index.ts` | `workspace:^` for internal deps | `"type": "module"` req | formatting at root via `yarn format`
+Rules: no build (export TS directly) | main/module/exports → `src/index.ts` | `workspace:^` for internal deps | `"type": "module"` req | formatting at root via `gjsify format`
 
 ## GJS Runtime Analysis
 

--- a/README.md
+++ b/README.md
@@ -16,153 +16,111 @@
   <img src=".github/feeling.gif" />
 </p>
 
-`ts-for-gir` is a robust [TypeScript](https://www.typescriptlang.org/) type definitions generator that improves the development experience of [GJS](https://gitlab.gnome.org/GNOME/gjs/) projects. It has been completely rewritten over time to provide a more complete and accurate TypeScript representation of the [GObject introspection](https://gi.readthedocs.io/en/latest/) interfaces. With `ts-for-gir`, developers can now benefit from TypeScript's strong typing and improved code navigation, making it easier to build robust and powerful applications with GJS.
+`ts-for-gir` generates accurate TypeScript definitions from [GObject Introspection](https://gi.readthedocs.io/en/latest/) for [GJS](https://gitlab.gnome.org/GNOME/gjs/) projects — strong typing, IDE jump-to-definition, autocompletion across the whole GNOME stack.
 
-Browse the full **[TypeScript API Documentation](https://gjsify.github.io/docs)** for GLib, GTK, GStreamer, and many other GNOME libraries.
+Browse the full **[TypeScript API Documentation](https://gjsify.github.io/docs)** for GLib, GTK, GStreamer, and more.
 
-## Getting Started
-
-### Install (GJS — no Node.js required) <sub>experimental</sub>
-
-> The GJS build is **experimental** and made possible by [GJSify](https://gjsify.github.io/gjsify/), which provides Node.js + Web APIs on top of GJS.
-
-With GJS installed, run the installer:
+## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gjsify/ts-for-gir/main/install.js -o /tmp/ts-for-gir-install.js
-gjs -m /tmp/ts-for-gir-install.js && rm /tmp/ts-for-gir-install.js
+gjsify dlx @ts-for-gir/cli create my-app   # no install, no Node.js
+# or
+npx @ts-for-gir/cli create my-app          # via npm
 ```
 
-This installs `ts-for-gir` to `~/.local/bin/`. Update anytime with `ts-for-gir self-update`.
+Pick a template interactively, or pass `--template <id>`:
 
-### Install (Node.js / npx)
-
-Install the latest LTS version of Node.js — we recommend using [NVM](https://github.com/nvm-sh/nvm). The fastest path to a working GJS + TypeScript project:
+| Template | Best for |
+|---|---|
+| **`types-gjsify`** | Node-free GJS app — all dev scripts (install, build, run, format) routed through [gjsify](https://gjsify.github.io/gjsify/) |
+| **`types-npm`** | Single-package, types from [`@girs/*`](https://github.com/gjsify/types) NPM, esbuild + node |
+| **`types-locally`** | Generate types into `./@types/` (no `@girs/*` dep) |
+| **`types-workspace`** | npm workspace with `@girs/*` as locally-generated workspace packages |
 
 ```bash
-npx @ts-for-gir/cli create my-app
+cd my-app && npm start    # or `gjsify run start` for types-gjsify
 ```
 
-That scaffolds a ready-to-run starter with `esbuild`, `tsconfig.json`, and a minimal Gtk/Adwaita `main.ts`. Pick a template interactively — or pass `--template <id>`:
+## Installation
 
-- **`types-npm`** — uses the pre-generated [`@girs/*`](https://github.com/gjsify/types) NPM packages (fastest start)
-- **`types-locally`** — generates types directly into `./@types/`, no `@girs/*` dependencies
-- **`types-workspace`** — npm workspace layout with locally-generated `@girs/*` as workspace packages
+### GJS — no Node.js required <sub>experimental</sub>
 
 ```bash
-cd my-app
-npm start
+curl -fsSL https://raw.githubusercontent.com/gjsify/ts-for-gir/main/install.js -o /tmp/install.js
+gjs -m /tmp/install.js && rm /tmp/install.js
 ```
 
-### Using the CLI directly
+Installs to `~/.local/bin/`. Update later with `ts-for-gir self-update`. Powered by [GJSify](https://gjsify.github.io/gjsify/).
 
-If you already have a project and just need type definitions, invoke `ts-for-gir` without scaffolding:
+### Node.js
 
 ```bash
-# GJS (no Node.js required):
-ts-for-gir generate Gtk-4.0
-
-# Node.js / npx:
-npx @ts-for-gir/cli generate Gtk-4.0
+npx @ts-for-gir/cli --help
+# or globally:
+npm install -g @ts-for-gir/cli
 ```
 
-Run `ts-for-gir --help` or `npx @ts-for-gir/cli --help` for all commands. See the [CLI documentation](/packages/cli/README.md) for detailed options and advanced usage.
+## CLI Usage
 
-**Debug Generation Issues:**
-If you encounter type generation problems, enable the reporter and use the analyze command:
 ```bash
-ts-for-gir generate Gtk-4.0 --reporter
-ts-for-gir analyze -f ./ts-for-gir-report.json
+ts-for-gir generate Gtk-4.0                          # generate types for a single module
+ts-for-gir generate Gtk-4.0 --reporter               # with diagnostics
+ts-for-gir analyze -f ./ts-for-gir-report.json       # inspect the report
+ts-for-gir --help                                    # all commands
 ```
 
-## Showcase
+See the [CLI documentation](/packages/cli/README.md) for advanced options.
 
-**GNOME Applications**
+## Pre-generated NPM Packages
 
-* [Audio Player](https://flathub.org/apps/org.gnome.Decibels) - Play audio files
-* [Counters](https://flathub.org/apps/io.gitlab.guillermop.Counters) - Keep track of anything
-* [Ignition](https://flathub.org/apps/io.github.flattool.Ignition) - Manage startup apps and scripts
-* [Learn 6502](https://flathub.org/apps/eu.jumplink.Learn6502) - Learn program vintage Game Consoles
-* [Sound Recorder](https://flathub.org/apps/org.gnome.SoundRecorder) - A simple, modern sound recorder
-* [Sticky Notes](https://flathub.org/apps/com.vixalien.sticky) - Pin notes to your desktop
-* [Weather](https://flathub.org/apps/org.gnome.Weather) - Show weather conditions and forecast
-* [K’uychi](https://flathub.org/en/apps/one.naiara.Kuychi) - Generate color palettes
-
-**GNOME Shell Extensions**
-
-* [gTile](https://github.com/gTile/gTile) - Tiling window management for GNOME Shell
-* [Copyous](https://github.com/boerdereinar/copyous) - Clipboard manager for GNOME Shell
-* [Rounded Window Corners](https://github.com/flexagoon/rounded-window-corners) - Add rounded corners to windows
-
-## Example Projects
-
-Looking for a starting point? These example projects demonstrate how to use the TypeScript definitions with various bundlers:
-
-- [GTK 4 Template with Vite](/examples/gtk-4-template-vite) - Modern UI with Vite bundling
-- [GNOME TypeScript Template](https://codeberg.org/nyx_lyb3ra/gnome-ts-template) - A template using GTK, libadwaita, TypeScript, Flatpak, and Meson
-
-More examples with screenshots and descriptions can be found in the [Examples directory](/examples/README.md). For information on using the examples with different CLI options, refer to the [CLI documentation](/packages/cli/README.md#using-the-generated-types).
-
-## NPM Packages
-
-If you are only interested in the types and do not want to generate them yourself, you can use our pre-generated NPM packages. For example, if you want to develop a Gtk4 application with GJS, it is enough to install the corresponding NPM packages:
+If you just want the types without generating them yourself:
 
 ```bash
-npm install @girs/gjs @girs/gtk-4.0 --save
+npm install @girs/gjs @girs/gtk-4.0
 ```
 
 ```ts
-import '@girs/gjs'
-import '@girs/gjs/dom'
-import '@girs/gtk-4.0'
+import "@girs/gjs";
+import "@girs/gjs/dom";
+import "@girs/gtk-4.0";
 
-import Gtk from 'gi://Gtk?version=4.0';
+import Gtk from "gi://Gtk?version=4.0";
 
 const button = new Gtk.Button();
 ```
 
-All pre-generated NPM packages can be found on [gjsify/types](https://github.com/gjsify/types).
+All packages are listed at [gjsify/types](https://github.com/gjsify/types). Missing a module? [Open an issue](https://github.com/gjsify/ts-for-gir/issues).
 
-> You want your or any other missing GObject introspection based library types to be published on NPM for every release? Then feel free to create an issue for it, we will be happy to include it.
+## Showcase
+
+**GNOME Applications** — [Audio Player](https://flathub.org/apps/org.gnome.Decibels), [Counters](https://flathub.org/apps/io.gitlab.guillermop.Counters), [Ignition](https://flathub.org/apps/io.github.flattool.Ignition), [Learn 6502](https://flathub.org/apps/eu.jumplink.Learn6502), [Sound Recorder](https://flathub.org/apps/org.gnome.SoundRecorder), [Sticky Notes](https://flathub.org/apps/com.vixalien.sticky), [Weather](https://flathub.org/apps/org.gnome.Weather), [K'uychi](https://flathub.org/en/apps/one.naiara.Kuychi).
+
+**GNOME Shell Extensions** — [gTile](https://github.com/gTile/gTile), [Copyous](https://github.com/boerdereinar/copyous), [Rounded Window Corners](https://github.com/flexagoon/rounded-window-corners).
+
+More starting points in the [examples directory](/examples/README.md) and the community [GNOME TypeScript Template](https://codeberg.org/nyx_lyb3ra/gnome-ts-template) (GTK + libadwaita + Flatpak + Meson).
 
 ## Project Structure
 
-ts-for-gir consists of several packages:
+ts-for-gir is a monorepo of focused packages:
 
-- [`@ts-for-gir/cli`](/packages/cli) - Command-line interface for generating TypeScript definitions, documentation, and analyzing reports
-- [`@gi.ts/parser`](/packages/parser) - Parser for GObject Introspection XML files
-- [`@ts-for-gir/lib`](/packages/lib) - Core library for processing GIR data
-- [`@ts-for-gir/reporter`](/packages/reporter) - Reporting system for problems and statistics with dependency injection
-- [`@ts-for-gir/generator-typescript`](/packages/generator-typescript) - TypeScript definition generator
-- [`@ts-for-gir/generator-json`](/packages/generator-json) - TypeDoc JSON generator with GIR metadata enrichment
-- [`@ts-for-gir/generator-html-doc`](/packages/generator-html-doc) - HTML documentation generator using TypeDoc
-- [`@ts-for-gir/generator-base`](/packages/generator-base) - Shared base class for generators
-- [`@ts-for-gir/typedoc-theme`](/packages/typedoc-theme) - Custom TypeDoc theme inspired by gi-docgen
-- [`@ts-for-gir/gir-module-metadata`](/packages/gir-module-metadata) - Curated metadata (descriptions, logos, licenses) for GIR namespaces
-- [`@ts-for-gir/templates`](/packages/templates) - Template files for generated packages (tsconfig, typedoc config, ambient declarations)
-- [`@ts-for-gir/tsconfig`](/packages/tsconfig) - Shared TypeScript configuration
-- [`@ts-for-gir/language-server`](/packages/language-server) - Language server for GIR files (experimental)
+- [`@ts-for-gir/cli`](/packages/cli) — CLI for generating types, docs, and analyzing reports
+- [`@ts-for-gir/lib`](/packages/lib), [`@gi.ts/parser`](/packages/parser), [`@ts-for-gir/reporter`](/packages/reporter) — core processing
+- [`@ts-for-gir/generator-typescript`](/packages/generator-typescript), [`@ts-for-gir/generator-json`](/packages/generator-json), [`@ts-for-gir/generator-html-doc`](/packages/generator-html-doc) — output backends
+- [`@ts-for-gir/templates`](/packages/templates), [`@ts-for-gir/tsconfig`](/packages/tsconfig), [`@ts-for-gir/typedoc-theme`](/packages/typedoc-theme) — shared scaffolding
+- [`@ts-for-gir/language-server`](/packages/language-server) — LSP for GIR files (experimental)
 
-### Submodules
-
-This repo contains Git submodules for pre-generated types and documentation:
-
-- `types-dev` (branch `dev`): used during local development. Scripts write generated packages here.
-- `types-release` (branch `main`): updated by the release workflow on tags.
-- `docs` (branch `main`): generated HTML documentation, deployed to [gjsify.github.io/docs](https://gjsify.github.io/docs).
-
-Useful scripts:
+Git submodules: `types-dev` (development scratch), `types-release` (published `@girs/*`), `docs` (deployed to [gjsify.github.io/docs](https://gjsify.github.io/docs)).
 
 ```bash
-yarn build:types          # generates into ./types-dev
-yarn build:types:release  # generates into ./types-release
-yarn build:doc            # generates HTML docs into ./docs
+gjsify run build:types          # regenerate into ./types-dev
+gjsify run build:types:release  # regenerate into ./types-release
+gjsify run build:doc            # build HTML docs into ./docs
 ```
 
-## Further Information
+## Further Reading
 
-- [TypeScript API Documentation](https://gjsify.github.io/docs) - Browsable API reference for all GJS type definitions
-- [Examples](/examples/README.md) - Detailed examples showing TypeScript with different bundlers
-- [CLI Documentation](/packages/cli/README.md) - Comprehensive guide to CLI options and features
-- [gjsify/types](https://github.com/gjsify/types) - Pre-generated NPM packages you can use directly
-- [GNOME Shell Extension Types](https://github.com/gjsify/gnome-shell) - Hand-written type definitions for GNOME Shell Extensions
+- [TypeScript API Documentation](https://gjsify.github.io/docs)
+- [Examples](/examples/README.md)
+- [CLI Documentation](/packages/cli/README.md)
+- [gjsify/types](https://github.com/gjsify/types) — pre-generated NPM packages
+- [gjsify/gnome-shell](https://github.com/gjsify/gnome-shell) — hand-written Shell Extension types

--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,8 @@
 			"!**/test",
 			"!**/tests",
 			"!**/templates",
+			"!**/dist-templates",
+			"!packages/cli/templates",
 			"!**/@types",
 			"!**/docs",
 			"!refs",

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,9 +12,9 @@ Each example:
 
 To use an example:
 1. Go to the example directory
-2. Run `yarn install` to install dependencies
-3. Run `yarn build` to build the example
-4. Run `yarn start` to run the example
+2. Run `gjsify install` to install dependencies
+3. Run `gjsify run build` to build the example
+4. Run `gjsify run start` to run the example
 
 **Note:** Examples must be built because GJS cannot execute TypeScript directly. However, the core ts-for-gir packages no longer require building and run directly as TypeScript files.
 
@@ -139,8 +139,8 @@ For most examples, you can use:
 
 ```bash
 cd examples/<example-directory>
-yarn install
-yarn start  # This will build and run the example
+gjsify install
+gjsify run start  # This will build and run the example
 ```
 
 Some examples like the DBus and HTTP examples have separate client and server parts:
@@ -148,15 +148,15 @@ Some examples like the DBus and HTTP examples have separate client and server pa
 ```bash
 # For DBus example
 cd examples/gio-2-dbus
-yarn install
-yarn start:server  # In one terminal
-yarn start:client  # In another terminal
+gjsify install
+gjsify run start:server  # In one terminal
+gjsify run start:client  # In another terminal
 
 # For HTTP example
 cd examples/soup-3-http
-yarn install
-yarn start:server  # In one terminal
-yarn start:client  # In another terminal
+gjsify install
+gjsify run start:server  # In one terminal
+gjsify run start:client  # In another terminal
 ```
 
 ## TypeScript Configuration

--- a/examples/dex-1-file-operations-promisify/README.md
+++ b/examples/dex-1-file-operations-promisify/README.md
@@ -71,9 +71,9 @@ await promisify(Dex.file_copy(source, dest, flags, priority), 'boolean');
 ## Installation & Start
 
 ```bash
-yarn install
-yarn build    # Build the TypeScript files
-yarn start    # Run the example
+gjsify install
+gjsify run build    # Build the TypeScript files
+gjsify run start    # Run the example
 ```
 
 ## Code Structure

--- a/examples/di-needle/README.md
+++ b/examples/di-needle/README.md
@@ -21,8 +21,8 @@ This example demonstrates how to combine GObject properties/signals with automat
 
 ```bash
 cd examples/di-needle
-yarn install
-yarn start alice alice@example.com
+gjsify install
+gjsify run start alice alice@example.com
 ```
 
 ## TypeScript Configuration

--- a/examples/di-tsyringe/README.md
+++ b/examples/di-tsyringe/README.md
@@ -22,8 +22,8 @@ This example demonstrates traditional dependency injection using [TSyringe](http
 
 ```bash
 cd examples/di-tsyringe
-yarn install
-yarn start alice alice@example.com
+gjsify install
+gjsify run start alice alice@example.com
 ```
 
 ## TypeScript Configuration

--- a/examples/di-wise/README.md
+++ b/examples/di-wise/README.md
@@ -21,8 +21,8 @@ This example demonstrates modern, type-safe dependency injection using [Wise DI]
 
 ```bash
 cd examples/di-wise
-yarn install
-yarn start
+gjsify install
+gjsify run start
 ```
 
 ## TypeScript Configuration

--- a/examples/gio-2-dbus/README.md
+++ b/examples/gio-2-dbus/README.md
@@ -37,14 +37,14 @@ Both approaches work simultaneously, providing seamless migration paths.
 
 ```bash
 # Build the TypeScript sources
-yarn build
+gjsify run build
 
 # Start the server (in one terminal)
-yarn start:server
+gjsify run start:server
 
 # Start the client (in another terminal)  
-yarn start:client
+gjsify run start:client
 
 # Or run both simultaneously
-yarn start
+gjsify run start
 ``` 

--- a/examples/gio-2-list-model/README.md
+++ b/examples/gio-2-list-model/README.md
@@ -53,10 +53,10 @@ For each interface method you need to implement:
 
 ```bash
 # Build the example
-yarn build
+gjsify run build
 
 # Run the example
-yarn start
+gjsify run start
 ```
 
 ## Expected Output

--- a/examples/gobject-param-spec/README.md
+++ b/examples/gobject-param-spec/README.md
@@ -50,9 +50,9 @@ const binding = sourceObj.bind_property_full(
 ## Running the Example
 
 ```bash
-yarn install
-yarn build
-yarn start
+gjsify install
+gjsify run build
+gjsify run start
 ```
 
 ## Key Learning Points

--- a/examples/gtk-4-signal-helpers/README.md
+++ b/examples/gtk-4-signal-helpers/README.md
@@ -115,10 +115,10 @@ Shows how to create functions that accept only valid signal names and enforce co
 
 ```bash
 # Build the TypeScript code
-yarn build
+gjsify run build
 
 # Run the example
-yarn start
+gjsify run start
 ```
 
 ## Key Concepts

--- a/examples/virtual-interface-test/README.md
+++ b/examples/virtual-interface-test/README.md
@@ -46,9 +46,9 @@ This approach gives you:
 ### Step 3: Build and Run the Example
 ```bash
 cd examples/virtual-interface-test
-yarn install
-yarn build
-yarn start
+gjsify install
+gjsify run build
+gjsify run start
 ```
 
 ## Benefits

--- a/packages/cli/scripts/process-templates.mjs
+++ b/packages/cli/scripts/process-templates.mjs
@@ -8,7 +8,6 @@
  * `workspace:^` references are user-workspace references, not ts-for-gir ones.
  */
 
-import { execFileSync } from "node:child_process";
 import { cpSync, existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,21 +27,39 @@ function readJson(path) {
 
 /**
  * Build a { packageName: version } map from every workspace in the monorepo.
- * Yarn's `workspaces list --json` already includes types-dev/* (the @girs/*
- * packages), so a single call covers both the CLI packages and the GIR types.
+ * Node-native walk of `package.json#workspaces` globs — no yarn dependency,
+ * works on the Node-free `gjsify install` install path.
+ *
+ * Supports the common globbing patterns we use here (`packages/*`,
+ * `examples/*`, `tests/*`, `types-dev/*`); plain string entries are treated
+ * as exact relative paths.
  */
 function buildVersionMap() {
-	const stdout = execFileSync("yarn", ["workspaces", "list", "--json"], {
-		cwd: MONOREPO_ROOT,
-		encoding: "utf8",
-		maxBuffer: 50 * 1024 * 1024,
-	});
+	const rootPkg = readJson(join(MONOREPO_ROOT, "package.json"));
+	const patterns = Array.isArray(rootPkg.workspaces)
+		? rootPkg.workspaces
+		: Array.isArray(rootPkg.workspaces?.packages)
+			? rootPkg.workspaces.packages
+			: [];
+
+	const dirs = new Set();
+	for (const pattern of patterns) {
+		if (pattern.endsWith("/*")) {
+			const base = pattern.slice(0, -2);
+			const baseAbs = join(MONOREPO_ROOT, base);
+			if (!existsSync(baseAbs)) continue;
+			for (const entry of readdirSync(baseAbs, { withFileTypes: true })) {
+				if (!entry.isDirectory()) continue;
+				dirs.add(join(baseAbs, entry.name));
+			}
+		} else {
+			dirs.add(join(MONOREPO_ROOT, pattern));
+		}
+	}
+
 	const map = {};
-	for (const line of stdout.trim().split("\n")) {
-		if (!line) continue;
-		const entry = JSON.parse(line);
-		if (entry.location === ".") continue;
-		const pkgPath = join(MONOREPO_ROOT, entry.location, "package.json");
+	for (const dir of dirs) {
+		const pkgPath = join(dir, "package.json");
 		if (!existsSync(pkgPath)) continue;
 		const pkg = readJson(pkgPath);
 		if (pkg.name && pkg.version) map[pkg.name] = pkg.version;

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -19,7 +19,8 @@ const command = "create [name]";
 const description = "Scaffold a new GJS TypeScript project from a template";
 
 const examples: ReadonlyArray<[string, string?]> = [
-	[`${APP_NAME} create my-app --template types-npm`, "Scaffold using the @girs/* NPM types"],
+	[`${APP_NAME} create my-app --template types-gjsify`, "Scaffold a Node-free GJS app via gjsify (recommended)"],
+	[`${APP_NAME} create my-app --template types-npm`, "Scaffold using the @girs/* NPM types + node/esbuild"],
 	[`${APP_NAME} create my-app --template types-locally`, "Scaffold and generate types into ./@types/ locally"],
 	[
 		`${APP_NAME} create my-app --template types-workspace`,
@@ -30,14 +31,19 @@ const examples: ReadonlyArray<[string, string?]> = [
 
 const TEMPLATE_CHOICES: ReadonlyArray<{ value: CreateTemplateId; name: string; description: string }> = [
 	{
-		value: "types-locally",
-		name: "types-locally",
-		description: "Generate GIR types directly into ./@types/ (no package format, no @girs/* deps)",
+		value: "types-gjsify",
+		name: "types-gjsify",
+		description: "Node-free: @girs/* from NPM, all dev scripts (install/build/run/format) routed through gjsify",
 	},
 	{
 		value: "types-npm",
 		name: "types-npm",
 		description: "Use pre-generated types from the @girs/* NPM packages",
+	},
+	{
+		value: "types-locally",
+		name: "types-locally",
+		description: "Generate GIR types directly into ./@types/ (no package format, no @girs/* deps)",
 	},
 	{
 		value: "types-workspace",
@@ -226,19 +232,30 @@ const handler = async (args: ConfigFlags) => {
 	log.success(`Scaffolded ${template} into ${targetDir}`);
 
 	if (opts.install) {
-		log.info("Running npm install...");
-		const result = spawnSync("npm", ["install", "--no-audit", "--no-fund"], {
+		// types-gjsify is Node-free at runtime — bootstrap deps via `gjsify install`
+		// so the user's first impression matches the rest of the template's scripts.
+		// Other templates remain on npm (matches the prior behavior + their README).
+		const installer = template === "types-gjsify" ? "gjsify" : "npm";
+		const installerArgs = template === "types-gjsify" ? ["install"] : ["install", "--no-audit", "--no-fund"];
+		log.info(`Running ${installer} install...`);
+		const result = spawnSync(installer, installerArgs, {
 			cwd: targetDir,
 			stdio: "inherit",
 		});
 		if (result.status !== 0) {
-			log.warn("npm install failed; you can re-run it manually in the project directory.");
+			log.warn(`${installer} install failed; you can re-run it manually in the project directory.`);
 		}
 	}
 
 	log.info("\nNext steps:");
 	log.white(`  cd ${projectName}`);
-	if (!opts.install) log.white("  npm install");
+	if (!opts.install) {
+		if (template === "types-gjsify") {
+			log.white("  gjsify install");
+		} else {
+			log.white("  npm install");
+		}
+	}
 	switch (template) {
 		case "types-locally":
 			log.white("  npm run generate");
@@ -252,6 +269,10 @@ const handler = async (args: ConfigFlags) => {
 		case "types-workspace":
 			log.white("  npm run build:types && npm install");
 			log.white("  npm run build:app && npm start");
+			break;
+		case "types-gjsify":
+			log.white("  gjsify run check");
+			log.white("  gjsify run build && gjsify run start");
 			break;
 	}
 };

--- a/packages/cli/src/config/options.ts
+++ b/packages/cli/src/config/options.ts
@@ -257,8 +257,8 @@ export const createOptions = {
 	template: {
 		type: "string" as const,
 		alias: "t",
-		description: "Template to scaffold (types-locally, types-npm, types-workspace)",
-		choices: ["types-locally", "types-npm", "types-workspace"] as const,
+		description: "Template to scaffold (types-locally, types-npm, types-workspace, types-gjsify)",
+		choices: ["types-locally", "types-npm", "types-workspace", "types-gjsify"] as const,
 	},
 	install: {
 		type: "boolean" as const,

--- a/packages/cli/src/types/command-args.ts
+++ b/packages/cli/src/types/command-args.ts
@@ -94,7 +94,7 @@ export interface DocCommandArgs extends GenerateCommandArgs {
 /**
  * Available scaffolding template identifiers for the create command.
  */
-export type CreateTemplateId = "types-locally" | "types-npm" | "types-workspace";
+export type CreateTemplateId = "types-locally" | "types-npm" | "types-workspace" | "types-gjsify";
 
 /**
  * Arguments for the create command

--- a/packages/cli/templates/types-gjsify/README.md
+++ b/packages/cli/templates/types-gjsify/README.md
@@ -1,0 +1,32 @@
+# __PROJECT_NAME__
+
+GJS + TypeScript starter, fully Node-free at runtime. Uses pre-generated [`@girs/*`](https://www.npmjs.com/org/girs) types and the [`gjsify` CLI](https://gjsify.github.io/gjsify/) for install, build, run, format and lint — no `npm`, no `node`, no `esbuild` ceremony.
+
+## Setup
+
+```sh
+gjsify install
+gjsify run build && gjsify run start
+```
+
+That's it. `gjsify build` produces a single GJS bundle with the right `firefox*` target + `gi://*` externals; `gjsify run` launches it with `LD_LIBRARY_PATH` / `GI_TYPELIB_PATH` pre-wired for any native typelib deps.
+
+## Scripts
+
+| Script | What it does |
+|---|---|
+| `gjsify install` | Install deps (Node-free; reads `gjsify-lock.json`) |
+| `gjsify run check` | TypeScript `tsc --noEmit` |
+| `gjsify run build` | Bundle `main.ts` → `dist/main.js` |
+| `gjsify run start` | Launch the bundle under `gjs -m` |
+| `gjsify run format` | Format via Biome |
+| `gjsify run fix` | Format + safe-fix lint + organize imports |
+| `gjsify run clear` | Remove `dist/` |
+
+## Adding GIR modules
+
+Install the matching `@girs/<name>-<version>` package and add it to `tsconfig.json`'s `types` array. Example for GStreamer:
+
+```sh
+gjsify install @girs/gst-1.0
+```

--- a/packages/cli/templates/types-gjsify/biome.json
+++ b/packages/cli/templates/types-gjsify/biome.json
@@ -1,0 +1,43 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": true
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab",
+		"lineWidth": 120,
+		"lineEnding": "lf"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"useImportType": "warn",
+				"useNodejsImportProtocol": "error",
+				"noNonNullAssertion": "off"
+			},
+			"suspicious": {
+				"noExplicitAny": "warn",
+				"noConsole": "off"
+			},
+			"correctness": {
+				"noUnusedImports": "warn"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double",
+			"semicolons": "always",
+			"trailingCommas": "all",
+			"arrowParentheses": "always"
+		}
+	},
+	"files": {
+		"includes": ["**", "!**/node_modules", "!**/dist", "!**/.cache"]
+	}
+}

--- a/packages/cli/templates/types-gjsify/biome.json
+++ b/packages/cli/templates/types-gjsify/biome.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true
-	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",

--- a/packages/cli/templates/types-gjsify/main.ts
+++ b/packages/cli/templates/types-gjsify/main.ts
@@ -1,0 +1,19 @@
+import Adw from "gi://Adw?version=1";
+import Gio from "gi://Gio?version=2.0";
+import Gtk from "gi://Gtk?version=4.0";
+
+const app = new Adw.Application({
+	applicationId: "com.example.__PROJECT_NAME__",
+	flags: Gio.ApplicationFlags.FLAGS_NONE,
+});
+
+app.connect("activate", (app: Adw.Application) => {
+	const label = new Gtk.Label({ label: "Hello from __PROJECT_NAME__" });
+	const window = new Gtk.ApplicationWindow({ application: app });
+	window.set_title("__PROJECT_NAME__");
+	window.set_default_size(320, 120);
+	window.set_child(label);
+	window.present();
+});
+
+app.run([imports.system.programInvocationName].concat(ARGV));

--- a/packages/cli/templates/types-gjsify/package.json
+++ b/packages/cli/templates/types-gjsify/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "__PROJECT_NAME__",
+	"version": "0.1.0",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"check": "tsc --noEmit",
+		"build": "gjsify build main.ts --app gjs --outfile dist/main.js",
+		"start": "gjsify run dist/main.js",
+		"format": "gjsify format",
+		"fix": "gjsify fix",
+		"clear": "rm -rf dist"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.13",
+		"@gjsify/cli": "^0.4.14",
+		"typescript": "^6.0.2"
+	},
+	"dependencies": {
+		"@girs/adw-1": "workspace:^",
+		"@girs/gio-2.0": "workspace:^",
+		"@girs/gjs": "workspace:^",
+		"@girs/glib-2.0": "workspace:^",
+		"@girs/gtk-4.0": "workspace:^"
+	}
+}

--- a/packages/cli/templates/types-gjsify/tsconfig.json
+++ b/packages/cli/templates/types-gjsify/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"types": ["@girs/gjs", "@girs/adw-1"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noImplicitThis": true,
+		"alwaysStrict": true
+	},
+	"files": ["main.ts"]
+}

--- a/tests/language-server-validation/README.md
+++ b/tests/language-server-validation/README.md
@@ -15,13 +15,13 @@ Tests the correct TypeScript type generation for GIR (GObject Introspection) bin
 
 ```bash
 # Generate types and run tests
-yarn test
+gjsify run test
 
 # Watch mode for development
-yarn test:watch
+gjsify run test:watch
 
 # Quick test run without regenerating types
-yarn test:dev
+gjsify run test:dev
 ```
 
 ## Test Structure

--- a/tests/types-locally/README.md
+++ b/tests/types-locally/README.md
@@ -1,3 +1,3 @@
 # `@ts-for-gir-test/types-locally`
 
-This package, which is part of the yarn workspace, is used to test the generation of local types without `package.json` support. It also tests the import of the same library in different versions, such as Gtk3 and Gtk4, to verify the `onlyVersionPrefix` generation option.
+This package, which is part of the gjsify workspace, is used to test the generation of local types without `package.json` support. It also tests the import of the same library in different versions, such as Gtk3 and Gtk4, to verify the `onlyVersionPrefix` generation option.

--- a/tests/types-no-advanced-variants/README.md
+++ b/tests/types-no-advanced-variants/README.md
@@ -1,3 +1,3 @@
 # `@ts-for-gir-test/types-no-advanced-variants`
 
-This package, which is part of the yarn workspace, is used to test the `noAdvancedVariants` generation option.
+This package, which is part of the gjsify workspace, is used to test the `noAdvancedVariants` generation option.


### PR DESCRIPTION
## Summary

Closes the doc-drift after the Phase F.5 yarn → gjsify migration, and adds a Node-free `types-gjsify` scaffold to the `create` command.

### Sweep yarn → gjsify across docs

The monorepo has been Node-free via `@gjsify/cli` since Phase F.5 (no `yarn.lock`, no `.yarn/`, `gjsify-lock.json` + `gjsify install/foreach/workspace` drive every script). README/AGENTS/example docs were stale.

- README.md restructured: shorter Quick Start leading with the new template; single table for the four templates; `gjsify dlx @ts-for-gir/cli create my-app` shown alongside `npx @ts-for-gir/cli create my-app`; collapsed redundant Showcase lists.
- AGENTS.md (= CLAUDE.md via symlink): all `yarn` script invocations → `gjsify run …` / `gjsify {workspace,foreach,format}`.
- All `examples/*/README.md` + `tests/*/README.md`.
- `.husky/pre-commit`: `yarn format` → `gjsify run format`.

### New `types-gjsify` template

Listed first in the interactive picker. Derived from `types-npm` + `types-workspace`:

- Single-package layout (like `types-npm`)
- `@girs/*` from NPM (no local generation)
- Every dev script routed through gjsify: `gjsify install/build/run/format/fix`
- Ships its own `biome.json` with gjsify-style defaults
- `--install` path uses `gjsify install` instead of `npm install`
- Next-steps hint printed by `create.ts` mentions `gjsify run`

### Bonus: fix process-templates.mjs

The script that resolves `workspace:^` deps in templates to concrete versions for the npm tarball was shelling out to `yarn workspaces list --json`. That breaks on systems where only yarn v1 is in PATH (yarn v1 doesn't support `workspaces list`). Replaced with a Node-native walk of `package.json#workspaces` globs — no yarn dependency, identical output.

### Biome config tweak

Excludes `packages/cli/templates/` + `**/dist-templates` from root `biome.json` so the template's own `biome.json` doesn't trip the nested-root check.

## Test plan

- [x] `node bin/ts-for-gir-dev create test --template types-gjsify --no-install` scaffolds a complete project with resolved `@girs/*` versions
- [x] `node scripts/process-templates.mjs` regenerates `dist-templates/` for all four templates (no yarn dependency)
- [x] `gjsify run check:lint` clean (346 files, no fixes applied)
- [x] `tsc --noEmit` clean
- [x] husky `pre-commit` (`gjsify run format`) runs clean on the migration commit itself