### PR TITLE
fix(installer, cli): bake gjsify native prebuild paths into launcher + full terminal width

### DIFF
--- a/install.js
+++ b/install.js
@@ -217,8 +217,66 @@ function pickLauncherTarget(pkg) {
 	throw new Error(`No '${DEFAULT_BIN_NAME}' bin declared in package.json (looked at gjsify.bin and bin)`);
 }
 
+/**
+ * Discover @gjsify/* native prebuild directories (Vala/GObject typelibs +
+ * shared libs) reachable from the user's gjsify global install — typically
+ * `~/.local/share/gjsify/global/node_modules/@gjsify/<pkg>/prebuilds/linux-<arch>/`.
+ * ts-for-gir's GJS bundle uses these via `imports.gi.GjsifyTerminal` for
+ * correct TTY width / isTTY / raw-mode detection; without GI_TYPELIB_PATH /
+ * LD_LIBRARY_PATH pointing at them, the bundle falls back to env-only
+ * defaults (no colors, 80-col wrap).
+ *
+ * Returns the empty array when no gjsify global install is present, in which
+ * case the launcher is written without an env preamble.
+ */
+function detectGjsifyNativePrebuildDirs() {
+	const xdgData =
+		GLib.getenv("XDG_DATA_HOME") || GLib.build_filenamev([GLib.get_home_dir(), ".local", "share"]);
+	const gjsifyPrefix =
+		GLib.getenv("GJSIFY_GLOBAL_PREFIX") || GLib.build_filenamev([xdgData, "gjsify", "global"]);
+	const nodeModulesGjsify = GLib.build_filenamev([gjsifyPrefix, "node_modules", "@gjsify"]);
+	const dir = Gio.File.new_for_path(nodeModulesGjsify);
+	if (!dir.query_exists(null)) return [];
+	// gjs runs on `process.arch`-equivalent x64 / arm64; mirror gjsify's
+	// detect-native-packages.ts arch map so the prebuild directory name
+	// matches the .so/.typelib layout shipped by gjsify.
+	const machine = (() => {
+		try {
+			const [, out] = GLib.spawn_command_line_sync("uname -m");
+			return new TextDecoder().decode(out).trim();
+		} catch {
+			return "x86_64";
+		}
+	})();
+	const archDir = `linux-${machine === "aarch64" ? "aarch64" : machine === "x86_64" ? "x86_64" : machine}`;
+	const out = [];
+	const enumerator = dir.enumerate_children("standard::name,standard::type", Gio.FileQueryInfoFlags.NONE, null);
+	let info;
+	while ((info = enumerator.next_file(null))) {
+		const name = info.get_name();
+		const pkgDir = GLib.build_filenamev([nodeModulesGjsify, name]);
+		const prebuildsDir = GLib.build_filenamev([pkgDir, "prebuilds", archDir]);
+		if (Gio.File.new_for_path(prebuildsDir).query_exists(null)) {
+			out.push(prebuildsDir);
+		}
+	}
+	enumerator.close(null);
+	return out;
+}
+
+function buildLauncherEnvPreamble(prebuildsDirs) {
+	if (prebuildsDirs.length === 0) return "";
+	const joined = shQuote(prebuildsDirs.join(":"));
+	return (
+		`GI_TYPELIB_PATH=${joined}\${GI_TYPELIB_PATH:+":$GI_TYPELIB_PATH"}\n` +
+		`LD_LIBRARY_PATH=${joined}\${LD_LIBRARY_PATH:+":$LD_LIBRARY_PATH"}\n` +
+		`export GI_TYPELIB_PATH LD_LIBRARY_PATH\n`
+	);
+}
+
 function writeLauncher(target) {
-	const launcher = `#!/bin/sh\nexec ${shQuote(target)} "$@"\n`;
+	const envPreamble = buildLauncherEnvPreamble(detectGjsifyNativePrebuildDirs());
+	const launcher = `#!/bin/sh\n${envPreamble}exec ${shQuote(target)} "$@"\n`;
 	const file = Gio.File.new_for_path(LAUNCHER_PATH);
 	file.replace_contents(
 		new TextEncoder().encode(launcher),

--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -5,11 +5,21 @@ import { hideBin } from "yargs/helpers";
 import { analyze, copy, create, doc, generate, json, list, selfUpdate } from "./commands/index.ts";
 
 try {
-	await yargs(hideBin(process.argv))
+	const cli = yargs(hideBin(process.argv));
+	await cli
 		.scriptName(APP_NAME)
 		.strict()
 		.usage(APP_USAGE)
 		.version(APP_VERSION)
+		// Use the full terminal width for help. yargs's default caps at 80
+		// (`Math.min(80, process.stdout.columns)`); we explicitly opt into
+		// the real terminal width so long option/description lines wrap at
+		// the actual terminal edge instead of an arbitrary 80-col limit.
+		// Under GJS, `process.stdout.columns` is backed by
+		// `@gjsify/terminal-native` (ioctl TIOCGWINSZ) when the typelib is
+		// on `GI_TYPELIB_PATH` — the install.js launcher imports those env
+		// vars from the gjsify global install when present.
+		.wrap(cli.terminalWidth())
 		// Disable yargs's internal `process.exit` and route both success
 		// and failure through `parseAsync` + an explicit `process.exit` so
 		// async command handlers complete and stdout drains before the


### PR DESCRIPTION
## Summary

- `install.js` writes `~/.local/bin/ts-for-gir` with a `GI_TYPELIB_PATH` / `LD_LIBRARY_PATH` preamble pointing at gjsify's globally-installed native prebuild dirs (`~/.local/share/gjsify/global/node_modules/@gjsify/*/prebuilds/linux-<arch>/`). Without this, the ts-for-gir GJS bundle's call to `imports.gi.GjsifyTerminal` throws at startup and `process.stdout` falls back to `isTTY=false` / `columns=80`.
- `packages/cli/src/start.ts` adds `.wrap(cli.terminalWidth())` so help uses the real TTY width instead of yargs's `Math.min(80, columns)` default.

## Root cause

`@ts-for-gir/cli`'s GJS bundle imports `@gjsify/terminal-native`, which does a synchronous `imports.gi.GjsifyTerminal` lookup at module-load time. If the typelib isn't on `GI_TYPELIB_PATH`, the lookup throws and the `nativeTerminal` loader returns `null`. `@gjsify/process` then has no way to query `Posix.isatty()` / `ioctl(TIOCGWINSZ)` / termios — `process.stdout.isTTY` resolves to `false` and `.columns` to the 80 fallback. yargs reads the resulting `process.stdout.columns` once at shim load and caps at 80.

The terminal-native typelib is shipped with gjsify, not with ts-for-gir. Detecting gjsify's global install at ts-for-gir install time is the lightweight way to reuse it without duplicating the prebuild.

## Behavior

- gjsify global install present → launcher prepends every `@gjsify/*` prebuild dir found under `~/.local/share/gjsify/global/node_modules/@gjsify/` to `GI_TYPELIB_PATH` + `LD_LIBRARY_PATH`. Existing values from the user's env are preserved as a suffix.
- gjsify global install absent → launcher is written without the preamble. No behavior change.
- `XDG_DATA_HOME` and `GJSIFY_GLOBAL_PREFIX` are honored (mirrors gjsify's `defaultGlobalLayout()`).

## Files

- `install.js`: new helpers `detectGjsifyNativePrebuildDirs()` + `buildLauncherEnvPreamble()`. `writeLauncher()` composes the preamble before `exec`.
- `packages/cli/src/start.ts`: `.wrap(cli.terminalWidth())`.

## Test plan

Verified locally on Linux x86_64:

- [x] After `gjs -m install.js --force` with gjsify globally installed, `~/.local/bin/ts-for-gir` contains the `GI_TYPELIB_PATH=…` / `LD_LIBRARY_PATH=…` prepend lines covering `http-soup-bridge`, `http2-native`, `sab-native`, `terminal-native`.
- [x] Under a PTY with `TIOCSWINSZ` 160×40: `process.stdout.columns === 160`, `process.stdout.isTTY === true`. `ts-for-gir --help` will use the full width once the `start.ts` change ships in a published bundle.
- [x] Without gjsify global present, the launcher is written without the preamble (gated by `Gio.File.query_exists(null)`).

## Companion PR

gjsify/gjsify#226 — same fix for the gjsify CLI launcher.