### PR TITLE
ci(release-app): init types-dev submodule before workspace install

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -34,8 +34,15 @@ jobs:
 
         git config --global --add safe.directory "*"
 
+    # `types-dev` provides the `@girs/*` workspaces that examples (and
+    # therefore `gjsify install --immutable`) reference via `workspace:^`.
+    # Without `submodules: true` the install step fails with "no workspace
+    # with that name exists" for every `@girs/<lib>` workspace dep. Matches
+    # the equivalent step in release-types.yml + release-docs.yml.
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        submodules: true
 
     - name: Setup npm auth
       env:


### PR DESCRIPTION
## Summary

`gjsify install --immutable` resolves `workspace:^` dependencies against the on-disk workspace list. Examples like \`examples/adw-1-hello\` declare \`\"@girs/adw-1\": \"workspace:^\"\`, which lives in \`types-dev/adw-1\` — a submodule. Without \`submodules: true\` on actions/checkout, the install step fails:

\`\`\`
gjsify install: @ts-for-gir-example/adw-1-hello-example declares
\"@girs/adw-1: workspace:^\" but no workspace with that name exists
\`\`\`

Matches the existing \`submodules: true\` already in \`release-types.yml\` + \`release-docs.yml\`.

## Detection

v4.0.0-rc.16 release attempt: **Release App workflow failed**, Release Types + Release Docs succeeded. Logs of the failed install step: https://github.com/gjsify/ts-for-gir/actions/runs/26188887289

## Root cause

Latent until Phase F moved app publishing from yarn (which silently skipped missing workspaces) to \`gjsify install --immutable\` (which correctly hard-fails). The other two release workflows already had the fix.

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release-app.yml"))'\` clean.
- [x] Diff: one-block change adding \`with: submodules: true\` + comment explaining why.
- [ ] After merge: trigger \`gh workflow run release-app.yml -f release_tag=v4.0.0-rc.16\` to retry the failed v4.0.0-rc.16 publish (npm registry shows nothing for @ts-for-gir/cli@4.0.0-rc.16 right now).