### PR TITLE
chore: bump @gjsify/cli to ^0.4.26 (fixes #392)

### DIFF
--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -10,7 +10,7 @@
     "release-it@^20.0.1",
     "rimraf@^6.1.3",
     "typescript@^6.0.3",
-    "@gjsify/cli@^0.4.25",
+    "@gjsify/cli@^0.4.26",
     "vite@^8.0.11",
     "@needle-di/core@^1.1.2",
     "esbuild@^0.28.0",
@@ -348,8 +348,8 @@
       "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gda-6.0": {
@@ -358,11 +358,11 @@
       "integrity": "sha512-7I7edX34M124BiElbI/BHK5yBByWYTkQ8WMTltTGoAFUPg0EC6xiP3KyvzS2DxUFdgTwC+8xicOUQay07QsNxQ==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
-        "@girs/libxml2-2.0": "2.0.0-4.0.1",
         "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1"
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/libxml2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@girs/gio-2.0": {
@@ -371,9 +371,9 @@
       "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1"
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/giounix-2.0": {
@@ -383,9 +383,9 @@
       "dependencies": {
         "@girs/gjs": "4.0.1",
         "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1"
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gjs": {
@@ -393,10 +393,10 @@
       "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
       "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1"
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/glib-2.0": {
@@ -443,69 +443,69 @@
       "dependencies": {
         "@girs/gjs": "4.0.1",
         "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1"
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/abort-controller": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.25.tgz",
-      "integrity": "sha512-DQa3xszLaSYwkGgRe/1LyGqb9gLpJEqtD6mgo4s25xi9PyGfixc1qxRyuxAgKXdG0MjYb8YMvkKWXOzRuYBb2w==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.26.tgz",
+      "integrity": "sha512-vE65kTZuAq5lzeDzBNmQQHj3I5wmQFWm/GgI2CTbwpLhapu6yltFOxaqYuOC/Jf37EoHrK1T/WAZHvyv0EZK/g==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.25"
+        "@gjsify/dom-events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/assert": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.25.tgz",
-      "integrity": "sha512-WZLQt0bIbnXJRPwTiZVv0CqPde5+NSsLVlc541GUuh0UdBs5Yfqpi4uLeCD6RKXwvfNnhlUBJ/SKN43pyuG0OQ=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.26.tgz",
+      "integrity": "sha512-aGNFZQEtUsKokmbJ+FskDKUPsPTJA82B8W4srDb3O9l/49H9NYptrsfpKXdK5h2fC3Ueu4dF+11b8G0xznv7DQ=="
     },
     "node_modules/@gjsify/async_hooks": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.25.tgz",
-      "integrity": "sha512-f1iyobExU9uQsANcV7mw0v0L55RuB7xqL6BWv2mkTEgEfdrtHTyShNuncYO8HcmDL2m/kvAuiwpT3gw84eTEWw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.26.tgz",
+      "integrity": "sha512-ULd58rJ69lgZ8q3/w+kD2p6k/mFHsLEV3B4vFV6dN6RxzvJ1pzOuLE4zDIO7G9JqLo9hPY2Ax1vSRHxDvEY1TQ==",
       "dependencies": {
-        "@gjsify/events": "^0.4.25"
+        "@gjsify/events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/buffer": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.25.tgz",
-      "integrity": "sha512-kYxdb1J325o6Vw6lYOcSJoV3eHRoHXencaYLa4UCqS5IYC4LwHqBVZlZoDrX4DrH3FkBfVeBrMnd/vyDTKmtQg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.26.tgz",
+      "integrity": "sha512-qzuCit4Lk/8fHCcVuv4MdEJQThKIMhIkn8ig/Ecj70Q61T7ALNF9s3wGrrcMROomdqyDMSRuSXMQ+VYVW+d9XQ==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/child_process": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.25.tgz",
-      "integrity": "sha512-TcvNUXjSLhuTvnfAaXv9nd+xgOPl8Ve9ytbfJH/qyVKnDo0JQfx+229719j1AkGEZtj4YHqrvXXugjAYFe9tnQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.26.tgz",
+      "integrity": "sha512-5RJu4ngzbYBqQ2n4CO9vrBF0sjQNWeqvrC6bQBMURto/evN/OcyHQW5EtSA8hv7MZv3BKoKx2aMlc/NQf1DJUw==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/cli": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.25.tgz",
-      "integrity": "sha512-PbnG7jwTDPS8Y1e9xi6T1Hp5eC35kP5/QnIbZlJDRzn7Cv1gnOSUuNl/Y18PSW7eIxyETMDzdp+EPUTLPvCkXw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.26.tgz",
+      "integrity": "sha512-R18YuaLR7xow2mmdJ2HssOROSkbrSPUT2ytziDQwL3jXuW7MF8xH/xg0q9fBWW6MkhPRgq14B/ubDBcds5uatw==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/create-app": "^0.4.25",
-        "@gjsify/node-globals": "^0.4.25",
-        "@gjsify/node-polyfills": "^0.4.25",
-        "@gjsify/npm-registry": "^0.4.25",
-        "@gjsify/resolve-npm": "^0.4.25",
-        "@gjsify/rolldown-plugin-gjsify": "^0.4.25",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.25",
-        "@gjsify/semver": "^0.4.25",
-        "@gjsify/tar": "^0.4.25",
-        "@gjsify/web-polyfills": "^0.4.25",
-        "@gjsify/workspace": "^0.4.25",
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/create-app": "^0.4.26",
+        "@gjsify/node-globals": "^0.4.26",
+        "@gjsify/node-polyfills": "^0.4.26",
+        "@gjsify/npm-registry": "^0.4.26",
+        "@gjsify/resolve-npm": "^0.4.26",
+        "@gjsify/rolldown-plugin-gjsify": "^0.4.26",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.26",
+        "@gjsify/semver": "^0.4.26",
+        "@gjsify/tar": "^0.4.26",
+        "@gjsify/web-polyfills": "^0.4.26",
+        "@gjsify/workspace": "^0.4.26",
         "cosmiconfig": "^9.0.1",
         "get-tsconfig": "^4.14.0",
         "pkg-types": "^2.3.1",
@@ -517,190 +517,190 @@
       }
     },
     "node_modules/@gjsify/cluster": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.25.tgz",
-      "integrity": "sha512-maEfnmEV+M76CU1S04kl7x63LtabVnf4DTc/6cwYCHaNHPAXZULHebmt+UeNFbUUM9R2Qmt2qKQqIYAymz8HTA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.26.tgz",
+      "integrity": "sha512-dJ4zKSdoJE9BAWgqIifzCZq+cGOtDqHvkswDoHVBjRtComgILxb+dxQKn/rBLyl5DVGzrFATUmDs4mtBmUmGJg==",
       "dependencies": {
-        "@gjsify/events": "^0.4.25"
+        "@gjsify/events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/compression-streams": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.25.tgz",
-      "integrity": "sha512-UicQlM1wbDFWjUKzNS+VWGCA9bitZLpzzItSlbeYW4nJt2r1IBF0p6QCxpg0f6ZPsOgU6B/nDNLydmZT0rnsyg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.26.tgz",
+      "integrity": "sha512-41lIhTVsjUtlu3ssBGuXtpGyL7o163AUo+axjr55erBLrFFDh3Nz/ZnLH29mDNZbJdKtBWmoTDRDBKrRzbRzJQ==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.4.25"
+        "@gjsify/web-streams": "^0.4.26"
       }
     },
     "node_modules/@gjsify/console": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.25.tgz",
-      "integrity": "sha512-PzMJFAwYFKxZfiHDR9fohg3hzMpBd4u0NBP+dqup4QuW3IPVFlUEKOmbmYiKJkyq/PsSCvg8Rq5DZr4epVA4GQ=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.26.tgz",
+      "integrity": "sha512-CCNTtWeHxugUgUQeivWSQI3wfMWjEEe3u/gj5V+nGP1OZ9Kui5kqZV5QUI7PwtphWzjjP5/Diye2CtqtfwPCzA=="
     },
     "node_modules/@gjsify/constants": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.25.tgz",
-      "integrity": "sha512-gzu5HxlPjIFJsQAa4nCgdZ6iWIukR4KI8bjt4ifoyc82RPgVdaQA7tmudz2BOdCtTGOLdfSrgEUXTinf95fX2g==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.26.tgz",
+      "integrity": "sha512-Xxhg1YRzeFkvLnAehq4wGj+Yl5ErE9GBSkgBmIoC3vk9KgbYkuCPyxvpuSaPvqZPGh/JLiuqpUNQ7DTpXsAD6g==",
       "dependencies": {
-        "@gjsify/crypto": "^0.4.25",
-        "@gjsify/fs": "^0.4.25",
-        "@gjsify/os": "^0.4.25"
+        "@gjsify/crypto": "^0.4.26",
+        "@gjsify/fs": "^0.4.26",
+        "@gjsify/os": "^0.4.26"
       }
     },
     "node_modules/@gjsify/create-app": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.25.tgz",
-      "integrity": "sha512-wfciF0cICJIGtjKclargRdP+CmsX5z+/8uZhXv6qJUpO1Ve9UAzl0MoVxnofLRaM6W68XxnXQzFa/UWLDzasOw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.26.tgz",
+      "integrity": "sha512-v0tr8sT4uzTVVD80YnVrWukjBPtcAjaG0yEqyaM7oaV0hcGaAH+kAhcqmQ35LX5osX8RWY3VhvFd2OrxK6XtCA==",
       "dependencies": {
         "yargs": "^18.0.0"
       },
       "bin": "./lib/index.js"
     },
     "node_modules/@gjsify/crypto": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.25.tgz",
-      "integrity": "sha512-K5qWZlxeL+nWvq4K/KxakaDdhSXmWZzmMRAoxw0UgtwOGVcWJKTGIiTN3BrzttsXrHzaYHOOOxE3U0BFgIBq2g==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.26.tgz",
+      "integrity": "sha512-v8Z7TNC91NZwIvRt2qx7WX8RrUz3vtyVDZ8da7gJ07ySpni1zaKh6t3t2ToplddnmihEOj8U0DOYS/2r6jWYdQ==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/stream": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/stream": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/dgram": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.25.tgz",
-      "integrity": "sha512-x5tC84vxcGqFpzQWyqBSkqOyZlQZhohx7PJ0mvf81wi/voU4Qy46TgsRWE80PJvUsXz6IOV6qNQ1hMZOpmBCvQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.26.tgz",
+      "integrity": "sha512-Rli8swCYQGQ/i54OLgm8EHVJFP2XvGSJQAu1Ah7Taju+N7puwSJb7VnUTDPrUfR3iXyq5FoAAcJ1lnbIusjN4A==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/diagnostics_channel": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.25.tgz",
-      "integrity": "sha512-7vBZGIHJEe2sF7H7HoE22Y7CdvX+Xl2SeQliZO+ae2bsWZ5azW5e+9lYsqncTnd2Hri0IVJmTkEeuRA9AlD+rw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.26.tgz",
+      "integrity": "sha512-pcvd5kCXGKb5PLZmMTKFbCKw2syOn9aJBr6IX+K0UyM+Ixq1+Y1wWNZtMhePw+fOQIOspg13WJNJtoxCN1V2Ww=="
     },
     "node_modules/@gjsify/dns": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.25.tgz",
-      "integrity": "sha512-PNrN79rFNdIwfgW04mlI2YBEwbcIzr+43wYComG8XB9zc6Y5zRI/nyRkOQboyjEAAnj3KDTe7kBgQmh4TJgDiw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.26.tgz",
+      "integrity": "sha512-uFFnRh2oXJlN7Hv6guqhXejUe9rtv1c4nQzTfUbEfIvN669fHWMHfhW5V0+RHNNCi6K8Jk1EKzKtGVcaod09YA==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/net": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/net": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/dom-events": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.25.tgz",
-      "integrity": "sha512-FffumYj/1rKvcFey8uhQuGVdHCrZuBBBVAUoFZloNfkZT1EKV7aDeZ1Hy5nq3gmyKDVyXWAFcVQodiM+Pv5fUA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.26.tgz",
+      "integrity": "sha512-PKunr1Ix/dqWW2sLQh0o6OAcv45kVI5ZH6ocgJoPAkr4OmNd8gGaG/q7PZKCBfErq+Wf9L1x92KRiWxEVH/Bfg==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.25"
+        "@gjsify/dom-exception": "^0.4.26"
       }
     },
     "node_modules/@gjsify/dom-exception": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.25.tgz",
-      "integrity": "sha512-j6gWLJv1+xSqTtBFAHK7oIzZHb2zqNIb50EfJqjag7V3ccBf3zu15NwqHYyuJNzmMKnxoq1lEA4p9wycTcZUeA=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.26.tgz",
+      "integrity": "sha512-Jk9yHdkBIbktAHe3cbfGd9plML02fIm2LQ0fGNIgWvS8tmRCmllDrS5rYSJJ4Ms17d+4QhUQlTD7Zh9j+shn4g=="
     },
     "node_modules/@gjsify/domain": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.25.tgz",
-      "integrity": "sha512-QhDXmY6SfaWErO2rsI1Zo8h1cyx5jLoIPp9mGnyefLzoh6Co8piELA0cXh15ctRDRBgWti/xKMEElgqzBz6Z+Q==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.26.tgz",
+      "integrity": "sha512-QdeS3rq++7BMkCMOtI4ZIHYpILyoW7NCv0DEW++5yMBsEYSJUKxnriIcJqQGbE8smsPzEPwFLvmQ5zlOaEbkgA==",
       "dependencies": {
-        "@gjsify/events": "^0.4.25"
+        "@gjsify/events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/domparser": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.25.tgz",
-      "integrity": "sha512-vwE7t7dlIrS+12tCaFylqNv3WgZcTsu7PStIQWF1L5C2t+V0a5aQkZf+Fk10xvD20ecR1/kyxVpuAKqtIfsJiA=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.26.tgz",
+      "integrity": "sha512-4iv0Kl8f1D4lBGq7CSeW4ppt91GIdVbDkq40unWnXXx4603XeCKWdi+Le2srS6HgsWQZ6h7jL5/ojALJL5RWkw=="
     },
     "node_modules/@gjsify/events": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.25.tgz",
-      "integrity": "sha512-R5lxhMe6raJexTFtQGCL+3SSjeQXrsI6qBG5uphiwEwNuMX+lJEWmhOJvl0vL0bLIGQTqrc0KL3hO+MDpkLPug==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.26.tgz",
+      "integrity": "sha512-sJ8RtwWXfRUHGDLatbzzLfQZG24rEkHpeCk3ic1dhgktXf/lmTqaFN4j8IP27jf3O317+WuJpNelSpxLKKA7uw==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/eventsource": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.25.tgz",
-      "integrity": "sha512-OoIbMLFrBuojN6lAlj4XznuYemQO1Xcf/Qlwff02NZ2MzRIZyP7kMJv9w+4paecy5lYhJqWbRP341A64ALn5+g==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.26.tgz",
+      "integrity": "sha512-edri1rrfUY3LrEogEOwQGqnG5eLA5Xmu4dcdW4MHEzTrlekKJOh9YzOeEcPNLrdfRE360vQDXUlOPZCuX8SvGg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.25",
-        "@gjsify/web-streams": "^0.4.25"
+        "@gjsify/dom-events": "^0.4.26",
+        "@gjsify/web-streams": "^0.4.26"
       }
     },
     "node_modules/@gjsify/fetch": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.25.tgz",
-      "integrity": "sha512-oPj5Ifk5dM6+jxD2h8pKoVPii5hClfP8APL6MVfpFJ8rwYFYS5CsKoT1iT/V74Y57pyHnam1l5FjnJMpo8e0tA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.26.tgz",
+      "integrity": "sha512-iGe3gcoNDDAAhEFAqzJ4zq9Ye09VNU5/DH8APp2MmOKtdQRtWL4j1+kY79hofzZjDfk0CycHCzDsWHcKnalNZQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/formdata": "^0.4.25",
-        "@gjsify/http": "^0.4.25",
-        "@gjsify/url": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/formdata": "^0.4.26",
+        "@gjsify/http": "^0.4.26",
+        "@gjsify/url": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/formdata": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.25.tgz",
-      "integrity": "sha512-hZDMB04rXGPJM4idTGFFN1WwR9WJaiM6LWHdyUBddgXWuJn/wW+A61sE81SpCEanvczyLN+RqwWf13G+sGGI4w=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.26.tgz",
+      "integrity": "sha512-xqKwQRVVlfoPPk4T6a+yeI665Btl2C5vg4FJyPbkQQkNRHTo7Jlytp2tF0CKCPSNxnuCpcIwBeDbLNh9MXRuWg=="
     },
     "node_modules/@gjsify/fs": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.25.tgz",
-      "integrity": "sha512-RM4vwCjgeRjyoRcVqC3IA9gLYsFl2UDz8Iz/VMHUlYORrPkkF98AnBvOHnskrswS7BLQzVSj4dkKRA9t2lejVQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.26.tgz",
+      "integrity": "sha512-oxJbxE1ITOiLDME/Iqyv+tc/kAfHDY+p4Auc/PBzPHZHaYHGbaZI+K3bOH4faJbBbCfWK6FLqQmbYQFPN9MafQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/stream": "^0.4.25",
-        "@gjsify/url": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/stream": "^0.4.26",
+        "@gjsify/url": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/gamepad": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.25.tgz",
-      "integrity": "sha512-WDGRR/8z4MOFmZ8Yny3h4Nd5R0152cn2FBB22VX8UfuQQllsQAgE60UMwqJUczqI69jRj4LsoTUUY55DyA/ofQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.26.tgz",
+      "integrity": "sha512-fNtvXzN1JSW6h4kMxgH5SwPbFLGlOj7ZZRxy0Nq/dXmbqfX1c4Y2iwNd+3jxpRO3opqJnArIAQhhyTvCKvlEwQ==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.25"
+        "@gjsify/dom-events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/http": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.25.tgz",
-      "integrity": "sha512-ZPKOSP8Z2vgdE2S9rTFaCk3mzmcFMj0W+7jp532mY0mWIbwJKDvZ2TKwS1LimfdXPD3kmKeGkyStfdcGYMF2Fw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.26.tgz",
+      "integrity": "sha512-IiHTHeSCvWAW+P8J/h/Dux/CvGt+UbEENc9QCxpzsM69uy25YbuzVdKXT/HQIP13cgtPJNhYmQyGwrdXYtVLAA==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/http-soup-bridge": "^0.4.25",
-        "@gjsify/net": "^0.4.25",
-        "@gjsify/stream": "^0.4.25",
-        "@gjsify/url": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/http-soup-bridge": "^0.4.26",
+        "@gjsify/net": "^0.4.26",
+        "@gjsify/stream": "^0.4.26",
+        "@gjsify/url": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.25.tgz",
-      "integrity": "sha512-znvvmyDZWfcQdBq5Kw18CUEdxb4f9kVY7KLf7BbUpHAIBiqvc44saUFZSePY13o+ngQcxncClsrMaxqMhYzXzA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.26.tgz",
+      "integrity": "sha512-7k2Nd8PLLHkl/GANAUYdXgSkCsuBm5mrVBl8X4O3jwLQYYZu1+l4ZUWwm5sPCeure8/UckO+or4as/pA8QyvOg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
@@ -710,23 +710,23 @@
       }
     },
     "node_modules/@gjsify/http2": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.25.tgz",
-      "integrity": "sha512-pr2a5FUEq604P+HBzkrl+n+M+mIyv0yRyy0SblItToqk/ckUMBfgaAgrGgRHj7r4wtN2i3+wDmsuk10cLOW2rQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.26.tgz",
+      "integrity": "sha512-4jGS8oIvt2nr6Po8DNP0I8OkiQauM0B5jb+uqHIhzXzqxQynd6derAlSIbP+Vex4F9t2rmSSmw8ubw35MUMfzQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gobject-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/http2-native": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/http2-native": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/http2-native": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.25.tgz",
-      "integrity": "sha512-D1od7Xrd9TTF+LtBe7g9Ad/xCMOrao5KUnCjWLZ32GeDdtjIRUS3xzYgsLTFdqbKEk+usInrkFCA053jPGZyHw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.26.tgz",
+      "integrity": "sha512-EU+Y44t0g06D6EPlugQlj/5mBPLwyiPCttKnlYITUSNQ1qhfGPqVjjBJ1IxvJwA0MSQl2OJqTiFnsMfz+NTfQg==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
@@ -734,182 +734,182 @@
       }
     },
     "node_modules/@gjsify/https": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.25.tgz",
-      "integrity": "sha512-8xxM8oOcSC60t6C6jDlo+ZUOyW/O/xa6STkOo4O7uxcOfe7tJPRtbNhmhU1NecLz1dYX6lJjrZWx0ik1HWR74Q==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.26.tgz",
+      "integrity": "sha512-FF/OfeGf8tUiqwacvX4kNyYU+MvSvWPs2n372bscZuU+7a/Maq9uqCyoWdnMszRb2ocLcRP3l/EVIOmNyLr77w==",
       "dependencies": {
-        "@gjsify/http": "^0.4.25",
-        "@gjsify/tls": "^0.4.25"
+        "@gjsify/http": "^0.4.26",
+        "@gjsify/tls": "^0.4.26"
       }
     },
     "node_modules/@gjsify/inspector": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.25.tgz",
-      "integrity": "sha512-v/RYDzIpzEtiYihQqNiNW9+CMCQ0J0AU53kgU5bm62afd9WLfoRtaQoEmxlZNvjiwKhdSeO45+oHY+i9Qbf9tA=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.26.tgz",
+      "integrity": "sha512-vKkpKvKwpGkoJ6pO9NM6Dunc+J3z54BJ5sQT5xZ5+0OSQqeb8RPRc4BttROcEM1zBctfPxPmKL85Modzv72EHQ=="
     },
     "node_modules/@gjsify/message-channel": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.25.tgz",
-      "integrity": "sha512-EHzixlpbWGXj0wp6eSbslIfbkzgNd/CkkLF7ObnV7cVbEmbQpRwCCzplm6BNW+eD/bBxnOLTNya7BvNTi1+j3Q==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.26.tgz",
+      "integrity": "sha512-N+Ufi9b6dnymiK7aSvOrlQ/na7Qs9rUOxszNYX72FXaRUTdLQ6CmTIGKFN8Q/gZRgxw6pfzjfMEe9cNNMa+hjw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.25"
+        "@gjsify/dom-events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/module": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.25.tgz",
-      "integrity": "sha512-ZNS4TrfhnxTjW7VbtOLiset4bfS79e0tFXyMjPX05r3xJPDMmNKG+TyoVf9xTWocjja4qlLst+zHDZ+TLAqNXg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.26.tgz",
+      "integrity": "sha512-crNR9icJPvky4L3gyrJOrgUth3odzRNb4X6pwMVSPVSxfpJLZQUY9dW77fzGmsvx1pa3EHO+HG6SJW5/h9rCMg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/net": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.25.tgz",
-      "integrity": "sha512-P9bL9ITRnduClaC/eUdmU+4RPXwboLZnTzrVA9WtqS0/lel0Sz80QgXaN2SmDoyeB+fbv23/KqdF+0bYC45JvQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.26.tgz",
+      "integrity": "sha512-xCeiLhHSk7BB2H/BZI7Th9Fjb+hy/dXxU1bsUudErjFokqEavoS+qS0/0r2B8BnJfs/4qu62n7SgTInCqjQZwg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/stream": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/stream": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/node-globals": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.25.tgz",
-      "integrity": "sha512-xhebLwVuTvf9tlBchNqIT5Y+fX4WHiTJV4wyGow7TWwx798xoP2DFQcKPOIFiVMBSE7+I41dC8IN432PzTxqCg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.26.tgz",
+      "integrity": "sha512-i6Nrtj37OV3CCGdg4AT8wnbQ/0uKK2vv4zuYX9DEk/Q7ivVQEAF/xIvo7r4GcSJ+J9CPcSSUwiG6hALqUVZ+bw==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/process": "^0.4.25",
-        "@gjsify/url": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/process": "^0.4.26",
+        "@gjsify/url": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/node-polyfills": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.25.tgz",
-      "integrity": "sha512-iBm6N0KSPuFNRAB4/SHNxy5UDMjycUHY5Ow/OU26ApsG912mcmwLkOisqz4M/eM83jGgTO5/shWv2yMMfaG6fg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.26.tgz",
+      "integrity": "sha512-U+JrKJeJN+DCs13vhjL7aMp55p0FyPxGRVfV5wSoqd1spDjD6d5BYh3EEYrz94Gnp3sKKCQz1pCIRp2EMdTROQ==",
       "dependencies": {
-        "@gjsify/assert": "^0.4.25",
-        "@gjsify/async_hooks": "^0.4.25",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/child_process": "^0.4.25",
-        "@gjsify/cluster": "^0.4.25",
-        "@gjsify/console": "^0.4.25",
-        "@gjsify/constants": "^0.4.25",
-        "@gjsify/crypto": "^0.4.25",
-        "@gjsify/dgram": "^0.4.25",
-        "@gjsify/diagnostics_channel": "^0.4.25",
-        "@gjsify/dns": "^0.4.25",
-        "@gjsify/domain": "^0.4.25",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/fs": "^0.4.25",
-        "@gjsify/http": "^0.4.25",
-        "@gjsify/http2": "^0.4.25",
-        "@gjsify/https": "^0.4.25",
-        "@gjsify/inspector": "^0.4.25",
-        "@gjsify/module": "^0.4.25",
-        "@gjsify/net": "^0.4.25",
-        "@gjsify/node-globals": "^0.4.25",
-        "@gjsify/os": "^0.4.25",
-        "@gjsify/path": "^0.4.25",
-        "@gjsify/perf_hooks": "^0.4.25",
-        "@gjsify/process": "^0.4.25",
-        "@gjsify/querystring": "^0.4.25",
-        "@gjsify/readline": "^0.4.25",
-        "@gjsify/sqlite": "^0.4.25",
-        "@gjsify/stream": "^0.4.25",
-        "@gjsify/string_decoder": "^0.4.25",
-        "@gjsify/sys": "^0.4.25",
-        "@gjsify/timers": "^0.4.25",
-        "@gjsify/tls": "^0.4.25",
-        "@gjsify/tty": "^0.4.25",
-        "@gjsify/url": "^0.4.25",
-        "@gjsify/util": "^0.4.25",
-        "@gjsify/v8": "^0.4.25",
-        "@gjsify/vm": "^0.4.25",
-        "@gjsify/worker_threads": "^0.4.25",
-        "@gjsify/zlib": "^0.4.25"
+        "@gjsify/assert": "^0.4.26",
+        "@gjsify/async_hooks": "^0.4.26",
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/child_process": "^0.4.26",
+        "@gjsify/cluster": "^0.4.26",
+        "@gjsify/console": "^0.4.26",
+        "@gjsify/constants": "^0.4.26",
+        "@gjsify/crypto": "^0.4.26",
+        "@gjsify/dgram": "^0.4.26",
+        "@gjsify/diagnostics_channel": "^0.4.26",
+        "@gjsify/dns": "^0.4.26",
+        "@gjsify/domain": "^0.4.26",
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/fs": "^0.4.26",
+        "@gjsify/http": "^0.4.26",
+        "@gjsify/http2": "^0.4.26",
+        "@gjsify/https": "^0.4.26",
+        "@gjsify/inspector": "^0.4.26",
+        "@gjsify/module": "^0.4.26",
+        "@gjsify/net": "^0.4.26",
+        "@gjsify/node-globals": "^0.4.26",
+        "@gjsify/os": "^0.4.26",
+        "@gjsify/path": "^0.4.26",
+        "@gjsify/perf_hooks": "^0.4.26",
+        "@gjsify/process": "^0.4.26",
+        "@gjsify/querystring": "^0.4.26",
+        "@gjsify/readline": "^0.4.26",
+        "@gjsify/sqlite": "^0.4.26",
+        "@gjsify/stream": "^0.4.26",
+        "@gjsify/string_decoder": "^0.4.26",
+        "@gjsify/sys": "^0.4.26",
+        "@gjsify/timers": "^0.4.26",
+        "@gjsify/tls": "^0.4.26",
+        "@gjsify/tty": "^0.4.26",
+        "@gjsify/url": "^0.4.26",
+        "@gjsify/util": "^0.4.26",
+        "@gjsify/v8": "^0.4.26",
+        "@gjsify/vm": "^0.4.26",
+        "@gjsify/worker_threads": "^0.4.26",
+        "@gjsify/zlib": "^0.4.26"
       }
     },
     "node_modules/@gjsify/npm-registry": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.25.tgz",
-      "integrity": "sha512-Gga5OYGIyxkQ3dXTDKbDyvriJcXjaE5n17QXsYFzqY0eIXgSw8Zt48ilGJOZZIoX7XV8Le/3Mkj9rBmCxEMoGQ=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.26.tgz",
+      "integrity": "sha512-o25GZKW0R+zfSO0GzMSLWktRsMqoR9J++NO/0u3ayapVvnMGWDTLWQxRdtOGpNpTAiWwOVoT/2n2r9Jn5T1umA=="
     },
     "node_modules/@gjsify/os": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.25.tgz",
-      "integrity": "sha512-8WrtGT4cVQb2uNEmOpXtfFpa2mPbx5uJ3ANrU2l/acXFg9h16LvLFS82nLHR9LIhu84PvzW6oRJW6iochG/9jg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.26.tgz",
+      "integrity": "sha512-I4df+pKCRBE8tWiwMUo2AzW9mOc2t0/XEwtu7LcJGxmiS/q7AcPnVCCWgjBuHOYU6yl9c6w0IYshV0srEFOo0A==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/path": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.25.tgz",
-      "integrity": "sha512-7msVr1KBftNO18o8ui7Oo4EOcBNghIO/1inZKjuirs8eSEx07LibepV5OEzwvsr/MAo9jN3hYm+5ujJcdY1pTw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.26.tgz",
+      "integrity": "sha512-aB4SpsM31UakzMRFsI0PxnoCyDSNzpD8e/EhdIC4fHo+VtRyRl5Jn+6fynV9K6HVbI1TPgKaMyAWn5J6RDT22w=="
     },
     "node_modules/@gjsify/perf_hooks": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.25.tgz",
-      "integrity": "sha512-/OLMh0WpeKeENF1gMbHM8ZH6oTS26gT/VTFlgxlfVm0ft/+QmmZytmkmB9l8hfEnLGjjsXkGoRPy2BlPn0Mhfw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.26.tgz",
+      "integrity": "sha512-aQbthR8SlXfToY4bC9lWtHO8tUjAbGrkuTyhB1V6fActv2vimWhUVVJ6n8VY2w58Los6lHuFSBr7U3W2vWNXjQ=="
     },
     "node_modules/@gjsify/process": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.25.tgz",
-      "integrity": "sha512-KbWbf0O5rHpjZ2KnZpVm8B5qB2x13M1pUeLqEPuaVkKBpiPR5+otO57Qfdc4SXpetlh0zri/KAl9nASDD1GLJw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.26.tgz",
+      "integrity": "sha512-XGv9OFmFnnjQUc5NcaTVRAi9/u5zSp3qvozcjEK/wDRCsN1QuBHgbdij1vusM+yWSJh73gh0l7k9UvJ0eNAmnw==",
       "dependencies": {
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/terminal-native": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/terminal-native": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/querystring": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.25.tgz",
-      "integrity": "sha512-VHCtJLcKIZKqXxxdDRO0IKM2K6LPJdn5Aoyzgh06l/O8S1X9AVEYLO21VKMMRouG1owtsxRL+wXL0vKAad3LIQ=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.26.tgz",
+      "integrity": "sha512-IhYl+XdvWdWJ2rI4nCYJOQapsHYYMRDpYPFWo3rnwwzzQfm0ax1pL6cvwrcSLnxT84v2g3xFDYnBowMl61ctVA=="
     },
     "node_modules/@gjsify/readline": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.25.tgz",
-      "integrity": "sha512-gUdElXu6tV6wqXH8QFr1+TJKWPPTzmSfnQGGSArwJ07kQHWtKKBt5bRXRicZn3EoXsYZHT1quqqsGKlPfIPI0g==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.26.tgz",
+      "integrity": "sha512-3iOByLdVDG/RPcuhMO3ZRLeMg7WY2jJMUxtyKuskVODYfIC68utFyN2brtCHhiJS9rCRKVJuX2mqhuRoXNl7Ew==",
       "dependencies": {
-        "@gjsify/events": "^0.4.25"
+        "@gjsify/events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/resolve-npm": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.25.tgz",
-      "integrity": "sha512-cqjFX40hBSRGsWcv9m73DJa9iLmGEQIoJSBfBqwcrAtyGoEaqLe+0CfcBL/DhzzCUfQJJKfOjRFTrDLE7+//QA=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.26.tgz",
+      "integrity": "sha512-vS1yMh1ni+Qr9FaHV4H7tDScm2H89mHN+rnaSWQh4XhMYZpV+m+B/UJnPb9uGCcd6MHfr7QmG+VXpCNMRqT7Cg=="
     },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.25.tgz",
-      "integrity": "sha512-uoB5AX4iJu38AoiFpxE8tdRSVipnxQbqQjAI8BzxQ+vI39AC9eK7hTdbjghYlTNlGQsQp3D2cQpHFb0nkJR+Iw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.26.tgz",
+      "integrity": "sha512-DoSnFNNUtCTO6RYjZyjkRxXBROgtnwPA4viBQl09o4OVgUy4A1h+nLzNqt1G0DgdrQFc/IDDtVWVNKSPUWDgjg==",
       "dependencies": {
         "@deepkit/type-compiler": "^1.0.19",
         "typescript": "^6.0.3"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.25.tgz",
-      "integrity": "sha512-7rMYfCmQoTFLmuGSMp6aafcvq902E7gO3QYLHp/dGvpONERxhdX31qQaCnIzqO9Gv1x7pv5PQKeSaZwtLLAFfg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.26.tgz",
+      "integrity": "sha512-+huE4KO/UHng8TAfZTyATDxFwdWxG4548YhlJaWxgaeat0PeR8F4gvrwmKH6MWrfaDD5PLCqz7VK+zrEUA5grg==",
       "dependencies": {
-        "@gjsify/console": "^0.4.25",
-        "@gjsify/resolve-npm": "^0.4.25",
-        "@gjsify/rolldown-plugin-deepkit": "^0.4.25",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.25",
-        "@gjsify/vite-plugin-blueprint": "^0.4.25",
+        "@gjsify/console": "^0.4.26",
+        "@gjsify/resolve-npm": "^0.4.26",
+        "@gjsify/rolldown-plugin-deepkit": "^0.4.26",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.26",
+        "@gjsify/vite-plugin-blueprint": "^0.4.26",
         "@rollup/pluginutils": "^5.3.0",
         "acorn": "^8.16.0",
         "acorn-walk": "^8.3.5",
@@ -918,23 +918,23 @@
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/vite-plugin-blueprint": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.25.tgz",
-      "integrity": "sha512-Wtvr0z5CTxqbkuSkE2u+w+fCTpp16FMwEJiwTgrBzib+MuGilgbjSleRKIbrgmoH33IxpTYOp2QRf+9ETM/ZxA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.26.tgz",
+      "integrity": "sha512-SwK+hGzVh0BlmVZD2t4/Nuo73pQ6lch1TGrDxOLXfyBYxMe8W4Nr+n19Un7io6XpARiCBXvqlEgwYptPg87vHw==",
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.25.tgz",
-      "integrity": "sha512-qvK68zVyj8hYfwPQRDDsREnjERfHQJsv3sltNcQPkJZftkKKEU++/3IpNs0Rn8OLeJlCWdmKsxipjr75uXCZUw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.26.tgz",
+      "integrity": "sha512-f2eG21TJU6pvnAISdYOQ3GArvQBq+DRf76GGe3tpFXC3CgPlCfUcxT0iKLDpbwemOEzS+Rqmm/o/lsnoyWY0gg=="
     },
     "node_modules/@gjsify/sab-native": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.25.tgz",
-      "integrity": "sha512-W4xGzIj7uniH2LSINCkpl+JRex5QY1biJ7OVb3PUpcNIPBxQarMmgn6Xr0uDl8QRFCo/LjbR20TviCW1YnVekw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.26.tgz",
+      "integrity": "sha512-lpWs3SC3QWS3MrDa0hfor8I056Ti+7zVVmKgjI01I+6m63nA00iPvBtEYgdYmfLSYaH7pndiOn23pJXwXjl/Kw==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
@@ -943,14 +943,14 @@
       }
     },
     "node_modules/@gjsify/semver": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.25.tgz",
-      "integrity": "sha512-gRBspcsfEQ41U5KLs0/bmrHQQ9BXG+Npf6jdKbR1GpJiraWMdfZC2upxf/Ghp9kBXr1JJdxtA3yn+n6w4kcJWw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.26.tgz",
+      "integrity": "sha512-Y9J3G1VcvsN/TrwKn5RBtZKLtqC8AqNQYOqWPyKHHAi9Y0+LeFWu9O9XzLQr3SWEG4tV0Gv6AFp5cDiRHXM15w=="
     },
     "node_modules/@gjsify/sqlite": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.25.tgz",
-      "integrity": "sha512-7E5aZgsmqK6NQkhLnTfL9XX09gdBsmJ6CTw/26monRxRIH3dVCGSqNxJ0BdkLvO3jivQDGDu926iGjSRbUzjMQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.26.tgz",
+      "integrity": "sha512-pJXu08ZR7i1DZnwszoXcuoI/I0Np6AW79lqW/E0XeFpWWg3WQtlR0DA2lSUcoOLtOvnNbZEt7wJMMWFozlnMlQ==",
       "dependencies": {
         "@girs/gda-6.0": "6.0.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
@@ -958,98 +958,98 @@
       }
     },
     "node_modules/@gjsify/stream": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.25.tgz",
-      "integrity": "sha512-1zI0wpDDZ6ndMaeQBxAwzx5oioS2o46mcOzkrLPvVxPsSmdhxAoXybyLv/7+IYNqrBn/eSj9kFRr4XGyPwxLCQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.26.tgz",
+      "integrity": "sha512-WxpKcZrJU7goEQsrrW6HYwx2QQfnNUfz+OPYO3GAMRvlMRSqtdyq0IszfU/IP/ey6WIJuCUkdZUN67rUkj9Z+A==",
       "dependencies": {
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/utils": "^0.4.25",
-        "@gjsify/web-streams": "^0.4.25"
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/utils": "^0.4.26",
+        "@gjsify/web-streams": "^0.4.26"
       }
     },
     "node_modules/@gjsify/string_decoder": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.25.tgz",
-      "integrity": "sha512-81bEW95KLEd0qEK/EDQb1lINvfWLbuDWAN2/beBROCkxrHScBuYfb5rVFopM7Han8TPxaedp924M+7QCPrfgJA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.26.tgz",
+      "integrity": "sha512-Dlr0Ph3Atx/XH6tljPCAHELf+AreSasr+YfJhOzC4oLvWTHzRZOhu3wb+rxKnXa1mJwxsdtHesiLtrWIO/ldPA==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.25"
+        "@gjsify/buffer": "^0.4.26"
       }
     },
     "node_modules/@gjsify/sys": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.25.tgz",
-      "integrity": "sha512-GFNo1or2/aFTjFdWAGyYYsSfua3K1z7R7Ir55DRqYhAk+CPSPGIMHKYEvYv0V9bwSHvqp8IxAgfR5/qj6r8QKA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.26.tgz",
+      "integrity": "sha512-M0/9fm8wDOWW+2zGb+VtjUgZuknoqGnyE4MKlacryVm6zqrC1BbJlrIORFK8xA83CB36Ep7PrPOnr8IWMRrIzw==",
       "dependencies": {
-        "@gjsify/util": "^0.4.25"
+        "@gjsify/util": "^0.4.26"
       }
     },
     "node_modules/@gjsify/tar": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.25.tgz",
-      "integrity": "sha512-xBw88o3KRVdG7dRwO/B2oE+eGapemipVPLsIwGhrfNnz4lKCyhZGS7yOMBtGfjIZjV35uGyPU8WjbgbdvjQqpg=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.26.tgz",
+      "integrity": "sha512-9Dlh2bGKHHlqzMDpGUx7ux0xmHYT48YOjVxPf7b4bkoTVOK8Zb132sRpcMWqP9bhxkdR6FFBSynQoI+cKnyeoQ=="
     },
     "node_modules/@gjsify/terminal-native": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.25.tgz",
-      "integrity": "sha512-BgVRZnb37kgIFw852+BZDnZfY27VZlmGDpiR8LDkH7JBoF87UfA7DJDRksICV1/I1vvZa5LQ0InGy5sPLkNv2A==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.26.tgz",
+      "integrity": "sha512-RNbG1TOzYH+fUdZVJb2To15yYIGMwjQWYJjbwf2H7BpEOdM311bpOyqh+ZkQ0ydv2VKq8QH29gaFHWrz5C0YLA==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/timers": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.25.tgz",
-      "integrity": "sha512-ADF9aaH0egxIQGQiCIYee7Ix8j+ErtFybUhfjskF6x15a+sOL6RntCKo8T+U7AvycEyFfy0qJjiSmJAD9WqlLw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.26.tgz",
+      "integrity": "sha512-L2x8QEUqFTT+PFyhGNGIkug9wCR+sv/Z4huLdygwpcd74lM9br0hKa92mYeYKMWgUP8jImVl1eLFgYt/4yOZQw=="
     },
     "node_modules/@gjsify/tls": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.25.tgz",
-      "integrity": "sha512-UKg2SHCOw2HYxkSuxPP7wd0RYbdRZ6H5pK20lfRJr8gETa0TTwGlJu9dha+zuhXq2CK9cvx9iwO4rXlFafQ/XQ==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.26.tgz",
+      "integrity": "sha512-M634DK7wuMjfOtwJ9sP1wEkOvINZVT2y7LBz0btB5dyEO8uyiZySj/T/Tl8FO4IfFned27CjMf0auEO9dAm+TQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/net": "^0.4.25",
-        "@gjsify/tls-native": "^0.4.25",
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/net": "^0.4.26",
+        "@gjsify/tls-native": "^0.4.26",
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/tls-native": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.4.25.tgz",
-      "integrity": "sha512-EitfhwlLNvF06Tv6Ieh0yCU5vrgf7rxe3wisppUzzfaS9AXENb2RvI63vTJ9pZDVYzGhIjP+ORhluBCRvPvlAw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.4.26.tgz",
+      "integrity": "sha512-0vtilEwA9W8kUbmv5xYmgUFYjtEpafyy7oVctb1pCsVU+Ry3amObGdJtGiwY6hfDduuClE/FSyiXfpJTRIsDzw==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tty": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.25.tgz",
-      "integrity": "sha512-MwzwAUZ0RiKSRYd++5Xo3O0e3MYQQnY8b3Bw6C2k89LwXlv8/YZI767Ronb3ET7tFsuYHORLEFSmNfUQMtSrvw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.26.tgz",
+      "integrity": "sha512-/I89n7GxCp6GHFgkKUXURl1OeSXbn8jJiJIW24vx+TmY61q8g0AGnYuaBg33VcdQJF2AENS+Gz3esbesKKJWQw==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/stream": "^0.4.25",
-        "@gjsify/terminal-native": "^0.4.25"
+        "@gjsify/stream": "^0.4.26",
+        "@gjsify/terminal-native": "^0.4.26"
       }
     },
     "node_modules/@gjsify/url": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.25.tgz",
-      "integrity": "sha512-ScM9EnGCvVGcGEB7l1MyWIYXXh64viZL6N7f+CtekN37sZ2BD57OVL5+2U7fgS7Av6P7Za+0W4q98OhGMGXaag==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.26.tgz",
+      "integrity": "sha512-2NM+bt7vSBHo7Xujp7bV/PnsgEu7iLlubqF4PYwMqaTGlU2bogFCNKl2ebGEm9IWDlLy6bODF0QbPg4rWhnU/w==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/util": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.25.tgz",
-      "integrity": "sha512-Dk2BNPM5y+dd1RyuueMbFBoZGJjTiYS6uYo2uIou8xhQJgg2SqivYJsIc+nlVcyF3O2jvHAq36Dv0dKA04JCJw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.26.tgz",
+      "integrity": "sha512-p+GoIcUqFXKqI46JiomDlX236nyLHlCUtuLX6ENVoDhWUOaW92JfqsI4P8nmoe48eZH1cRAk6vDobWEAyDY1xQ=="
     },
     "node_modules/@gjsify/utils": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.25.tgz",
-      "integrity": "sha512-SqPB4vKx3ezdQN4ovSfgsiPwGVLqbZJ0A0RBA5zrs/bAB+Ekc0HXGsP/uYnA4JlHvmqWSUFILLo8nUM85y6gIA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.26.tgz",
+      "integrity": "sha512-Bl6ykg+P2Vp+XOJMxYqJPd8wr3l5xSoUTuM+ORWW6+MFuKCFmWGSmsTZI8hRmPvVyO9XdKiUwtPKEqeZELQHUQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/giounix-2.0": "2.0.0-4.0.1",
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@gjsify/v8": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.25.tgz",
-      "integrity": "sha512-wrEnOcLtUZAy6N9ZAqAfRrFVbdNSL2acAIWWsNwZ8maP5oBaXXk4gijjWbGVUF9Vyg8KDx1mrata6jiy9xPHKA=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.26.tgz",
+      "integrity": "sha512-+ZECzCjH96h4VcFCbK4C3ifP1PJDXOuCKyvKJcBJdNuM2eX8rTtew+FTBz8bKQIAo821R11aLmhgXDFKG49zCw=="
     },
     "node_modules/@gjsify/vite-plugin-blueprint": {
       "version": "0.3.21",
@@ -1072,133 +1072,133 @@
       }
     },
     "node_modules/@gjsify/vm": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.25.tgz",
-      "integrity": "sha512-kLzLEBJzmNdb9zcI2m3GmbEtrtx0XO0Tlv83xfsEcw48wbhSmPga2DX4qi3vQ+FZb7Tt839k1JIvyoW9WnxlOg=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.26.tgz",
+      "integrity": "sha512-XzQcHSOz9ULPYiHecWxnRZk/gcS6E3czqRzeIqB5tnM3oUJPqA9ENSm5UxzO5gHwQ3HZE0Zz+hyif6s6FkANRQ=="
     },
     "node_modules/@gjsify/web-globals": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.25.tgz",
-      "integrity": "sha512-xemkuNvIXJEi47ahqFZ01+FEei4RaJbxo6gnbFfN0rCvJdT4Wz7kfMQbwdIDODoMWamuKjBCzkw9AB1blErH2Q==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.26.tgz",
+      "integrity": "sha512-CoudD9XC5GpfE7yecDVM26kKXpyU6DFy0RDx87qBhgT6ZzllykZiiA3ZTAdRoseKiS7iIb/9O73XVrZa01RzLw==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.25",
-        "@gjsify/buffer": "^0.4.25",
-        "@gjsify/compression-streams": "^0.4.25",
-        "@gjsify/dom-events": "^0.4.25",
-        "@gjsify/dom-exception": "^0.4.25",
-        "@gjsify/eventsource": "^0.4.25",
-        "@gjsify/formdata": "^0.4.25",
-        "@gjsify/gamepad": "^0.4.25",
-        "@gjsify/perf_hooks": "^0.4.25",
-        "@gjsify/url": "^0.4.25",
-        "@gjsify/web-streams": "^0.4.25",
-        "@gjsify/webaudio": "^0.4.25",
-        "@gjsify/webcrypto": "^0.4.25"
+        "@gjsify/abort-controller": "^0.4.26",
+        "@gjsify/buffer": "^0.4.26",
+        "@gjsify/compression-streams": "^0.4.26",
+        "@gjsify/dom-events": "^0.4.26",
+        "@gjsify/dom-exception": "^0.4.26",
+        "@gjsify/eventsource": "^0.4.26",
+        "@gjsify/formdata": "^0.4.26",
+        "@gjsify/gamepad": "^0.4.26",
+        "@gjsify/perf_hooks": "^0.4.26",
+        "@gjsify/url": "^0.4.26",
+        "@gjsify/web-streams": "^0.4.26",
+        "@gjsify/webaudio": "^0.4.26",
+        "@gjsify/webcrypto": "^0.4.26"
       }
     },
     "node_modules/@gjsify/web-polyfills": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.25.tgz",
-      "integrity": "sha512-WxqnEHM2a7x5EXjhPZ0sdzuU+yZ9wGEnYRB2o5kZpti0Gn5dgtbOwRuujkLaJzN01MgMcHLp5+gYxjfIqEGDcg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.26.tgz",
+      "integrity": "sha512-sDzNvEN5QhiWqtgup6CmvSEqThg2xAHKSi3FlgOW238oan+ZTkhAVL4ngzqQy+FosW+59GpRZ0wDTgDxyTah2g==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.25",
-        "@gjsify/compression-streams": "^0.4.25",
-        "@gjsify/dom-events": "^0.4.25",
-        "@gjsify/dom-exception": "^0.4.25",
-        "@gjsify/domparser": "^0.4.25",
-        "@gjsify/eventsource": "^0.4.25",
-        "@gjsify/fetch": "^0.4.25",
-        "@gjsify/formdata": "^0.4.25",
-        "@gjsify/gamepad": "^0.4.25",
-        "@gjsify/message-channel": "^0.4.25",
-        "@gjsify/web-globals": "^0.4.25",
-        "@gjsify/web-streams": "^0.4.25",
-        "@gjsify/webassembly": "^0.4.25",
-        "@gjsify/webaudio": "^0.4.25",
-        "@gjsify/webcrypto": "^0.4.25",
-        "@gjsify/websocket": "^0.4.25",
-        "@gjsify/webstorage": "^0.4.25",
-        "@gjsify/xmlhttprequest": "^0.4.25"
+        "@gjsify/abort-controller": "^0.4.26",
+        "@gjsify/compression-streams": "^0.4.26",
+        "@gjsify/dom-events": "^0.4.26",
+        "@gjsify/dom-exception": "^0.4.26",
+        "@gjsify/domparser": "^0.4.26",
+        "@gjsify/eventsource": "^0.4.26",
+        "@gjsify/fetch": "^0.4.26",
+        "@gjsify/formdata": "^0.4.26",
+        "@gjsify/gamepad": "^0.4.26",
+        "@gjsify/message-channel": "^0.4.26",
+        "@gjsify/web-globals": "^0.4.26",
+        "@gjsify/web-streams": "^0.4.26",
+        "@gjsify/webassembly": "^0.4.26",
+        "@gjsify/webaudio": "^0.4.26",
+        "@gjsify/webcrypto": "^0.4.26",
+        "@gjsify/websocket": "^0.4.26",
+        "@gjsify/webstorage": "^0.4.26",
+        "@gjsify/xmlhttprequest": "^0.4.26"
       }
     },
     "node_modules/@gjsify/web-streams": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.25.tgz",
-      "integrity": "sha512-x6HZxqeD80n4UTWsw2iXJpqKrTEQjt84PE6o1Oltbqxt6WwErz8IVfBh/H2Nazhbr81E7xadbIBddQwdQpm5YA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.26.tgz",
+      "integrity": "sha512-mktGUluePwLZ22jGx1uBISkpU2XYnJHC/WCsc8azB58NTqZiBz9B+2/GvUAGiYpRmjTtmIVGB5qVY7ODK7tQpw==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.25"
+        "@gjsify/utils": "^0.4.26"
       }
     },
     "node_modules/@gjsify/webassembly": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.25.tgz",
-      "integrity": "sha512-qyVrSjIWDGpumBQPvHDt8WbxTEtIbvHpTqWrSi0FKN5IkHOfRYeMoPrIbrvO1Ep27iAqLE0JkuCTGizDyZfHYQ=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.26.tgz",
+      "integrity": "sha512-RKxRUaFzr51uSOklhIj90y4BZHofULF7YhUeh+Yo1OvWFH93GTM5ItAY7aGIAJ+nRneb3Ve6kGBVtdXbHEucfQ=="
     },
     "node_modules/@gjsify/webaudio": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.25.tgz",
-      "integrity": "sha512-hznrNc9HkTBubWyiPISHukQCS+YD6l/6LFihifOivHfoJCYdt9ZcvHojwRdChvYcSrzMRZAv5iY1nSNDdnGQzg==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.26.tgz",
+      "integrity": "sha512-lhiLJ59iaW2OmbzvRFiOCue0v6sMQYc+iFc157ScE039NKVhFyFniw4qP3vjCw9iUpG/JNoWu3v3Kf0+mpxMyA==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.25"
+        "@gjsify/dom-events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/webcrypto": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.25.tgz",
-      "integrity": "sha512-Nf0DvUypM0hgN7nz3BezNid2J50qSUbPzAhsFXg5GsnfRVsjQ32bQk3OtipfwnGQpG34M0F9h8spnVczrc2Wzw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.26.tgz",
+      "integrity": "sha512-ssySfv42S/4gS/4pZhYdqEYv3d99jJNOpszNDw0kgJiVcBRRuN7Gzd5qYuI6HzHa62NMaFrM0FV1soP7cjTvaQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.25"
+        "@gjsify/dom-exception": "^0.4.26"
       }
     },
     "node_modules/@gjsify/websocket": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.25.tgz",
-      "integrity": "sha512-IlZF2gJmxhv0wAEx755FIpUkQYMYX/jCt8YvzkJx7Xhx8Gnp2l1nWcp+Pe8DnieuB8W10Xxzj9KrwjMai02R3w==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.26.tgz",
+      "integrity": "sha512-F8WpvIA8R0LQjftJS+i2nSjDHpsYStOZIt+RfhAnVBvLBjFDgBTk3mfzT5L8ynPvtuUidpzjNpszL87qIyfP2Q==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/dom-events": "^0.4.25"
+        "@gjsify/dom-events": "^0.4.26"
       }
     },
     "node_modules/@gjsify/webstorage": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.25.tgz",
-      "integrity": "sha512-vjcdxPS0us9fLWkL8PpXj2eqxFFjUpo/ex9ppB0DBor18daeP5YOo98M63HOgYCMGslHDjiJkXHyb+SRA0+4pw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.26.tgz",
+      "integrity": "sha512-hiiRq7qGpYHWVmW+yH4zFY0MGxp+m0iuLTlv+lhl7j5trJMqpkwc+IPCIlNSIG1QiwC0L1nZxRpiNR5a5aEHKw=="
     },
     "node_modules/@gjsify/worker_threads": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.25.tgz",
-      "integrity": "sha512-swST6SMPf9Ue/zi3etjf591bDe0JxFgFHEicr/QMKUsf3OoGfPHOAjLi0Tiof90IetJYJR7RHAShE4HOtx1NyA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.26.tgz",
+      "integrity": "sha512-Mh/nuGpwaKlShi9nEWuwY5lNPLfkuJLcUrTvj3KaP56XCFKjDbdV65ttiPn+tcPYX2Zj1Am54scz0Bd0sS2vbg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/events": "^0.4.25",
-        "@gjsify/message-channel": "^0.4.25",
-        "@gjsify/sab-native": "^0.4.25"
+        "@gjsify/events": "^0.4.26",
+        "@gjsify/message-channel": "^0.4.26",
+        "@gjsify/sab-native": "^0.4.26"
       }
     },
     "node_modules/@gjsify/workspace": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.25.tgz",
-      "integrity": "sha512-Ueo+OZP2E6yLJHiWBcaX8cD3yCXqj86N6Qc/foRF1UhdrOee1zPhTlQN9/iphSOx/1OdJbdO4/FpldH1RJLJgw=="
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.26.tgz",
+      "integrity": "sha512-j4bNJOulrBOohhtZ7oTUgZfsWRXDzIjwZ74n1Cw9w85yGJSolqttaVyBu202wbbG8d+IPzz18NAIbWKqIsG2MQ=="
     },
     "node_modules/@gjsify/xmlhttprequest": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.25.tgz",
-      "integrity": "sha512-+PmV1iyfBM+2mwL7PjFmpODhvk1Z+Mfo4og+Rm7MzQM1BQ7li5WnlegfQu6A7c6VfWVj13safF61iyagmgqGnw==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.26.tgz",
+      "integrity": "sha512-SUYo7conI+pJJN+vkMavQJVet4XSACdqGzUKLGr0cENo5ZdY7WjwNnstUpzfnUdAiNHvII/+qb4nRVEy5lJ7Wg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/fetch": "^0.4.25"
+        "@gjsify/fetch": "^0.4.26"
       }
     },
     "node_modules/@gjsify/zlib": {
-      "version": "0.4.25",
-      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.25.tgz",
-      "integrity": "sha512-lkCsLmk3U8+wsFrL63BQ4wpfcwWZ1o6F1N4vBLPN44KbZjWrSg77/nqqt72+YEIy1E8RkKkU/LRVja+c2ctH5w==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.26.tgz",
+      "integrity": "sha512-UZrlscNedwTNSkavovjpnEkUnsUefsERBZepOH4hAdQTTm7vyHEh3QWZuZvc1HZmS53Ew1kYMqOkz5Ejdz7I9A==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1"
@@ -1608,15 +1608,14 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.9",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.9.tgz",
-      "integrity": "sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A==",
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
       "dependencies": {
         "@octokit/endpoint": "^11.0.3",
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
         "content-type": "^2.0.0",
-        "fast-content-type-parse": "^3.0.0",
         "json-with-bigint": "^3.5.3",
         "universal-user-agent": "^7.0.2"
       }
@@ -2846,9 +2845,9 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.22.tgz",
+      "integrity": "sha512-/e2Ly3Docn9kYByap6TV4oquJ3wQuz3c+kC74riqtkwU9CwTMeuj6t2rW+bRr4pyOx/CYQM4wr0RgaKQwGEz0A==",
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -4213,11 +4212,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="
-    },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"release-it": "^20.0.1",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",
-		"@gjsify/cli": "^0.4.25"
+		"@gjsify/cli": "^0.4.26"
 	},
 	"workspaces": [
 		"examples/*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -165,7 +165,7 @@
 	},
 	"devDependencies": {
 		"@gi.ts/parser": "workspace:^",
-		"@gjsify/cli": "^0.4.25",
+		"@gjsify/cli": "^0.4.26",
 		"@ts-for-gir/generator-base": "workspace:^",
 		"@ts-for-gir/generator-html-doc": "workspace:^",
 		"@ts-for-gir/generator-json": "workspace:^",


### PR DESCRIPTION
Bumps `@gjsify/cli` `^0.4.25` → `^0.4.26` (root + `packages/cli`) and regenerates `gjsify-lock.json`.

## Why

gjsify v0.4.26 ships the **location-independent bundled-dep data-read fix** ([gjsify#311](https://github.com/gjsify/gjsify/pull/311)): a bundled dependency that reads its own on-disk files via `import.meta.url` now resolves them from the bundle's **actual install location at runtime**, instead of a path baked relative to the build location.

That build-relative path was correct in the workspace (CI was green) but doubled to `node_modules/node_modules/<dep>` once the GJS bundle is published and installed at `node_modules/@ts-for-gir/cli/bin/…`. Concretely it crashed the globally-installed `ts-for-gir` GJS CLI at startup when bundled `typedoc` read its i18n / `package.json` files.

Rebuilding `bin/ts-for-gir-gjs` against `@gjsify/cli@0.4.26` resolves that — **fixes #392**.

## Changes

- `@gjsify/cli` `^0.4.25` → `^0.4.26` (root devDeps + `packages/cli` devDeps)
- `gjsify-lock.json` regenerated (`gjsify install`)

No source changes; the fix is entirely in the bundler the GJS CLI is built with.