### PR TITLE
docs(examples): GObject.registerClass static-block ordering trap + Form A docstring

### DIFF
--- a/examples/gobject-param-spec/main.ts
+++ b/examples/gobject-param-spec/main.ts
@@ -12,8 +12,30 @@ if (System.version < 18200) {
 	System.exit(0);
 }
 
-// Example class demonstrating different ParamSpec usages
+// Example class demonstrating different ParamSpec usages.
+//
+// This follows pattern *Form A* from
+// https://gjsify.github.io/gjsify/patterns/gobject-classes/ — all
+// `GObject.registerClass()` metadata (`GTypeName`, `Properties`,
+// `Signals`, `Implements`) is passed inline in the static block's
+// call, instead of as separate `static [GObject.properties] = …`
+// fields. That sidesteps the static-block ordering trap behind
+// https://gitlab.gnome.org/GNOME/gjs/-/work_items/704: with no
+// `static [GObject.*] = …` initializers in scope, there's nothing
+// for the static block to evaluate too early. See the
+// `gobject-static-block-ordering` example for the side-by-side
+// broken/fixed demo of that bug.
+//
+// `static override $gtype: GObject.GType<ExampleObject>` narrows the
+// statically-inherited `static $gtype: GType<GObject.Object>` from
+// the base class to the concrete subclass type. Required if
+// anything in the codebase does `GObject.type_is_a(x, ExampleObject)`
+// or passes `ExampleObject` to APIs expecting
+// `GType<ExampleObject>`. The `override` keyword satisfies
+// TypeScript without changing runtime behaviour — GJS sets the
+// property on the constructor as part of `registerClass`.
 class ExampleObject extends GObject.Object {
+	static override $gtype: GObject.GType<ExampleObject>;
 	static {
 		GObject.registerClass(
 			{

--- a/examples/gobject-static-block-ordering/README.md
+++ b/examples/gobject-static-block-ordering/README.md
@@ -1,0 +1,39 @@
+# GObject.registerClass — static-block ordering trap
+
+Reproducer for the bug behind [GNOME/gjs#704](https://gitlab.gnome.org/GNOME/gjs/-/work_items/704): a `GObject.registerClass()` call inside a `static { … }` block runs in source-order, so any `static [GObject.interfaces] = …` / `static [GObject.properties] = …` field declared **after** the block is invisible to `registerClass`. The result is silent at type-check time but blows up at runtime when an unregistered vfunc is invoked.
+
+This example demonstrates three class shapes side-by-side and asserts each one behaves as expected at runtime:
+
+| Class | Pattern | Outcome |
+|---|---|---|
+| `BrokenFoo` | `static { registerClass }` first, `static [GObject.interfaces]` after | `Initable.init()` throws *Could not find definition of virtual function init* |
+| `WorkingFoo` | `static [GObject.interfaces]` first, `static { registerClass }` last | `init()` runs the vfunc body |
+| `InlineFoo` | metadata passed inline to `registerClass({ Implements: [...] }, Class)` | `init()` runs the vfunc body — no ordering question |
+
+`InlineFoo` is the form `patterns/gobject-classes` on the website recommends, because the ordering rule is not enforceable at the type level — a refactor that moves a static field around silently breaks `WorkingFoo`'s pattern.
+
+## Run
+
+```bash
+gjsify run check        # type-check the three classes
+gjsify run build        # tsc → dist/main.js
+gjsify run start        # gjs -m dist/main.js
+```
+
+Expected output:
+
+```
+✓ BrokenFoo.init() threw as expected: Could not find definition of virtual function init
+[WorkingFoo] vfunc_init body — should print
+✓ WorkingFoo.init() ran the vfunc body
+[InlineFoo] vfunc_init body — should print
+✓ InlineFoo.init() ran the vfunc body
+```
+
+The script exits with status 1 if `BrokenFoo` doesn't throw — that's the regression assertion: if a future upstream gjs change fixes the bug, this example will start failing and we'll know to update the pattern guidance.
+
+## See also
+
+- [Patterns → GObject classes](https://gjsify.github.io/gjsify/patterns/gobject-classes/) — full pattern reference + the `static override $gtype` workaround for TypeScript's static-inheritance invariance.
+- [`examples/gobject-param-spec`](../gobject-param-spec) — the recommended Form A in production-shaped use with the full ParamSpec surface.
+- [`examples/gobject-register-class-inference`](../gobject-register-class-inference) — Form C (functional / no static block) with type-inference assertions.

--- a/examples/gobject-static-block-ordering/main.ts
+++ b/examples/gobject-static-block-ordering/main.ts
@@ -48,7 +48,9 @@ let brokenError: string | null = null;
 try {
 	class BrokenFoo extends GObject.Object {
 		static override $gtype: GObject.GType<BrokenFoo>;
-		static { GObject.registerClass(BrokenFoo); }
+		static {
+			GObject.registerClass(BrokenFoo);
+		}
 		static [GObject.interfaces] = [Gio.Initable];
 		vfunc_init(_cancellable: Gio.Cancellable | null): boolean {
 			print("[BrokenFoo] vfunc_init body — should NOT print");
@@ -62,7 +64,9 @@ try {
 }
 
 if (brokenError === null) {
-	printerr("FAIL: BrokenFoo was expected to throw (either at registerClass time or at init() time), but completed cleanly");
+	printerr(
+		"FAIL: BrokenFoo was expected to throw (either at registerClass time or at init() time), but completed cleanly",
+	);
 	System.exit(1);
 }
 print(`✓ BrokenFoo failed as expected: ${brokenError}`);
@@ -81,7 +85,9 @@ class WorkingFoo extends GObject.Object {
 		print("[WorkingFoo] vfunc_init body — should print");
 		return true;
 	}
-	static { GObject.registerClass(WorkingFoo); }
+	static {
+		GObject.registerClass(WorkingFoo);
+	}
 }
 
 const working = new WorkingFoo() as unknown as Gio.Initable;

--- a/examples/gobject-static-block-ordering/main.ts
+++ b/examples/gobject-static-block-ordering/main.ts
@@ -1,0 +1,119 @@
+/**
+ * GObject.registerClass + static block — ordering trap demo.
+ *
+ * Reproducer for GNOME/gjs work_items/704:
+ *   https://gitlab.gnome.org/GNOME/gjs/-/work_items/704
+ *
+ * `GObject.registerClass()` inside a `static { … }` block runs in the
+ * source-order position of that block. If a `static [GObject.interfaces]`
+ * (or any other field `registerClass` reads) appears AFTER the static
+ * block, registerClass fires too early — the interfaces / properties /
+ * vfuncs declared there are not picked up. The failure shows up at
+ * class evaluation time on current GJS (1.86+) as
+ *   `Gjs-CRITICAL: Could not find definition of virtual function init`
+ * thrown out of `_classInit`. Older GJS versions deferred the same
+ * error to the first `vfunc_init` invocation.
+ *
+ * This example demonstrates the broken pattern side-by-side with two
+ * fixed ones, runs all three, and asserts:
+ *   - constructing the broken class raises the expected ordering error
+ *   - the corrected static-block-last class registers + runs vfunc_init
+ *   - the inline-metadata class registers + runs vfunc_init
+ *
+ * See https://gjsify.github.io/gjsify/patterns/gobject-classes/ for the
+ * full pattern reference.
+ */
+
+import Gio from "gi://Gio?version=2.0";
+import GObject from "gi://GObject?version=2.0";
+import System from "system";
+
+// ─── Broken: registerClass-first, static fields after ────────────────────
+//
+// `static { GObject.registerClass(BrokenFoo); }` runs first. By the time
+// it executes, `static [GObject.interfaces]` is still `undefined`. On
+// current GJS the registerClass call itself throws out of `_classInit`
+// because the class declares a `vfunc_init` that doesn't match any
+// interface the registered class implements — the trap is *visible*
+// at module load on this runtime, but on older GJS it deferred to the
+// first `.init()` call. Either way it's a runtime error caused by
+// source ordering, not a missing API.
+//
+// Wrapped in a try block because the throw happens at the
+// `class BrokenFoo` declaration's static-block evaluation — without
+// the try, the whole module file fails to load and the working demos
+// below never run.
+
+let brokenError: string | null = null;
+try {
+	class BrokenFoo extends GObject.Object {
+		static override $gtype: GObject.GType<BrokenFoo>;
+		static { GObject.registerClass(BrokenFoo); }
+		static [GObject.interfaces] = [Gio.Initable];
+		vfunc_init(_cancellable: Gio.Cancellable | null): boolean {
+			print("[BrokenFoo] vfunc_init body — should NOT print");
+			return true;
+		}
+	}
+	const broken = new BrokenFoo() as unknown as Gio.Initable;
+	broken.init(null);
+} catch (err) {
+	brokenError = err instanceof Error ? err.message : String(err);
+}
+
+if (brokenError === null) {
+	printerr("FAIL: BrokenFoo was expected to throw (either at registerClass time or at init() time), but completed cleanly");
+	System.exit(1);
+}
+print(`✓ BrokenFoo failed as expected: ${brokenError}`);
+
+// ─── Working: registerClass-last, static fields first ────────────────────
+//
+// Source order: `vfunc_init` (prototype — order-independent), then
+// `static [GObject.interfaces] = […]`, then `static { registerClass(...); }`.
+// When registerClass runs, the interfaces array is already assigned, so
+// Initable's vtable is wired up and `vfunc_init` lands as the init impl.
+
+class WorkingFoo extends GObject.Object {
+	static override $gtype: GObject.GType<WorkingFoo>;
+	static [GObject.interfaces] = [Gio.Initable];
+	vfunc_init(_cancellable: Gio.Cancellable | null): boolean {
+		print("[WorkingFoo] vfunc_init body — should print");
+		return true;
+	}
+	static { GObject.registerClass(WorkingFoo); }
+}
+
+const working = new WorkingFoo() as unknown as Gio.Initable;
+working.init(null);
+print("✓ WorkingFoo.init() ran the vfunc body");
+
+// ─── Inline (preferred Form A): metadata in registerClass call ───────────
+//
+// Sidesteps the ordering question entirely. No `static [GObject.*] = …`
+// initializers exist — everything `registerClass` needs is in its own
+// arguments. This is the form `patterns/gobject-classes` recommends.
+
+class InlineFoo extends GObject.Object {
+	static override $gtype: GObject.GType<InlineFoo>;
+	vfunc_init(_cancellable: Gio.Cancellable | null): boolean {
+		print("[InlineFoo] vfunc_init body — should print");
+		return true;
+	}
+	static {
+		GObject.registerClass(
+			{
+				GTypeName: "InlineFoo",
+				Implements: [Gio.Initable],
+			},
+			InlineFoo,
+		);
+	}
+}
+
+const inline = new InlineFoo() as unknown as Gio.Initable;
+inline.init(null);
+print("✓ InlineFoo.init() ran the vfunc body");
+
+print("");
+print("Done — see https://gjsify.github.io/gjsify/patterns/gobject-classes/ for the pattern reference.");

--- a/examples/gobject-static-block-ordering/package.json
+++ b/examples/gobject-static-block-ordering/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@ts-for-gir-example/gobject-static-block-ordering",
+	"description": "Demonstrates the static-block ordering trap (GNOME/gjs#704) side-by-side: broken init order fails at runtime, correct order works.",
+	"type": "module",
+	"private": true,
+	"scripts": {
+		"build": "tsc",
+		"start": "gjs -m dist/main.js",
+		"check": "tsc --noEmit",
+		"clear": "rm -rf dist"
+	},
+	"devDependencies": {
+		"typescript": "^6.0.3"
+	},
+	"dependencies": {
+		"@girs/gio-2.0": "workspace:^",
+		"@girs/gjs": "workspace:^",
+		"@girs/glib-2.0": "workspace:^",
+		"@girs/gobject-2.0": "workspace:^"
+	}
+}

--- a/examples/gobject-static-block-ordering/tsconfig.json
+++ b/examples/gobject-static-block-ordering/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"lib": ["ESNext"],
+		"types": ["@girs/gjs", "@girs/gobject-2.0", "@girs/glib-2.0", "@girs/gio-2.0"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noImplicitThis": true,
+		"alwaysStrict": true,
+		"outDir": "./dist"
+	},
+	"files": ["main.ts"]
+}


### PR DESCRIPTION
## Why

Companion to the new [Patterns → GObject classes](https://gjsify.github.io/gjsify/patterns/gobject-classes/) page on the website ([gjsify/gjsify#247](https://github.com/gjsify/gjsify/pull/247)) — gives readers a runnable side-by-side demo of:

- the static-block ordering trap behind [GNOME/gjs#704](https://gitlab.gnome.org/GNOME/gjs/-/work_items/704)
- the two correct shapes (fields-first vs metadata-inline)
- the `static override $gtype: GObject.GType<Foo>` declaration that narrows the statically-inherited `$gtype` from the base class (per Philip Chimento's matrix thread)

## What lands

### `examples/gobject-static-block-ordering/` (new)

Three classes side-by-side, all exercised at runtime with assertions:

| Class | Pattern | Outcome |
|---|---|---|
| `BrokenFoo` | `static { registerClass }` first, `static [interfaces]` after | throws *Could not find definition of virtual function init* at class registration on GJS 1.86+ — wrapped in try/catch so the rest of the demo runs |
| `WorkingFoo` | `static [interfaces]` first, `static { registerClass }` last | `init()` runs the vfunc body |
| `InlineFoo` | metadata passed inline to `registerClass({ Implements: [...] }, Foo)` | `init()` runs the vfunc body — no ordering question (preferred Form A) |

Regression guard: if `BrokenFoo` ever stops throwing (upstream gjs fix), the script exits 1 — we'll know to update the pattern guidance.

### `examples/gobject-param-spec/main.ts` (augmented)

Adds the `static override $gtype: GObject.GType<ExampleObject>` declaration and an explanatory docstring block above the class explaining why this is Form A and how it sidesteps the ordering trap. No behavioural change — runtime output unchanged.

## Test plan

- [x] `gjsify run check` clean in both example dirs
- [x] `gjsify run start` in `gobject-static-block-ordering` prints all three ✓ lines and exits 0
- [x] `gjsify run start` in `gobject-param-spec` still emits the full ParamSpec demo
- [ ] After [gjsify/gjsify#247](https://github.com/gjsify/gjsify/pull/247) merges + deploys, the `https://gjsify.github.io/gjsify/patterns/gobject-classes/` links in both READMEs and main.ts headers resolve