### PR TITLE
fix(release-app): add skip_publish input (default true on dispatch)

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -22,6 +22,11 @@ on:
         description: 'Existing release tag to (re)upload assets to (e.g. v4.0.0-rc.17). Leave empty for a no-op dispatch from main.'
         required: false
         default: ''
+      skip_publish:
+        description: 'Skip the npm publish step (default true — re-uploads are for fixing missing release assets; npm side already published).'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   publish-app:
@@ -92,7 +97,13 @@ jobs:
     # `npm i -g`, `gjsify install -g`, and the install.mjs bootstrapper
     # resolve it from there.
 
+    # Publish to npm on the `release` event (always) or on
+    # workflow_dispatch with skip_publish=false. Re-running an existing
+    # release should leave npm alone (each version is published exactly
+    # once); use skip_publish=true (the default) when the goal is just to
+    # (re-)upload missing release assets without touching npm.
     - name: Publish app packages to npm
+      if: ${{ github.event_name == 'release' || inputs.skip_publish == false }}
       env:
         WS_PATH: ${{ github.workspace }}
         # Surface OIDC mode + per-package PUT URLs in the job log so a


### PR DESCRIPTION
## Why

Re-running an existing release to upload missing assets shouldn't try to republish to npm — every package is published exactly once. The v4.0.0-rc.17 retry just now ([run 26225627962](https://github.com/gjsify/ts-for-gir/actions/runs/26225627962)) failed because:

- `workflow_dispatch` checks out the rc.17 tag (per the ref pin from #408)
- rc.17's `gjsify-lock.json` pins `@gjsify/cli@0.4.14`, predating Trusted Publishing
- the publish step ran anyway, got 404 from npm's auth, failed
- the **asset-upload step (the whole point of this dispatch) never ran**

## Fix

Mirror gjsify/gjsify's `release.yml` skip_publish pattern. Gate publish step on `release` event OR `inputs.skip_publish == false`. Default `skip_publish=true` on dispatch — the common case is "re-upload assets for an already-published release".

## After merge

```bash
gh workflow run release-app.yml -f release_tag=v4.0.0-rc.17
# uploads install.js + ts-for-gir-gjs + .sha256 to the release
# skips npm publish (rc.17 already on npm)
```