### PR TITLE
fix(deps): bump stale @gjsify/cli@^0.4.19 → ^0.4.23 in lockfile

### DIFF
--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -37,7 +37,7 @@
     "inquirer@^13.4.2",
     "typedoc@^0.28.19",
     "yargs@^18.0.0",
-    "@gjsify/cli@^0.4.19",
+    "@gjsify/cli@^0.4.23",
     "@types/ejs@^3.1.5",
     "@types/inquirer@^9.0.9",
     "@types/node@^25.6.2",


### PR DESCRIPTION
Follow-up to #421. The lockfile's \`requested\` array carries TWO \`@gjsify/cli\` entries — one for the root workspace (was \`^0.4.22\`) and one for the cli pkg itself (was \`^0.4.19\`). My v0.4.23 bump script only matched the \`^0.4.22\` spec, leaving the \`^0.4.19\` entry stale.

CI now fails at \`gjsify install --immutable\` with:

> \`install: --immutable but gjsify-lock.json is stale.\`
> \`- @gjsify/cli@^0.4.19\`

…because the \`@gjsify/cli@^0.4.19\` spec no longer has a matching lockfile install (the actual install entry was bumped to 0.4.23 alongside the rest of the @gjsify/* tree).

## Fix

Single-line patch: \`@gjsify/cli@^0.4.19\` → \`@gjsify/cli@^0.4.23\` in the lockfile's \`requested\` array. No other change.

## Why a separate PR

#421 is already merged. This one-line touch up restores \`gjsify install --immutable\` so CI on PR #417 turns green.