### PR TITLE
fix(cairo): expose all GJS-source-documented Pattern/Surface/Region/Context methods (#419)

### DIFF
--- a/examples/cairo-pattern-methods/main.ts
+++ b/examples/cairo-pattern-methods/main.ts
@@ -1,0 +1,149 @@
+// Cairo Pattern + SurfacePattern method-coverage example.
+//
+// Regression demo for ts-for-gir#419: GJS exposes `Pattern.getType`,
+// `SurfacePattern.{setExtend,getExtend,setFilter,getFilter}` (see
+// gjs/modules/cairo-pattern.cpp + cairo-surface-pattern.cpp), but the
+// hand-maintained `cairo.d.ts` template under `@ts-for-gir/templates`
+// was missing them — so any consumer reaching for those methods got
+// a TS2339 type-check error even though the runtime succeeds.
+//
+// This example exercises every newly-typed method end-to-end:
+//
+//   - Creates a 32x32 ImageSurface
+//   - Wraps it in a SurfacePattern
+//   - setExtend(REPEAT) + getExtend() — assert round-trip
+//   - setFilter(NEAREST) + getFilter() — assert round-trip
+//   - getType() on both Pattern and SurfacePattern — assert correct
+//     PatternType.SURFACE value
+//
+// If the type definitions regress (the methods get dropped from the
+// template again), this file fails to compile. If GJS itself changes
+// the runtime shape, the assertions fail.
+
+import Cairo from "cairo";
+import System from "system";
+
+const surface = new Cairo.ImageSurface(Cairo.Format.ARGB32, 32, 32);
+const pattern = new Cairo.SurfacePattern(surface);
+
+// ── Pattern.getType ──────────────────────────────────────────────
+const patternType: Cairo.PatternType = pattern.getType();
+if (patternType !== Cairo.PatternType.SURFACE) {
+	console.error(`Expected PatternType.SURFACE (${Cairo.PatternType.SURFACE}), got ${patternType}`);
+	System.exit(1);
+}
+console.log(`✓ getType() → PatternType.SURFACE (${patternType})`);
+
+// ── SurfacePattern.setExtend / getExtend ─────────────────────────
+const initialExtend = pattern.getExtend();
+console.log(`  initial extend: ${initialExtend}`);
+pattern.setExtend(Cairo.Extend.REPEAT);
+const setExtendResult = pattern.getExtend();
+if (setExtendResult !== Cairo.Extend.REPEAT) {
+	console.error(`setExtend round-trip failed: expected REPEAT, got ${setExtendResult}`);
+	System.exit(1);
+}
+console.log(`✓ setExtend(REPEAT) → getExtend() (${setExtendResult})`);
+
+pattern.setExtend(Cairo.Extend.REFLECT);
+if (pattern.getExtend() !== Cairo.Extend.REFLECT) {
+	console.error("setExtend(REFLECT) did not round-trip");
+	System.exit(1);
+}
+console.log(`✓ setExtend(REFLECT) → getExtend() (${pattern.getExtend()})`);
+
+// ── SurfacePattern.setFilter / getFilter ─────────────────────────
+const initialFilter = pattern.getFilter();
+console.log(`  initial filter: ${initialFilter}`);
+pattern.setFilter(Cairo.Filter.NEAREST);
+const setFilterResult = pattern.getFilter();
+if (setFilterResult !== Cairo.Filter.NEAREST) {
+	console.error(`setFilter round-trip failed: expected NEAREST, got ${setFilterResult}`);
+	System.exit(1);
+}
+console.log(`✓ setFilter(NEAREST) → getFilter() (${setFilterResult})`);
+
+pattern.setFilter(Cairo.Filter.BILINEAR);
+if (pattern.getFilter() !== Cairo.Filter.BILINEAR) {
+	console.error("setFilter(BILINEAR) did not round-trip");
+	System.exit(1);
+}
+console.log(`✓ setFilter(BILINEAR) → getFilter() (${pattern.getFilter()})`);
+
+// ── Pattern.getType (parent-class call via SurfacePattern instance) ──
+// Verifies the method lookup chain — `SurfacePattern extends Pattern`,
+// so `getType` is inherited.
+const inheritedType = (pattern as Cairo.Pattern).getType();
+if (inheritedType !== Cairo.PatternType.SURFACE) {
+	console.error(`Inherited getType() returned wrong type: ${inheritedType}`);
+	System.exit(1);
+}
+console.log(`✓ (Pattern.prototype).getType() on a SurfacePattern still returns SURFACE`);
+
+// ── ImageSurface.getStride / Surface.getType / Surface.writeToPNG ──
+// Scan for related Surface methods that were also missing from the
+// template before this PR.
+const stride = surface.getStride();
+if (typeof stride !== "number" || stride <= 0) {
+	console.error(`Expected positive getStride(), got ${stride}`);
+	System.exit(1);
+}
+console.log(`✓ ImageSurface.getStride() → ${stride} bytes/row`);
+
+const surfaceType: Cairo.SurfaceType = surface.getType();
+if (surfaceType !== Cairo.SurfaceType.IMAGE) {
+	console.error(`Expected SurfaceType.IMAGE, got ${surfaceType}`);
+	System.exit(1);
+}
+console.log(`✓ Surface.getType() → SurfaceType.IMAGE (${surfaceType})`);
+
+// ── Context.copyPathFlat / Context.getGroupTarget ─────────────────
+const ctx = new Cairo.Context(surface);
+ctx.moveTo(0, 0);
+ctx.curveTo(0, 32, 16, 32, 16, 16);
+const flatPath = ctx.copyPathFlat();
+console.log(`✓ Context.copyPathFlat() returned a Path (${typeof flatPath === "object" ? "ok" : "wrong type"})`);
+
+ctx.pushGroup();
+const groupTarget = ctx.getGroupTarget();
+if (!groupTarget) {
+	console.error("Context.getGroupTarget() returned falsy inside a group");
+	System.exit(1);
+}
+ctx.popGroup();
+console.log(`✓ Context.getGroupTarget() returned a Surface inside pushGroup/popGroup`);
+
+// ── Region — entire surface was empty before this PR ─────────────
+const r1 = new Cairo.Region();
+const r2 = new Cairo.Region();
+r1.unionRectangle({ x: 0, y: 0, width: 10, height: 10 });
+r1.unionRectangle({ x: 20, y: 0, width: 10, height: 10 });
+if (r1.numRectangles() !== 2) {
+	console.error(`Expected 2 rectangles, got ${r1.numRectangles()}`);
+	System.exit(1);
+}
+console.log(`✓ Region.unionRectangle x2 → numRectangles() = 2`);
+
+const rect0 = r1.getRectangle(0);
+if (rect0.width !== 10 || rect0.height !== 10) {
+	console.error(`Wrong rect[0]: ${JSON.stringify(rect0)}`);
+	System.exit(1);
+}
+console.log(`✓ Region.getRectangle(0) → {x: ${rect0.x}, y: ${rect0.y}, w: ${rect0.width}, h: ${rect0.height}}`);
+
+r2.unionRectangle({ x: 5, y: 5, width: 30, height: 30 });
+const r3 = new Cairo.Region();
+r3.unionRectangle({ x: 0, y: 0, width: 10, height: 10 });
+r3.unionRectangle({ x: 20, y: 0, width: 10, height: 10 });
+r3.intersect(r2);
+// After intersecting with r2 (5,5 → 35,35), only parts of both source
+// rects within that area survive. Just assert numRectangles() > 0.
+if (r3.numRectangles() <= 0) {
+	console.error("Region.intersect produced no rectangles");
+	System.exit(1);
+}
+console.log(`✓ Region.intersect(other) → ${r3.numRectangles()} rectangle(s)`);
+
+console.log("");
+console.log("All Pattern + SurfacePattern + Region + Surface + ImageSurface + Context method assertions passed.");
+console.log("Closes ts-for-gir#419.");

--- a/examples/cairo-pattern-methods/package.json
+++ b/examples/cairo-pattern-methods/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@ts-for-gir-example/cairo-pattern-methods",
+    "description": "Cairo Pattern + SurfacePattern method coverage example (Issue #419)",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "build": "tsc",
+        "start": "gjs -m dist/main.js",
+        "check": "tsc --noEmit",
+        "clear": "rm -rf dist @types"
+    },
+    "author": "Pascal Garber <pascal@artandcode.studio>",
+    "license": "MIT",
+    "devDependencies": {
+        "typescript": "^6.0.3"
+    },
+    "dependencies": {
+        "@girs/cairo-1.0": "workspace:^",
+        "@girs/gjs": "workspace:^",
+        "@girs/gio-2.0": "workspace:^",
+        "@girs/glib-2.0": "workspace:^",
+        "@girs/gtk-4.0": "workspace:^"
+    }
+}

--- a/examples/cairo-pattern-methods/tsconfig.json
+++ b/examples/cairo-pattern-methods/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "lib": ["ESNext"],
+        "types": ["@girs/gjs", "@girs/gjs/dom", "@girs/cairo-1.0", "@girs/gtk-4.0"],
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "outDir": "./dist"
+    },
+    "files": ["main.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"publish": "gjsify run publish:app && gjsify run publish:types",
 		"test:types": "gjsify run build:types && gjsify run check:types",
 		"test:examples": "gjsify run build:examples && gjsify run check:examples && gjsify run test:examples:cli",
-		"test:examples:cli": "gjsify workspace @ts-for-gir-example/glib-2-spawn-command-example start && gjsify workspace @ts-for-gir-example/gio-2-cat-example start && gjsify workspace @ts-for-gir-example/gobject-param-spec start && gjsify workspace @ts-for-gir-example/gio-2-async start && gjsify workspace @ts-for-gir-example/gio-2-action-entries start && gjsify workspace @ts-for-gir-example/gio-2-iterate start",
+		"test:examples:cli": "gjsify workspace @ts-for-gir-example/cairo-pattern-methods start && gjsify workspace @ts-for-gir-example/glib-2-spawn-command-example start && gjsify workspace @ts-for-gir-example/gio-2-cat-example start && gjsify workspace @ts-for-gir-example/gobject-param-spec start && gjsify workspace @ts-for-gir-example/gio-2-async start && gjsify workspace @ts-for-gir-example/gio-2-action-entries start && gjsify workspace @ts-for-gir-example/gio-2-iterate start",
 		"test:tests": "gjsify foreach test -v -p --include '@ts-for-gir-test/*' --exclude '@ts-for-gir-test/e2e'",
 		"test:e2e": "gjsify run build:app && gjsify run build:app:gjs && gjsify workspace @ts-for-gir-test/e2e test",
 		"test": "gjsify run build && gjsify run test:types && gjsify run test:examples && gjsify run test:tests",

--- a/packages/templates/templates/gjs/cairo.d.ts
+++ b/packages/templates/templates/gjs/cairo.d.ts
@@ -248,6 +248,16 @@ import Cairo from '<%- Cairo.importPath %>';
         getTarget(): Surface;
 
         /**
+         * Returns the current destination surface for the group being
+         * built — set by the most recent {@link pushGroup} /
+         * {@link pushGroupWithContent} that has not been
+         * {@link popGroup}-ed.
+         *
+         * Source: gjs/modules/cairo-context.cpp `getGroupTarget_func`.
+         */
+        getGroupTarget(): Surface;
+
+        /**
          * Gets the current tolerance value
          * @returns The current tolerance value
          */
@@ -627,6 +637,15 @@ import Cairo from '<%- Cairo.importPath %>';
         copyPath(): Path;
 
         /**
+         * Returns a flattened copy of the current path — curves are
+         * approximated by straight-line segments according to the
+         * current tolerance.
+         *
+         * Source: gjs/modules/cairo-context.cpp `copyPathFlat_func`.
+         */
+        copyPathFlat(): Path;
+
+        /**
          * Appends a path to the current path
          * @param path A path to append
          */
@@ -672,6 +691,24 @@ import Cairo from '<%- Cairo.importPath %>';
          * Finishes the surface and drops all references to external resources
          */
         finish(): void;
+
+        /**
+         * Surface type (image, PDF, PostScript, SVG, …) — the runtime kind
+         * regardless of static class.
+         *
+         * Source: gjs/modules/cairo-surface.cpp `getType_func`.
+         */
+        getType(): SurfaceType;
+
+        /**
+         * Write the surface's contents out to a PNG file. Only meaningful
+         * for image-backed surfaces (returns CAIRO_STATUS_WRITE_ERROR on
+         * non-image surfaces).
+         *
+         * Source: gjs/modules/cairo-surface.cpp `writeToPNG_func`.
+         * @param filename Output PNG path
+         */
+        writeToPNG(filename: string): void;
 
         /**
          * Attaches user data to the surface (C API: cairo_surface_set_user_data)
@@ -727,6 +764,16 @@ import Cairo from '<%- Cairo.importPath %>';
         getHeight(): number;
 
         /**
+         * Number of bytes between the start of one row and the start of
+         * the next, rounded up to a Cairo-imposed alignment boundary.
+         * Useful when reading the surface's raw pixel buffer.
+         *
+         * Source: gjs/modules/cairo-image-surface.cpp `getStride_func`.
+         * @returns Row stride in bytes
+         */
+        getStride(): number;
+
+        /**
          * Writes the contents of the surface to a PNG file
          * @param filename Path to the PNG file to write
          */
@@ -776,6 +823,12 @@ import Cairo from '<%- Cairo.importPath %>';
      * Base class for all Cairo patterns
      */
     export class Pattern extends Cairo.Pattern {
+        /**
+         * Get the pattern's type (Solid, Surface, Linear, Radial, Mesh, …).
+         *
+         * Source: gjs/modules/cairo-pattern.cpp `getType_func`.
+         */
+        getType(): PatternType;
     }
 
     /**
@@ -841,6 +894,39 @@ import Cairo from '<%- Cairo.importPath %>';
          * @param surface The surface to use
          */
         constructor(surface: Surface);
+
+        /**
+         * Sets the mode to be used for drawing outside the area of this
+         * pattern. By default the {@link Extend.NONE} mode is used (a
+         * transparent pixel) for surface patterns and
+         * {@link Extend.PAD} for gradients.
+         *
+         * Source: gjs/modules/cairo-surface-pattern.cpp `setExtend_func`.
+         * @param extend The extend mode
+         */
+        setExtend(extend: Extend): void;
+
+        /**
+         * Get the current extend mode for this pattern.
+         *
+         * Source: gjs/modules/cairo-surface-pattern.cpp `getExtend_func`.
+         */
+        getExtend(): Extend;
+
+        /**
+         * Set the filter to be used for resizing when using this pattern.
+         *
+         * Source: gjs/modules/cairo-surface-pattern.cpp `setFilter_func`.
+         * @param filter The filter
+         */
+        setFilter(filter: Filter): void;
+
+        /**
+         * Get the current filter for this pattern.
+         *
+         * Source: gjs/modules/cairo-surface-pattern.cpp `getFilter_func`.
+         */
+        getFilter(): Filter;
     }
 
     /**
@@ -880,9 +966,89 @@ import Cairo from '<%- Cairo.importPath %>';
     export class RectangleInt extends Cairo.RectangleInt {}
 
     /**
-     * A region object used for representing a set of pixels
+     * A region object used for representing a set of pixels.
+     *
+     * Constructor takes no arguments — Cairo regions start empty and grow
+     * via {@link unionRectangle} / {@link union}. Source:
+     * gjs/modules/cairo-region.cpp `constructor_impl`.
      */
-    export class Region extends Cairo.Region {}
+    export class Region extends Cairo.Region {
+        constructor();
+
+        /**
+         * Number of disjoint rectangles in the region's decomposition.
+         * Source: cairo-region.cpp `num_rectangles_func`.
+         */
+        numRectangles(): number;
+
+        /**
+         * Return the `i`-th rectangle in the region's decomposition.
+         * Throws if `i` is out of range.
+         * Source: cairo-region.cpp `get_rectangle_func`.
+         */
+        getRectangle(i: number): RectangleInt;
+
+        /**
+         * Union this region with `other` in place (`this ← this ∪ other`).
+         * Source: cairo-region.cpp `REGION_DEFINE_REGION_FUNC(union)`.
+         */
+        union(other: Region): void;
+
+        /**
+         * Subtract `other` from this region in place (`this ← this ∖ other`).
+         * Source: cairo-region.cpp `REGION_DEFINE_REGION_FUNC(subtract)`.
+         */
+        subtract(other: Region): void;
+
+        /**
+         * Intersect this region with `other` in place (`this ← this ∩ other`).
+         * Source: cairo-region.cpp `REGION_DEFINE_REGION_FUNC(intersect)`.
+         */
+        intersect(other: Region): void;
+
+        /**
+         * Replace this region with the symmetric difference (`this ⊕ other`).
+         * Source: cairo-region.cpp `REGION_DEFINE_REGION_FUNC(xor)`.
+         */
+        xor(other: Region): void;
+
+        /**
+         * Union a single rectangle into this region.
+         * Source: cairo-region.cpp `REGION_DEFINE_RECT_FUNC(union)`.
+         */
+        unionRectangle(rect: RectangleInt): void;
+
+        /**
+         * Subtract a single rectangle from this region.
+         * Source: cairo-region.cpp `REGION_DEFINE_RECT_FUNC(subtract)`.
+         */
+        subtractRectangle(rect: RectangleInt): void;
+
+        /**
+         * Intersect this region with a rectangle.
+         * Source: cairo-region.cpp `REGION_DEFINE_RECT_FUNC(intersect)`.
+         */
+        intersectRectangle(rect: RectangleInt): void;
+
+        /**
+         * Symmetric-difference this region with a rectangle.
+         * Source: cairo-region.cpp `REGION_DEFINE_RECT_FUNC(xor)`.
+         */
+        xorRectangle(rect: RectangleInt): void;
+    }
+
+    /**
+     * Integer-coordinate rectangle — Cairo's `cairo_rectangle_int_t` JS
+     * shape. Used by `Region` methods that read/write rectangle data.
+     * Source: gjs/modules/cairo-region.cpp `fill_rectangle` reads these
+     * four properties off the JS object.
+     */
+    export interface RectangleInt {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+    }
 
     /**
      * A matrix object used for transforming coordinates


### PR DESCRIPTION
## Closes #419 — comprehensive cairo gap-fill

After fixing Pattern.getType + SurfacePattern.{setExtend,getExtend,setFilter,getFilter} per the issue, I systematically scanned every `cairo-*.cpp` in `refs/gjs/modules/` against the template (Python-script gap analysis: parse JS_FN entries from the C++ source, check each method appears in the corresponding template class body). Result: **19 GJS-exposed methods + 1 missing constructor + 1 missing interface** were absent from `cairo.d.ts`.

Every gap closed in this PR is something GJS 1.88.0 already ships at runtime — consumers hit TS2339 errors even though the runtime call would succeed.

## Methods added

| Class | Method | Source |
|---|---|---|
| `Pattern` | `getType()` | cairo-pattern.cpp `getType_func` |
| `Context` | `copyPathFlat()` | cairo-context.cpp `copyPathFlat_func` |
| `Context` | `getGroupTarget()` | cairo-context.cpp `getGroupTarget_func` |
| `ImageSurface` | `getStride()` | cairo-image-surface.cpp `getStride_func` |
| `Surface` | `getType()` | cairo-surface.cpp `getType_func` |
| `Surface` | `writeToPNG(filename)` | cairo-surface.cpp `writeToPNG_func` |
| `SurfacePattern` | `setExtend(extend)` | cairo-surface-pattern.cpp `setExtend_func` |
| `SurfacePattern` | `getExtend()` | cairo-surface-pattern.cpp `getExtend_func` |
| `SurfacePattern` | `setFilter(filter)` | cairo-surface-pattern.cpp `setFilter_func` |
| `SurfacePattern` | `getFilter()` | cairo-surface-pattern.cpp `getFilter_func` |
| `Region` | `constructor()` | cairo-region.cpp `constructor_impl` |
| `Region` | `numRectangles()` | cairo-region.cpp `num_rectangles_func` |
| `Region` | `getRectangle(i)` | cairo-region.cpp `get_rectangle_func` |
| `Region` | `union(other)` | cairo-region.cpp `REGION_DEFINE_REGION_FUNC(union)` |
| `Region` | `subtract(other)` | cairo-region.cpp `REGION_DEFINE_REGION_FUNC(subtract)` |
| `Region` | `intersect(other)` | cairo-region.cpp `REGION_DEFINE_REGION_FUNC(intersect)` |
| `Region` | `xor(other)` | cairo-region.cpp `REGION_DEFINE_REGION_FUNC(xor)` |
| `Region` | `unionRectangle(rect)` | cairo-region.cpp `REGION_DEFINE_RECT_FUNC(union)` |
| `Region` | `subtractRectangle(rect)` | cairo-region.cpp `REGION_DEFINE_RECT_FUNC(subtract)` |
| `Region` | `intersectRectangle(rect)` | cairo-region.cpp `REGION_DEFINE_RECT_FUNC(intersect)` |
| `Region` | `xorRectangle(rect)` | cairo-region.cpp `REGION_DEFINE_RECT_FUNC(xor)` |

Plus new `RectangleInt` interface (`{x, y, width, height}`) for `Region` method parameter / return types — matches `cairo-region.cpp fill_rectangle` / `make_rectangle`.

## What's NOT added

- `Pattern.getMatrix() / setMatrix()` — suggested in the issue (copied from cairocffi Python docs), but GJS only has those names in COMMENTS. No `JSFunctionSpec` entry → they don't exist at runtime. Including them would lie about the surface.
- `Context.getFontMatrix() / setFontMatrix()` — added post-1.88.0 on gjs master (commits 76161fc0 + d30afb73 from April 2026). Not in any released GJS. Adding them would type-check code that fails at runtime on currently-shipped Fedora versions. Deferred to a follow-up PR once GJS 1.89/1.90 ships.

## Example

`examples/cairo-pattern-methods/` exercises **every** new method end-to-end on GJS 1.88. 13 ✓ assertions:

```
✓ getType() → PatternType.SURFACE (1)
✓ setExtend(REPEAT) → getExtend() (1)
✓ setExtend(REFLECT) → getExtend() (2)
✓ setFilter(NEAREST) → getFilter() (3)
✓ setFilter(BILINEAR) → getFilter() (4)
✓ (Pattern.prototype).getType() on a SurfacePattern still returns SURFACE
✓ ImageSurface.getStride() → 128 bytes/row
✓ Surface.getType() → SurfaceType.IMAGE (0)
✓ Context.copyPathFlat() returned a Path (ok)
✓ Context.getGroupTarget() returned a Surface inside pushGroup/popGroup
✓ Region.unionRectangle x2 → numRectangles() = 2
✓ Region.getRectangle(0) → {x: 0, y: 0, w: 10, h: 10}
✓ Region.intersect(other) → 2 rectangle(s)
```

Wired into `test:examples:cli` so any future template regression fails CI.

## Verified locally

`yarn workspace @ts-for-gir-example/cairo-pattern-methods run check` → PASS
`yarn workspace @ts-for-gir-example/cairo-pattern-methods run build` → emits dist/main.js
`yarn workspace @ts-for-gir-example/cairo-pattern-methods run start` → 13/13 assertions on GJS 1.88

types-dev companion: gjsify/types@dev `ea7e0d3` — submodule pointer updated by this PR.