### PR TITLE
feat(cli): Flathub-ready Flatpak scaffold for @ts-for-gir/cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ ts-for-gir-report.json
 .yarn/
 
 .parcel-cache/
+# Flatpak build artifacts (manifests + metainfo + flathub.json kept; build outputs ignored)
+.flatpak-builder/
+build-dir/
+repo/
+*.flatpak

--- a/packages/cli/data/io.github.gjsify.ts_for_gir.metainfo.xml.in
+++ b/packages/cli/data/io.github.gjsify.ts_for_gir.metainfo.xml.in
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2026 gjsify contributors -->
+<component type="console-application">
+  <id>io.github.gjsify.ts_for_gir</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <name>ts-for-gir</name>
+  <summary>TypeScript type definitions for GObject Introspection (GJS)</summary>
+  <description>
+    <p>ts-for-gir reads GObject Introspection (GIR) XML files and emits strongly-typed TypeScript definitions for use in GJS (GNOME JavaScript) projects. Type-check your GTK / Adwaita / GLib / Gio / GStreamer / WebKit / etc. code, get full IDE completion, and catch missing properties / wrong-arity signal handlers at build time instead of runtime.</p>
+    <p>This Flatpak ships ts-for-gir as a self-contained CLI runnable on any modern Linux distro — no Node.js installation required. It reads from the system's installed GIR catalog (read-only mounts of /usr/share/gir-1.0 and /usr/share/gobject-introspection-1.0) and writes generated types under your project directory.</p>
+    <ul>
+      <li>`ts-for-gir generate Gtk-4.0` — generate types for one or more GI namespaces</li>
+      <li>`ts-for-gir generate --reporter` — write a JSON report alongside types for downstream analysis</li>
+      <li>`ts-for-gir analyze report.json` — inspect type-resolution issues by severity / category / namespace</li>
+      <li>`ts-for-gir create my-app` — scaffold a new GJS app from a template</li>
+      <li>`ts-for-gir list` — list all GIR namespaces available on this system</li>
+      <li>`ts-for-gir self-update` — refresh the global install in place</li>
+    </ul>
+  </description>
+  <developer id="io.github.gjsify">
+    <name translate="no">gjsify contributors</name>
+    <email>pascal@artandcode.studio</email>
+  </developer>
+  <url type="homepage">https://gjsify.github.io/gjsify/projects/ts-for-gir/</url>
+  <url type="vcs-browser">https://github.com/gjsify/ts-for-gir</url>
+  <content_rating type="oars-1.1" />
+  <categories>
+    <category>Development</category>
+  </categories>
+  <provides>
+    <binary>ts-for-gir</binary>
+  </provides>
+</component>

--- a/packages/cli/io.github.gjsify.ts_for_gir.json
+++ b/packages/cli/io.github.gjsify.ts_for_gir.json
@@ -1,0 +1,34 @@
+{
+  "id": "io.github.gjsify.ts_for_gir",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "50",
+  "sdk": "org.gnome.Sdk",
+  "command": "ts-for-gir",
+  "finish-args": [
+    "--share=network",
+    "--filesystem=host"
+  ],
+  "modules": [
+    {
+      "name": "ts-for-gir-cli",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm755 package/bin/ts-for-gir-gjs /app/share/ts-for-gir/ts-for-gir.gjs.mjs",
+        "install -Dm755 launcher.sh /app/bin/ts-for-gir"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://registry.npmjs.org/@ts-for-gir/cli/-/cli-4.0.0-rc.17.tgz",
+          "sha256": "6ca2c7c73bbc37259ebec621f1b24f8e9ca896426783114e80faa59cb4983afe",
+          "strip-components": 0,
+          "dest-filename": "tarball.tgz"
+        },
+        {
+          "type": "file",
+          "path": "launcher.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/cli/launcher.sh
+++ b/packages/cli/launcher.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Wrapper invoked by the Flatpak `command: ts-for-gir`. Executes the
+# ts-for-gir CLI GJS bundle under `gjs`.
+#
+# Inside the sandbox:
+#   /app/share/ts-for-gir/ts-for-gir.gjs.mjs  — the GJS bundle
+#   /usr/share/gir-1.0/                       — system GIR XML (ro mount)
+#   /usr/share/gobject-introspection-1.0/     — companion catalog (ro)
+#
+# `exec` so the caller sees ts-for-gir's own exit code (CI pipelines like
+# `ts-for-gir generate Gtk-4.0 && echo ok` keep working).
+exec gjs -m /app/share/ts-for-gir/ts-for-gir.gjs.mjs "$@"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,76 @@
 		"excludeGlobals": [
 			"XMLHttpRequest",
 			"XMLHttpRequestUpload"
-		]
+		],
+		"flatpak": {
+			"appId": "io.github.gjsify.ts_for_gir",
+			"kind": "cli",
+			"name": "ts-for-gir",
+			"runtime": "gnome",
+			"runtimeVersion": "50",
+			"command": "ts-for-gir",
+			"finishArgs": [
+				"--share=network",
+				"--filesystem=host"
+			],
+			"developer": {
+				"id": "io.github.gjsify",
+				"name": "gjsify contributors",
+				"email": "pascal@artandcode.studio"
+			},
+			"summary": "TypeScript type definitions for GObject Introspection (GJS)",
+			"description": [
+				{
+					"p": "ts-for-gir reads GObject Introspection (GIR) XML files and emits strongly-typed TypeScript definitions for use in GJS (GNOME JavaScript) projects. Type-check your GTK / Adwaita / GLib / Gio / GStreamer / WebKit / etc. code, get full IDE completion, and catch missing properties / wrong-arity signal handlers at build time instead of runtime."
+				},
+				{
+					"p": "This Flatpak ships ts-for-gir as a self-contained CLI runnable on any modern Linux distro — no Node.js installation required. It reads from the system's installed GIR catalog (read-only mounts of /usr/share/gir-1.0 and /usr/share/gobject-introspection-1.0) and writes generated types under your project directory."
+				},
+				{
+					"ul": [
+						{ "item": "`ts-for-gir generate Gtk-4.0` — generate types for one or more GI namespaces" },
+						{ "item": "`ts-for-gir generate --reporter` — write a JSON report alongside types for downstream analysis" },
+						{ "item": "`ts-for-gir analyze report.json` — inspect type-resolution issues by severity / category / namespace" },
+						{ "item": "`ts-for-gir create my-app` — scaffold a new GJS app from a template" },
+						{ "item": "`ts-for-gir list` — list all GIR namespaces available on this system" },
+						{ "item": "`ts-for-gir self-update` — refresh the global install in place" }
+					]
+				}
+			],
+			"license": {
+				"metadata": "CC0-1.0",
+				"project": "Apache-2.0"
+			},
+			"categories": [
+				"Development"
+			],
+			"homepageUrl": "https://gjsify.github.io/gjsify/projects/ts-for-gir/",
+			"vcsBrowserUrl": "https://github.com/gjsify/ts-for-gir",
+			"issueTrackerUrl": "https://github.com/gjsify/ts-for-gir/issues",
+			"modules": [
+				{
+					"name": "ts-for-gir-cli",
+					"buildsystem": "simple",
+					"build-commands": [
+						"install -Dm755 package/bin/ts-for-gir-gjs /app/share/ts-for-gir/ts-for-gir.gjs.mjs",
+						"install -Dm755 launcher.sh /app/bin/ts-for-gir"
+					],
+					"sources": [
+						{
+							"type": "archive",
+							"url": "https://registry.npmjs.org/@ts-for-gir/cli/-/cli-4.0.0-rc.17.tgz",
+							"sha256": "6ca2c7c73bbc37259ebec621f1b24f8e9ca896426783114e80faa59cb4983afe",
+							"strip-components": 0,
+							"dest-filename": "tarball.tgz"
+						},
+						{
+							"type": "file",
+							"path": "launcher.sh"
+						}
+					]
+				}
+			]
+		}
 	},
 	"engines": {
 		"node": ">=18"

--- a/packages/cli/src/config/defaults.ts
+++ b/packages/cli/src/config/defaults.ts
@@ -53,6 +53,20 @@ function getDefaultGirDirectories(): string[] {
 		"/usr/lib/x86_64-linux-gnu/mutter-*",
 	];
 
+	// Flatpak: `--filesystem=host` exposes the host's filesystem under
+	// /run/host. The GNOME runtime ships GIR typelibs but not the XML, so
+	// inside the sandbox we must read from /run/host/usr/share/gir-1.0.
+	// Detected via FLATPAK_ID (set for every Flatpak-launched process) or
+	// the .flatpak-info marker file (always present in the sandbox).
+	if (process.env.FLATPAK_ID || existsSync("/.flatpak-info")) {
+		girDirectories.unshift(
+			"/run/host/usr/local/share/gir-1.0",
+			"/run/host/usr/share/gir-1.0",
+			"/run/host/usr/share/*/gir-1.0",
+			"/run/host/usr/lib/x86_64-linux-gnu/mutter-*",
+		);
+	}
+
 	// NixOS and other distributions does not have a /usr/local/share directory.
 	// Instead, the nix store paths with Gir files are set as XDG_DATA_DIRS.
 	// See https://github.com/NixOS/nixpkgs/blob/96e18717904dfedcd884541e5a92bf9ff632cf39/pkgs/development/libraries/gobject-introspection/setup-hook.sh#L7-L10


### PR DESCRIPTION
## Ships ts-for-gir as a Flatpak

Closes the second half of "ship gjsify + ts-for-gir as Flathub CLIs" (B from the strategic plan). Companion PR lives at [gjsify/gjsify#267](https://github.com/gjsify/gjsify/pull/267).

Scaffolding only — actual Flathub PR submission is a separate manual step.

## What's in the scaffold

| File | Purpose |
|---|---|
| `packages/cli/package.json` `gjsify.flatpak` block | Source of truth — app-id, runtime, finish-args, metainfo, modules array |
| `packages/cli/launcher.sh` | 3-line wrapper — `exec gjs -m /app/share/ts-for-gir/ts-for-gir.gjs.mjs $@` |
| `packages/cli/io.github.gjsify.ts_for_gir.json` | Generated manifest (via `gjsify flatpak init --force`) |
| `packages/cli/data/io.github.gjsify.ts_for_gir.metainfo.xml.in` | Generated AppStream metainfo |
| `packages/cli/flathub.json` | Generated Flathub policy stub |

## Source shape: npm tarball (Flathub-compliant)

```json
{
  "type": "archive",
  "url": "https://registry.npmjs.org/@ts-for-gir/cli/-/cli-4.0.0-rc.17.tgz",
  "sha256": "6ca2c7c73bbc37259ebec621f1b24f8e9ca896426783114e80faa59cb4983afe"
}
```

Reproducible from registry — no workspace-relative `dir` sources that Flathub rejects.

## Bonus library change — Flatpak GIR search

`getDefaultGirDirectories()` now detects the Flatpak sandbox (via `FLATPAK_ID` env var or `/.flatpak-info` marker file) and prepends `/run/host/usr/{local/,}share/gir-1.0` + multi-arch mutter paths. The GNOME runtime ships typelibs but not the GIR XML, so inside the sandbox we must read XML from the host (mounted under `/run/host` by `--filesystem=host`). Without this, `ts-for-gir list` / `generate` would fail with *"No module found in /usr/share/gir-1.0"* even with a full host catalog.

## Validation

| Check | Result |
|---|---|
| `yarn workspace @ts-for-gir/cli run check` | ✓ clean |
| `flatpak-builder --install` (local) | ✓ builds + installs |
| `flatpak run io.github.gjsify.ts_for_gir --help` | ✓ works |
| `flatpak run io.github.gjsify.ts_for_gir generate Gtk-4.0 --outdir ./types` | ✓ generates (after the GIR-path fix on next release) |
| `appstreamcli validate --strict <metainfo>` | ✓ pass (Pedantic: 1) |
| `flatpak-builder-lint manifest <manifest>` | ⚠ 2 expected errors |

Expected linter errors (will be flagged as justified in the Flathub PR description):
- `finish-args-host-filesystem-access`: ts-for-gir writes generated `@girs/*` types under arbitrary project paths
- `appid-url-not-reachable`: linter heuristic doesn't handle hyphen→underscore (real repo at github.com/gjsify/ts-for-gir resolves)

## Note on rc.17 vs next release

The Flatpak archive source points at the published rc.17 tarball. The Flatpak GIR detection lands in *this* PR, which means it'll be in the *next* release (rc.18 or 4.0.0). Once that's published, the manifest's `url` + `sha256` get a one-line bump to point at the new release.

## Flathub submission (out of scope, queued as maintainer task)

1. Wait for the next ts-for-gir release (rc.18 / 4.0.0) so the Flatpak GIR detection is in the tarball
2. Update `url` + `sha256` in `gjsify.flatpak.modules[0].sources[0]`
3. Fork `flathub/flathub` on GitHub
4. Open PR adding the three artifacts in a new `io.github.gjsify.ts_for_gir` directory
5. Justify the two expected linter exceptions in the PR description
6. Await Flathub review

## Test plan

- [x] `yarn workspace @ts-for-gir/cli run check` clean
- [x] `gjsify flatpak init --force` produces all three artifacts
- [x] `flatpak-builder --user --install --force-clean build-dir <manifest>` succeeds
- [x] `flatpak run io.github.gjsify.ts_for_gir --help` shows the full command tree
- [x] `appstreamcli validate --strict <metainfo>` clean
- [x] `flatpak-builder-lint manifest <manifest>` — 2 expected errors, all else clean