### PR TITLE
fix(gobject): reach enhanced registerClass overloads + cleanup

### DIFF
--- a/examples/gobject-register-class-inference/README.md
+++ b/examples/gobject-register-class-inference/README.md
@@ -1,0 +1,32 @@
+# GObject.registerClass Property-Inference Example
+
+Demonstrates that when the return value of `GObject.registerClass()` is
+captured, the resulting class surfaces property types declared in the
+`Properties` block:
+
+```ts
+const Counter = GObject.registerClass({ Properties: { count: ... } }, class extends GObject.Object {});
+new Counter().count; // typed as number
+```
+
+Before this PR, the "enhanced" overload that performs this inference was
+shadowed by an earlier "standard" overload (`registerClass<T extends
+ObjectConstructor>(cls: T): T`) that matched any class extending
+`GObject.Object` and returned the class type unchanged. The two overload
+sets are now mutually exclusive on the `noAdvancedVariants` flag, so the
+inference path is reachable.
+
+The idiomatic `static { GObject.registerClass(...) }` pattern (see the
+`gobject-param-spec` example) is unaffected by this change.
+
+## Run
+
+```sh
+gjsify workspace @ts-for-gir-example/gobject-register-class-inference start
+```
+
+## Type-check
+
+```sh
+gjsify workspace @ts-for-gir-example/gobject-register-class-inference check
+```

--- a/examples/gobject-register-class-inference/main.ts
+++ b/examples/gobject-register-class-inference/main.ts
@@ -1,0 +1,36 @@
+/**
+ * GObject.registerClass property-inference example.
+ *
+ * Exercises the inference path that becomes reachable after the standard
+ * overloads are no longer emitted alongside the enhanced ones. Property
+ * types declared in the `Properties` block are surfaced on the registered
+ * class via `RegisteredPrototype`.
+ *
+ * The companion `gobject-param-spec` example covers the idiomatic
+ * `static { GObject.registerClass(...) }` pattern, which is unaffected.
+ */
+
+import GObject from "gi://GObject?version=2.0";
+
+const Counter = GObject.registerClass(
+	{
+		GTypeName: "ExampleCounter",
+		Properties: {
+			count: GObject.ParamSpec.int("count", null, null, GObject.ParamFlags.READWRITE, 0, Number.MAX_SAFE_INTEGER, 0),
+			label: GObject.ParamSpec.string("label", null, null, GObject.ParamFlags.READWRITE, "counter"),
+		},
+	},
+	class extends GObject.Object {},
+);
+
+const c = new Counter();
+
+// Property types from the Properties block are surfaced on the instance.
+c.count = 5;
+c.label = "hello";
+
+print(`count=${c.count} label=${c.label}`);
+
+// Regression assertion: wrong property type is rejected.
+// @ts-expect-error: count is typed as number, not string
+c.count = "still wrong";

--- a/examples/gobject-register-class-inference/package.json
+++ b/examples/gobject-register-class-inference/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "@ts-for-gir-example/gobject-register-class-inference",
+	"description": "Demonstrates GObject.registerClass property inference when the return value is captured",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"build": "tsc",
+		"start": "gjs -m dist/main.js",
+		"check": "tsc --noEmit",
+		"clear": "rm -rf dist"
+	},
+	"devDependencies": {
+		"typescript": "^6.0.3"
+	},
+	"dependencies": {
+		"@girs/gjs": "workspace:^",
+		"@girs/glib-2.0": "workspace:^",
+		"@girs/gobject-2.0": "workspace:^"
+	}
+}

--- a/examples/gobject-register-class-inference/tsconfig.json
+++ b/examples/gobject-register-class-inference/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"types": ["@girs/gjs", "@girs/gobject-2.0", "@girs/glib-2.0"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noImplicitThis": true,
+		"alwaysStrict": true,
+		"outDir": "./dist"
+	},
+	"files": ["main.ts"]
+}

--- a/packages/templates/templates/gobject-2.0.d.ts
+++ b/packages/templates/templates/gobject-2.0.d.ts
@@ -41,29 +41,17 @@ export interface MetaInfo<Props, Interfaces, Sigs> {
 export type Property<K extends ParamSpec> = K extends ParamSpec<infer T> ? T : any
 
 <%_ if (!noAdvancedVariants) { _%>
-// Advanced type inference for GObject class registration
-// String conversion utilities for property names
+// Advanced type inference for GObject class registration.
+// Convert kebab-case property names (e.g. "my-prop") to snake_case
+// ("my_prop"). GJS exposes registered properties on the JS side as
+// snake_case (and via `get_property('kebab-name')`), so we only alias to
+// that form; camelCase aliases would not match anything at runtime.
 type SnakeToUnderscoreCase<S extends string> = S extends `${infer T}-${infer U}`
     ? `${T}_${SnakeToUnderscoreCase<U>}`
     : S extends `${infer T}`
       ? `${T}`
       : never
 
-type SnakeToCamelCase<S extends string> = S extends `${infer T}-${infer U}`
-    ? `${Lowercase<T>}${SnakeToPascalCase<U>}`
-    : S extends `${infer T}`
-      ? `${Lowercase<T>}`
-      : SnakeToPascalCase<S>
-
-type SnakeToPascalCase<S extends string> = string extends S
-    ? string
-    : S extends `${infer T}-${infer U}`
-      ? `${Capitalize<Lowercase<T>>}${SnakeToPascalCase<U>}`
-      : S extends `${infer T}`
-        ? `${Capitalize<Lowercase<T>>}`
-        : never
-
-type SnakeToCamel<T> = { [P in keyof T as P extends string ? SnakeToCamelCase<P> : P]: T[P] }
 type SnakeToUnderscore<T> = { [P in keyof T as P extends string ? SnakeToUnderscoreCase<P> : P]: T[P] }
 
 // Advanced utility types for class registration
@@ -88,7 +76,7 @@ export type RegisteredPrototype<
     P extends {},
     Props extends { [key: string]: ParamSpec },
     Interfaces extends any[],
-> = Properties<P, SnakeToCamel<Props> & SnakeToUnderscore<Props>> & UnionToIntersection<Interfaces[number]> & P
+> = Properties<P, SnakeToUnderscore<Props>> & UnionToIntersection<Interfaces[number]> & P
 
 type Ctor = new (...a: any[]) => object
 type Init = { _init(...args: any[]): void }

--- a/packages/templates/templates/gobject-2.0.d.ts
+++ b/packages/templates/templates/gobject-2.0.d.ts
@@ -319,9 +319,12 @@ export type SignalCallback<Emitter, Fn> = Fn extends (...args: infer P) => infer
 // TODO: What about the generated class Closure
 export type TClosure<R = any, P = any> = (...args: P[]) => R
 
+<%_ if (noAdvancedVariants) { _%>
+// Fallback registerClass overloads — used when advanced variants are
+// disabled. The class type is returned unchanged: callers are expected to
+// declare property/signal types manually on their class body.
 type ObjectConstructor = { new (...args: any[]): Object }
 
-// Standard registerClass overloads
 export function registerClass<T extends ObjectConstructor>(cls: T): T
 
 export function registerClass<
@@ -335,9 +338,18 @@ export function registerClass<
         }
     },
 >(options: MetaInfo<Props, Interfaces, Sigs>, cls: T): T
-
-<%_ if (!noAdvancedVariants) { _%>
-// Enhanced registerClass overloads with advanced type inference
+<%_ } else { _%>
+// Enhanced registerClass overloads with advanced type inference. Previously
+// shadowed by the standard overloads above, which matched any class
+// extending GObject.Object via `T extends ObjectConstructor` and returned
+// the class type unchanged — making the enhanced inference unreachable.
+// The two overload sets are now mutually exclusive on the `noAdvancedVariants`
+// flag.
+//
+// When the return value is captured (`const Foo = GObject.registerClass(...)`),
+// the resulting class carries inferred property types via RegisteredPrototype.
+// The idiomatic `static { GObject.registerClass(...) }` pattern discards the
+// return and is unaffected.
 
 export function registerClass<P extends {}, T extends new (...args: any[]) => P>(
     klass: T,
@@ -354,17 +366,7 @@ export function registerClass<
         }
     },
 >(
-    options: {
-        GTypeName?: string
-        GTypeFlags?: TypeFlags
-        Properties?: Props
-        Signals?: Sigs
-        Implements?: Interfaces
-        CssName?: string
-        Template?: string
-        Children?: string[]
-        InternalChildren?: string[]
-    },
+    options: MetaInfo<Props, Interfaces, Sigs>,
     klass: T,
 ): RegisteredClass<T, Props, Interfaces>
 <%_ } _%>


### PR DESCRIPTION
## Summary

Two related cleanups to the type declarations for `GObject.registerClass()`.

### 1. The "enhanced" overloads were unreachable

`gobject-2.0.d.ts` declared two sets of `registerClass` overloads — "standard" (returning `T` unchanged) and "enhanced" (returning `RegisteredClass<T, Props, Interfaces>` with property type inference). Because the standard overloads were declared first and matched any class extending `GObject.Object` via `T extends ObjectConstructor`, TypeScript's first-match overload resolution always picked them. The enhanced inference path was effectively dead code.

This PR makes the two sets mutually exclusive on the `noAdvancedVariants` flag: standard overloads ship only when advanced variants are disabled, enhanced overloads otherwise. Callers that capture the return value now actually receive a class with inferred property types:

```ts
const Counter = GObject.registerClass(
  { Properties: { count: GObject.ParamSpec.int(...) } },
  class extends GObject.Object {},
);
new Counter().count; // typed as number; previously `any`
```

The idiomatic `static { GObject.registerClass(...) }` pattern discards the return and is **unaffected** by this change.

### 2. Pre-existing options-shape narrowness

The enhanced overload duplicated `MetaInfo`'s options shape inline with `Template?: string`, while `MetaInfo` itself has `Template?: Uint8Array | GLib.Bytes | string`. Without fix 1, the inline version was unreachable so the bug was invisible; with fix 1 it surfaced as a `gtk-4-template-tsc` build failure. Replaced the duplicated shape with `MetaInfo<Props, Interfaces, Sigs>` directly.

### 3. Drop unused camelCase property aliases

`RegisteredPrototype` aliased each kebab-case property to both `snake_case` *and* `camelCase`. GJS only exposes `snake_case` (and the kebab form via `get_property()`) at runtime, so the camelCase aliases were misleading autocomplete suggestions that would fail at runtime. A repo-wide search found no usage; removed.

## Out of scope

Several other improvements to `RegisteredClass` (typed property-dict constructor, typed `connect`/`emit` from `Signals.<name>.param_types`) were considered and dropped from this PR — the strict-checking benefit was largely illusory due to TypeScript's overload-resolution behavior when intersecting typed overloads with the inherited string-keyed `connect(signal: string, cb: any)` fallback. They can be revisited as a follow-up if concrete users of the const-capture pattern surface concrete needs.

## Example

`examples/gobject-register-class-inference/` — minimal example exercising the now-reachable property inference, with a `@ts-expect-error` regression assertion that wrong property types are rejected.

The companion `gobject-param-spec` example continues to demonstrate the `static {}` pattern and is unaffected.

## Test plan

- [x] `gjsify run build:types` regenerates `/types-dev/` cleanly
- [x] `gjsify run check:examples` passes across all examples
- [x] `gjsify workspace @ts-for-gir-test/types-no-advanced-variants test` passes (the standard-overload fallback path remains intact for `noAdvancedVariants: true`)
- [x] `gjsify run test:tests` passes
- [x] `gjsify run check:app` passes
- [x] New example compiles; the `@ts-expect-error` assertion fires
- [ ] CI regenerates `/types-dev/` from the new template and runs end-to-end

Note: the CI failure on the previous push was unrelated — both jobs aborted at the `curl https://github.com/gjsify/gjsify/releases/latest/download/install.mjs` bootstrap step with HTTP 404. The cli bump in #407 may address it.