### PR TITLE
ci(release): switch release-app to OIDC + fix release-docs pull divergence

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -44,15 +44,15 @@ jobs:
       with:
         submodules: true
 
-    - name: Setup npm auth
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-      run: |
-        cat > $HOME/.npmrc <<NPMRC
-        //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
-        registry=https://registry.npmjs.org/
-        NPMRC
-        chmod 600 $HOME/.npmrc
+    # npm Trusted Publishing (OIDC). gjsify publish 0.4.16+ auto-detects
+    # OIDC mode when ACTIONS_ID_TOKEN_REQUEST_URL + _TOKEN are present
+    # (handled by GitHub Actions because the workflow declares
+    # `id-token: write` above) AND no NODE_AUTH_TOKEN env is exported.
+    # Both `@ts-for-gir/*` and `@gi.ts/*` packages have Trusted Publisher
+    # entries configured for this repo + this workflow filename on
+    # npmjs.com, so a per-package OIDC exchange yields a short-lived
+    # (~5min) publish token. No long-lived NPM_TOKEN secret needed; the
+    # previous Setup-npm-auth step is retired.
 
     - name: Bootstrap @gjsify/cli via install.mjs (Node-free)
       run: |

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -58,8 +58,13 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git remote set-url origin "https://x-access-token:${PAT_TOKEN}@github.com/gjsify/docs.git"
         git fetch origin
-        git checkout main
-        git pull origin main
+        # `git pull` refuses to merge when local and origin/main have
+        # diverged (each with their own commit) — happens when two CI
+        # runs publish docs back-to-back and the first push lands while
+        # the second is still local. Force-sync to origin/main; the
+        # submodule's local commit is always disposable (re-built from
+        # the parent ts-for-gir version on each release run).
+        git checkout -B main origin/main
 
     - name: Generate JSON files
       env:


### PR DESCRIPTION
## Why

The v4.0.0-rc.17 release event triggered three workflows; one succeeded, two failed:

| Workflow | Status | Why |
|---|---|---|
| Release Docs (release event) | ✓ | Lucky — divergence not hit on the original run |
| Release App (release event) | ✗ | NODE_AUTH_TOKEN secret invalid → npm 404 on every PUT |
| Release Types (release event) | ✗ | Same npm 404 |
| Release Docs (workflow_dispatch retry) | ✗ | `git pull origin main` refused: divergent submodule branches |
| Release App (workflow_dispatch retry) | ✗ | Same auth bug |
| Release Types (workflow_dispatch retry) | ✓ | Different code path |

Result: `@ts-for-gir/cli@4.0.0-rc.17` and siblings never reached npm. `ts-for-gir self-update` falls back to `npm update -g` (which can't find the version).

## Part A — release-app.yml: drop the broken Setup-npm-auth step

The previous step wrote `$HOME/.npmrc` with `_authToken=$NODE_AUTH_TOKEN` expanding a long-lived NPM_TOKEN secret. That secret was rotated/disabled by npm's *"Mini Shai-Hulud"* precaution, so every publish PUT returned 404 Not Found (npm masks invalid-token as 404 to avoid leaking existence info).

`gjsify publish` 0.4.16+ auto-detects npm Trusted Publishing (OIDC) when:
- `ACTIONS_ID_TOKEN_REQUEST_URL` + `_TOKEN` are present (handled by GitHub Actions because the workflow already declares `id-token: write`), AND
- No `NODE_AUTH_TOKEN` env is exported.

Both `@ts-for-gir/*` and `@gi.ts/*` packages have Trusted Publisher entries configured on npmjs.com for this repo + this workflow filename. Dropping the auth step makes auto-detect pick OIDC for the next release run.

## Part B — release-docs.yml: replace `git pull` with hard reset

Replace `git pull origin main` (which refuses to merge when local and origin have diverged) with `git checkout -B main origin/main`. The submodule's local commit is always disposable — rebuilt from the parent ts-for-gir version on each release run.

## Recovery procedure (after this PR merges)

```bash
gh workflow run release-app.yml  -f release_tag=v4.0.0-rc.17
gh workflow run release-docs.yml -f release_tag=v4.0.0-rc.17
```

That re-runs the failed publishes using the new (fixed) workflow files from main against the v4.0.0-rc.17 tag.

## Out of scope (separate PR)

Adding `install.mjs` + GJS bundle as GitHub-release assets so `ts-for-gir self-update` works without re-running `npm i -g`. Tracked locally; needs `gjsify generate-installer` + bundle output path + softprops/action-gh-release wiring (analogous to gjsify's release.yml asset upload step).