### PR TITLE
feat(release-app): upload install.js + GJS bundle as release assets

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -9,12 +9,19 @@ name: Release App
 on:
   release:
     types: [published]
+  # Manual reruns. Two scenarios:
+  #   1. Re-publish + (re-)upload assets for a real existing release whose
+  #      original `release`-event run didn't finish (asset upload skipped,
+  #      partial publish, etc). Pass the tag in `release_tag`; the workflow
+  #      rebuilds + republishes + uploads the assets to the named release.
+  #   2. Ad-hoc smoke test from main with no release attached. Leave
+  #      `release_tag` empty.
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to use for commit message'
+        description: 'Existing release tag to (re)upload assets to (e.g. v4.0.0-rc.17). Leave empty for a no-op dispatch from main.'
         required: false
-        default: 'manual'
+        default: ''
 
 jobs:
   publish-app:
@@ -39,10 +46,14 @@ jobs:
     # Without `submodules: true` the install step fails with "no workspace
     # with that name exists" for every `@girs/<lib>` workspace dep. Matches
     # the equivalent step in release-types.yml + release-docs.yml.
+    # `release` event auto-checks-out the tag. `workflow_dispatch` with a
+    # `release_tag` input must explicitly target that tag so the rebuilt
+    # bundle + install.js match what shipped (not main HEAD).
     - name: Checkout repository
       uses: actions/checkout@v6
       with:
         submodules: true
+        ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
 
     # npm Trusted Publishing (OIDC). gjsify publish 0.4.16+ auto-detects
     # OIDC mode when ACTIONS_ID_TOKEN_REQUEST_URL + _TOKEN are present
@@ -90,9 +101,43 @@ jobs:
         GJSIFY_PUBLISH_DEBUG: "1"
       run: PATH="$WS_PATH/node_modules/.bin:$PATH" gjsify run publish:app
 
+    # Ship the Node-free install path:
+    #   - install.js          bootstrap script users curl to install ts-for-gir
+    #                         without Node (`curl -fsSL <rel>/download/install.js | gjs -m -`)
+    #   - ts-for-gir-gjs      GJS bundle that `ts-for-gir self-update` looks for
+    #                         under GJS_ASSET_NAME (see packages/cli/src/commands/
+    #                         self-update.ts). Without this asset on the release,
+    #                         self-update falls back to "use npm update".
+    #   - ts-for-gir-gjs.sha256  checksum companion for install verification.
+    #
+    # Uploads only on the `release` event (normal flow) or on a
+    # `workflow_dispatch` run that explicitly names a `release_tag` —
+    # mirrors gjsify/gjsify's release.yml asset-upload gating.
+    - name: Generate ts-for-gir-gjs.sha256
+      if: github.event_name == 'release' || inputs.release_tag != ''
+      run: |
+        cd packages/cli/bin
+        sha256sum ts-for-gir-gjs | awk '{print $1}' > ts-for-gir-gjs.sha256
+        cat ts-for-gir-gjs.sha256
+
+    - name: Upload installer + GJS bundle to GitHub release
+      if: github.event_name == 'release' || inputs.release_tag != ''
+      uses: softprops/action-gh-release@v3
+      with:
+        # On `release` softprops infers tag_name from the event payload.
+        # On `workflow_dispatch` we must pass it explicitly so the action
+        # targets the operator-specified tag instead of creating a new
+        # release from HEAD.
+        tag_name: ${{ github.event.release.tag_name || inputs.release_tag }}
+        files: |
+          install.js
+          packages/cli/bin/ts-for-gir-gjs
+          packages/cli/bin/ts-for-gir-gjs.sha256
+
     - name: Summary
       env:
         RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
       run: |
         echo "App packages successfully published to npm for release ${RELEASE_TAG}"
         echo "Published packages: @ts-for-gir/* and @gi.ts/*"
+        echo "Release assets uploaded: install.js, ts-for-gir-gjs, ts-for-gir-gjs.sha256"


### PR DESCRIPTION
## Why

ts-for-gir's Node-free install path was complete on the local side but silently broken end-to-end:

- ✅ `install.js` at repo root (curl-installable bootstrap)
- ✅ `packages/cli/bin/ts-for-gir-gjs` builds correctly via `build:app:gjs`
- ✅ `ts-for-gir self-update` looks for asset `ts-for-gir-gjs` on the GitHub release (see `packages/cli/src/commands/self-update.ts:GJS_ASSET_NAME`)
- ❌ **release-app.yml never uploaded either file to the GitHub release**

User-visible symptom from yesterday:

```
$ ts-for-gir self-update
Checking for updates... (current: v4.0.0-rc.15)
Updating to v4.0.0-rc.17...
No GJS binary found in release v4.0.0-rc.17.
self-update requires the GJS bundle to be installed via install.js.
For npm installations use: npm update -g @ts-for-gir/cli
```

## Fix

Add a `softprops/action-gh-release@v3` step after `Publish app packages to npm` that uploads three assets to the release record:

- `install.js`
- `packages/cli/bin/ts-for-gir-gjs`
- `packages/cli/bin/ts-for-gir-gjs.sha256` *(generated in-workflow)*

Mirrors `gjsify/gjsify`'s `release.yml`. Gated on the `release` event OR a `workflow_dispatch` run that explicitly names a `release_tag`, so a no-op manual dispatch doesn't overwrite existing assets.

## Ancillary changes (symmetry with gjsify/release.yml)

1. **`workflow_dispatch.inputs.release_tag` default**: `'manual'` → `''`. The asset-upload gate (`release_tag != ''`) now correctly excludes no-op manual dispatches. Description updated to point at the real use case (recovering a release whose original run didn't finish).

2. **`actions/checkout` `ref`**: explicitly set to the release tag when present, so a manual rerun rebuilds from the same source as the original release rather than current main HEAD.

## Test plan

After merge:

```bash
# Upload assets to the existing v4.0.0-rc.17 release (originally failed to upload):
gh workflow run release-app.yml -f release_tag=v4.0.0-rc.17

# Verify:
gh release view v4.0.0-rc.17 --json assets --jq '.assets[].name'
# Should list: install.js, ts-for-gir-gjs, ts-for-gir-gjs.sha256

# Then locally:
ts-for-gir self-update
# Should find the binary on release and switch from rc.15 to rc.17
```