### PR TITLE
fix(cli): chain process-templates into build (was prepack-only)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -124,7 +124,7 @@
 	"scripts": {
 		"start": "node bin/ts-for-gir-dev",
 		"start:prod": "node bin/ts-for-gir",
-		"build": "node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings esbuild.ts && chmod +x bin/ts-for-gir-dev && chmod +x bin/ts-for-gir",
+		"build": "node --experimental-specifier-resolution=node --experimental-strip-types --experimental-transform-types --no-warnings esbuild.ts && chmod +x bin/ts-for-gir-dev && chmod +x bin/ts-for-gir && node scripts/process-templates.mjs",
 		"build:gjs": "gjsify build",
 		"build:templates": "node scripts/process-templates.mjs",
 		"prepack": "node scripts/process-templates.mjs",


### PR DESCRIPTION
## The bug

\`ts-for-gir create my-app\` fails on a freshly-installed 4.0.0 CLI with:

\`\`\`
No templates found in <prefix>/node_modules/@ts-for-gir/templates
\`\`\`

The tarball is missing the \`dist-templates/\` directory — \`findTemplatesRoot\` falls through every absent \`dist-templates\` candidate and lands on the sibling \`@ts-for-gir/templates\` package (the ambient-types package, which contains no scaffold templates).

## Root cause

\`@ts-for-gir/cli\`'s scaffold templates were only generated by the \`prepack\` script. But \`gjsify pack\` (used by the release workflow's \`publish:app\` script) does not run npm lifecycle scripts — \`prepack\` / \`prepare\` / \`prepublishOnly\` are all skipped, matching the speed-first design of the native packer but diverging from \`npm pack\`'s behaviour. So \`dist-templates/\` was never produced before packaging.

## Fix

Append \`node scripts/process-templates.mjs\` to the \`build\` script so \`dist-templates\` lands on disk during the regular build pipeline — independent of which packer runs the publish. \`prepack\` is kept as a safety net for direct \`npm pack\` users.

Verified: \`yarn workspace @ts-for-gir/cli run build\` now writes 4 templates under \`packages/cli/dist-templates/\` (types-gjsify, types-locally, types-npm, types-workspace). The published tarball picks them up via the existing \`files: [..., "dist-templates"]\`.

## Followup

Tracked separately in [gjsify/gjsify](https://github.com/gjsify/gjsify): \`gjsify pack\` should honor \`prepack\` / \`prepare\` / \`prepublishOnly\` lifecycle scripts to match \`npm pack\` semantics. Until then, any workspace package that relies on those scripts is silently broken under gjsify-native publish.

## Release plan

This is the only fix on top of 4.0.0. Merge → release 4.0.1 immediately. Users running \`gjsify dlx @ts-for-gir/cli create my-app\` or \`npx @ts-for-gir/cli create my-app\` will then resolve to a working tarball.

## Test plan

- [x] \`yarn workspace @ts-for-gir/cli run build\` produces dist-templates
- [x] \`packages/cli/dist-templates/\` contains all 4 expected scaffold dirs
- [ ] (post-release) Verify \`gjsify dlx @ts-for-gir/cli@4.0.1 create my-app\` lists the 4 templates