### PR TITLE
ci(build-validate): stop recursive submodule checkout — fixes gitlab.gnome.org 503 crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          submodules: true
+          # Skip recursive submodule checkout: the reference-only
+          # `refs/*` submodules under gitlab.gnome.org regularly 503
+          # and crash CI even though `build-validate` doesn't read
+          # them (it only consumes `types-dev` for the generator
+          # diff). Match the selective pattern the other jobs use.
+          submodules: false
+      - name: Checkout types-dev submodule
+        run: |
+          git config --global --add safe.directory "*"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git submodule update --init types-dev
       - name: Detect changed paths
         uses: dorny/paths-filter@v3
         id: filter


### PR DESCRIPTION
The `build-validate` job's `actions/checkout@v6` step used `submodules: true`, which **recursively** clones every submodule listed in `.gitmodules`. Most of those (`refs/devdocsgjs`, `refs/gi-docgen`, `refs/gjs`, `refs/gjs-guide`, `refs/gnome-shell`, `refs/gtk-doc`, `refs/library-icons`) live on **gitlab.gnome.org** and are reference-only material — they are NOT read by anything in the build pipeline.

When gitlab.gnome.org throws 503 ([which it just did in run #26359770945](https://github.com/gjsify/ts-for-gir/actions/runs/26359770945/job/77596883557)) the entire job crashes with:

```
fatal: unable to access 'https://gitlab.gnome.org/...': 503
fatal: clone of 'https://gitlab.gnome.org/...' into submodule path 'refs/...' failed
Failed to clone 'refs/...' a second time, aborting
```

## Fix

Switch to the same selective pattern the `check` / `test-units` / `test-e2e` jobs already use: `submodules: false` on checkout, then a single targeted `git submodule update --init types-dev` step. `types-dev` is the only submodule `build-validate` actually needs — for the `cd ./types-dev && git diff | cat` generator-diff step after `build:types`.

## Why this is the right fix at the core

Reference-only submodules (`refs/*`) exist for human/IDE consultation per the workspace convention; CI doesn't read them. Pulling them anyway just to discard them adds:

- ~30+ unnecessary network calls per job run (one per submodule)
- Multi-minute checkout time even on a healthy day
- A cross-host SPOF (gitlab.gnome.org outages → ts-for-gir CI red)
- Aborted runs whenever any single submodule URL flakes

The fix is two lines (`submodules: true` → `submodules: false`, plus the explicit `git submodule update --init types-dev` step that mirrors the other three jobs). Test plan: this PR's own CI exercises the `build-validate` path on a fresh runner without recursive submodules.