### PR TITLE
docs(readme): trim GJS install section — bootstrap first, gjsify alt below

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,36 +45,16 @@ cd my-app && npm start    # or `gjsify run start` for types-gjsify
 
 ## Installation
 
-### GJS — no Node.js required <sub>experimental</sub>
-
-Three equivalent paths, depending on whether you want a one-shot run, a managed install, or a self-updating standalone install. All three require only [GJS](https://gjs.guide/) at runtime — no Node.js. Powered by [GJSify](https://gjsify.github.io/gjsify/).
-
-**One-shot — `gjsify dlx` (npx-style, no install):**
-
-```bash
-gjsify dlx @ts-for-gir/cli list
-gjsify dlx @ts-for-gir/cli generate Gtk-4.0
-```
-
-`gjsify dlx` fetches the package into a content-addressed cache (`~/.cache/gjsify/dlx`), runs its GJS bundle, and reuses the cache on subsequent invocations of the same spec. Pair with `--reinstall` to force a refresh.
-
-**Global install via the gjsify CLI:**
-
-```bash
-gjsify install -g @ts-for-gir/cli
-ts-for-gir --help
-```
-
-Installs into the user-global XDG location (`~/.local/share/gjsify/global`) and symlinks the binary to `~/.local/bin/ts-for-gir`. Re-run the same command to update.
-
-**Bootstrap installer — `curl | gjs` one-liner** (handy when the `gjsify` CLI is not yet installed):
+### GJS — no Node.js required
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gjsify/ts-for-gir/main/install.js -o /tmp/install.js
 gjs -m /tmp/install.js && rm /tmp/install.js
 ```
 
-Installs to `~/.local/bin/`. Update later with `ts-for-gir self-update`.
+Installs to `~/.local/bin/`. Update later with `ts-for-gir self-update`. Powered by [GJSify](https://gjsify.github.io/gjsify/).
+
+Alternative — if you already have the [gjsify CLI](https://gjsify.github.io/gjsify/) installed: `gjsify dlx @ts-for-gir/cli <args>` (npx-style, no install) or `gjsify install -g @ts-for-gir/cli` (managed global).
 
 ### Node.js
 


### PR DESCRIPTION
Per feedback: the three-method exposition was too verbose for a README. New shape:

- `curl | gjs install.js` bootstrap first (works without any prerequisites)
- gjsify-CLI alternatives (`dlx` / `install -g`) collapsed into one follow-up line for users who already have the CLI installed
- Full detail (when to pick which path, cache layout, etc.) lives on the [website project page](https://gjsify.github.io/gjsify/projects/ts-for-gir/), already linked at the top of the README

Also drops the `experimental` tag — the install path has been stable since 4.0.0-rc.15.