### PR TITLE
fix(cli): self-update accepts gjsify-global node_modules location

### DIFF
--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -17,9 +17,35 @@ const GJS_ASSET_NAME = "ts-for-gir-gjs";
 function getCurrentBinaryPath(): string | null {
 	const p = process.argv[1] ?? null;
 	if (!p) return null;
-	// Refuse to update in dev mode (source file or node_modules path)
-	if (p.endsWith(".ts") || p.includes("node_modules")) return null;
+	// Refuse to update in dev mode — running from a source `.ts` file or
+	// from a project-local `node_modules/` (in which case the user should
+	// update via their package manager, not by replacing the binary in
+	// place).
+	if (p.endsWith(".ts")) return null;
+	if (p.includes("/node_modules/") && !isGjsifyGlobalLocation(p)) return null;
 	return p;
+}
+
+/**
+ * Recognise the gjsify-install global location (`~/.local/share/gjsify/global/
+ * node_modules/<pkg>/...`, set up by `gjsify install -g` and `install.js`).
+ *
+ * The previous broad `path.includes("node_modules")` check rejected this
+ * location alongside genuine project-local installs, even though the
+ * gjsify-global location IS the canonical install spot for `ts-for-gir
+ * self-update`. The fix: only refuse updates for paths that contain
+ * `node_modules` AND aren't under the gjsify-global root.
+ *
+ * Matches both XDG_DATA_HOME-rooted and the documented fallback
+ * (`$HOME/.local/share/gjsify/global/`).
+ */
+function isGjsifyGlobalLocation(p: string): boolean {
+	const xdgData = process.env.XDG_DATA_HOME;
+	const home = process.env.HOME;
+	const candidates: string[] = [];
+	if (xdgData) candidates.push(`${xdgData}/gjsify/global/`);
+	if (home) candidates.push(`${home}/.local/share/gjsify/global/`);
+	return candidates.some((root) => p.startsWith(root));
 }
 
 async function fetchJson(url: string): Promise<unknown> {


### PR DESCRIPTION
## The bug

`ts-for-gir self-update` refused to run when ts-for-gir was installed via the **canonical install path** for gjsify users:

```
$ ts-for-gir self-update
Checking for updates... (current: v4.0.0-rc.17)
Updating to v4.0.1...
Cannot determine current binary path for update.
self-update only works when running the installed GJS binary.
```

Root cause: `gjsify install -g @ts-for-gir/cli` (and the `install.js` bootstrap) places the GJS bundle at `~/.local/share/gjsify/global/node_modules/@ts-for-gir/cli/bin/ts-for-gir-gjs`. That path **contains `node_modules`**, which tripped the dev-mode guard (`p.includes("node_modules")`) that was meant to refuse self-updates against project-local installs.

## Fix

New `isGjsifyGlobalLocation()` predicate that distinguishes the two cases:

- **Gjsify-global root** (`$XDG_DATA_HOME/gjsify/global/` or `$HOME/.local/share/gjsify/global/`) → self-update proceeds. This IS the canonical install location.
- **Any other `node_modules` path** → still refuses. The user should run `npm update -g @ts-for-gir/cli` (or equivalent) on those.

Also tightened the substring check from `includes('node_modules')` to `includes('/node_modules/')` to avoid pathological false positives on directory names that merely contain `node_modules` as a substring.

## Why this matters

The whole point of `self-update` is to give users on the Node-free install path a one-command upgrade. Forcing them back to a package-manager-mediated update defeats the purpose.

## Release plan

Ship as 4.0.2 immediately after merge. The fix is one-file, single-function, no test surface beyond what's already there (the dev-mode guard against `.ts` paths is preserved).

## Test plan

- [x] `yarn workspace @ts-for-gir/cli run check` clean
- [ ] (post-release) On a fresh `gjsify install -g @ts-for-gir/cli@4.0.1` → `ts-for-gir self-update` → bumps to 4.0.2 in place
- [ ] (post-release) On a project-local `npm install @ts-for-gir/cli@4.0.2` → `./node_modules/.bin/ts-for-gir self-update` → still refuses with the original message