### PR TITLE
fix(release-app): explicit --trusted + GJSIFY_PUBLISH_DEBUG

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -84,6 +84,10 @@ jobs:
     - name: Publish app packages to npm
       env:
         WS_PATH: ${{ github.workspace }}
+        # Surface OIDC mode + per-package PUT URLs in the job log so a
+        # failed exchange can be debugged without re-running with a
+        # local patch. Equivalent of gjsify/gjsify's release.yml.
+        GJSIFY_PUBLISH_DEBUG: "1"
       run: PATH="$WS_PATH/node_modules/.bin:$PATH" gjsify run publish:app
 
     - name: Summary

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"update:submodules": "git submodule foreach git pull",
 		"update:packages": "gjsify upgrade --latest",
 		"update": "gjsify run update:submodules && gjsify run update:packages",
-		"publish:app": "gjsify run build:app && gjsify foreach -v -p --no-private --include '@ts-for-gir/*' --include '@gi.ts/*' --exec -- gjsify publish --tolerate-republish --tag latest --access public --provenance",
+		"publish:app": "gjsify run build:app && gjsify foreach -v -p --no-private --include '@ts-for-gir/*' --include '@gi.ts/*' --exec -- gjsify publish --trusted --tolerate-republish --tag latest --access public --provenance",
 		"publish:types": "gjsify foreach -v -p --no-private --include '@girs/*' --exec -- gjsify publish --tolerate-republish --tag latest --access public",
 		"publish": "gjsify run publish:app && gjsify run publish:types",
 		"test:types": "gjsify run build:types && gjsify run check:types",


### PR DESCRIPTION
## Why

The PR #403 recovery run for v4.0.0-rc.17 still failed with \`{\"error\":\"Not found\"}\` on every package. The error body is ambiguous between \"OIDC exchange rejected\" (no Trusted Publisher / workflow_ref mismatch) and \"PUT itself unauthorized\" (no auth at all) — and without \`GJSIFY_PUBLISH_DEBUG=1\` in the workflow env, the \`auth-mode:\` diagnostic line never fires, so we can't tell.

## Changes

1. **\`publish:app\` script: explicit \`--trusted\` flag.** Force OIDC mode so a missing or misconfigured Trusted Publisher fails loudly with \`OidcExchangeError\` + the npm response body. Previously the auto-detect path (no NODE_AUTH_TOKEN env, OIDC env vars present) was supposed to pick OIDC — but apparently didn't, and explicit \`--trusted\` removes the ambiguity.

2. **\`release-app.yml\` step env: \`GJSIFY_PUBLISH_DEBUG=1\`.** Mirrors what gjsify/gjsify's own release.yml does — surfaces the per-package PUT URL + auth-mode in the job log, so the next failure (if any) is diagnosable from CI output alone.

## Recovery (after merge)

\`\`\`bash
gh workflow run release-app.yml -f release_tag=v4.0.0-rc.17
\`\`\`