### PR TITLE
docs(readme): document `gjsify dlx` + `gjsify install -g` install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,34 @@ cd my-app && npm start    # or `gjsify run start` for types-gjsify
 
 ### GJS — no Node.js required <sub>experimental</sub>
 
+Three equivalent paths, depending on whether you want a one-shot run, a managed install, or a self-updating standalone install. All three require only [GJS](https://gjs.guide/) at runtime — no Node.js. Powered by [GJSify](https://gjsify.github.io/gjsify/).
+
+**One-shot — `gjsify dlx` (npx-style, no install):**
+
+```bash
+gjsify dlx @ts-for-gir/cli list
+gjsify dlx @ts-for-gir/cli generate Gtk-4.0
+```
+
+`gjsify dlx` fetches the package into a content-addressed cache (`~/.cache/gjsify/dlx`), runs its GJS bundle, and reuses the cache on subsequent invocations of the same spec. Pair with `--reinstall` to force a refresh.
+
+**Global install via the gjsify CLI:**
+
+```bash
+gjsify install -g @ts-for-gir/cli
+ts-for-gir --help
+```
+
+Installs into the user-global XDG location (`~/.local/share/gjsify/global`) and symlinks the binary to `~/.local/bin/ts-for-gir`. Re-run the same command to update.
+
+**Bootstrap installer — `curl | gjs` one-liner** (handy when the `gjsify` CLI is not yet installed):
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gjsify/ts-for-gir/main/install.js -o /tmp/install.js
 gjs -m /tmp/install.js && rm /tmp/install.js
 ```
 
-Installs to `~/.local/bin/`. Update later with `ts-for-gir self-update`. Powered by [GJSify](https://gjsify.github.io/gjsify/).
+Installs to `~/.local/bin/`. Update later with `ts-for-gir self-update`.
 
 ### Node.js
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 `ts-for-gir` generates accurate TypeScript definitions from [GObject Introspection](https://gi.readthedocs.io/en/latest/) for [GJS](https://gitlab.gnome.org/GNOME/gjs/) projects — strong typing, IDE jump-to-definition, autocompletion across the whole GNOME stack.
 
+📖 **Project page on the gjsify website**: [gjsify.github.io/gjsify/projects/ts-for-gir](https://gjsify.github.io/gjsify/projects/ts-for-gir/) — install paths, quickstart, generator usage, links to the related [Patterns](https://gjsify.github.io/gjsify/patterns/) docs.
+
 Browse the full **[TypeScript API Documentation](https://gjsify.github.io/docs)** for GLib, GTK, GStreamer, and more.
 
 ## Quick Start


### PR DESCRIPTION
## Adds two new install paths

Both Node-free, GJS-runtime only:

### One-shot via \`gjsify dlx\` (npx-style)

\`\`\`bash
gjsify dlx @ts-for-gir/cli list
gjsify dlx @ts-for-gir/cli generate Gtk-4.0
\`\`\`

Content-addressed cache at \`~/.cache/gjsify/dlx\`; subsequent invocations of the same spec reuse it. \`--reinstall\` forces a refresh.

### Global install via \`gjsify install -g\`

\`\`\`bash
gjsify install -g @ts-for-gir/cli
ts-for-gir --help
\`\`\`

Installs into \`~/.local/share/gjsify/global\` and symlinks the binary to \`~/.local/bin/ts-for-gir\`. Re-run to update.

## Dependency

Both paths require **gjsify v0.4.21+** (the bare-spec → `latest` dist-tag fix in [gjsify/gjsify#249](https://github.com/gjsify/gjsify/pull/249)). Without that fix, bare-name resolution picks the abandoned v3.3.0 release instead of 4.0.0-rc.17 because semver \`*\` skips prereleases.

## What's preserved

- Existing \`curl | gjs install.js\` one-liner stays as a self-bootstrap path for users who don't have the gjsify CLI installed yet.
- Node.js \`npx\` / \`npm install -g\` section unchanged.