### PR TITLE
feat(cli): show the active runtime in --help

### DIFF
--- a/packages/cli/src/start.ts
+++ b/packages/cli/src/start.ts
@@ -4,6 +4,29 @@ import { hideBin } from "yargs/helpers";
 
 import { analyze, copy, create, doc, generate, json, list, selfUpdate } from "./commands/index.ts";
 
+/**
+ * Returns a human-readable label for the current JS runtime and version.
+ *
+ * GJS must be checked first: the gjsify Node-compat layer exposes
+ * `process.versions.node` even inside a GJS process, so checking
+ * `imports.system` is the only reliable discriminator.
+ */
+function runtimeLabel(): string {
+	try {
+		const sys = (globalThis as { imports?: { system?: { version?: number } } }).imports?.system;
+		if (sys?.version !== undefined) {
+			const v = Number(sys.version);
+			return `GJS ${Math.floor(v / 10000)}.${Math.floor((v % 10000) / 100)}.${v % 100} (SpiderMonkey)`;
+		}
+	} catch {
+		/* not GJS */
+	}
+	if (typeof process !== "undefined" && typeof process.versions?.node === "string") {
+		return `Node.js ${process.version}`;
+	}
+	return "unknown runtime";
+}
+
 try {
 	const cli = yargs(hideBin(process.argv));
 	await cli
@@ -39,6 +62,7 @@ try {
 		.command(selfUpdate as unknown as CommandModule)
 		.demandCommand(1)
 		.help()
+		.epilogue(`Running on ${runtimeLabel()}`)
 		.parseAsync();
 	process.exit(0);
 } catch (err) {

--- a/tests/e2e/dual-runtime-parity/run.mjs
+++ b/tests/e2e/dual-runtime-parity/run.mjs
@@ -218,13 +218,16 @@ describe('dual-runtime parity: Node bundle vs GJS bundle', { timeout: 10 * 60 * 
       assert.ok(gjsHelp.includes(cmd),  `GJS --help missing "${cmd}"`);
     }
 
-    // Compare word-by-word: yargs wraps usage to terminal width, which Node
-    // (no-TTY → no wrap) and GJS (80-col) resolve differently. Content parity
-    // is what matters, not the cosmetic wrap.
+    // Compare word-by-word, EXCLUDING the per-runtime epilogue line: the CLI's
+    // `--help` ends with `Running on <runtime>` (`Node.js vX` vs `GJS X.Y.Z`),
+    // which is INTENTIONALLY different per runtime — that's the point of that
+    // line. yargs also wraps usage to terminal width differently per runtime,
+    // so word-level comparison ignores the cosmetic wrap too.
+    const stripRuntime = (s) => s.replace(/Running on [^\n]*/g, '');
     assert.equal(
-      normaliseWords(node.stdout),
-      normaliseWords(gjs.stdout),
-      '--help command/option content differs between Node and GJS runtimes',
+      normaliseWords(stripRuntime(node.stdout)),
+      normaliseWords(stripRuntime(gjs.stdout)),
+      '--help command/option content differs between Node and GJS runtimes (excluding the runtime epilogue)',
     );
   });
 


### PR DESCRIPTION
## What

Adds a `runtimeLabel()` helper to `packages/cli/src/start.ts` and wires it into the yargs chain via `.epilogue(...)`, so `ts-for-gir --help` closes with a line like:

```
Running on Node.js v24.x.x
```

or, when invoked via the GJS bundle (`bin/ts-for-gir-gjs`):

```
Running on GJS 1.86.0 (SpiderMonkey)
```

## Why GJS is checked first

The gjsify Node-compat layer running inside a GJS process exposes `process.versions.node`, which would otherwise produce a false "Node.js" label. Checking `imports.system` (the canonical GJS-only global) before falling through to `process.versions.node` avoids this trap — identical logic to what the gjsify CLI uses.

## Consistency

The `runtimeLabel()` function is intentionally identical to the one in the gjsify CLI so both tools show the same format and behavior.

## Verification

- Biome format ran (`biome format --write`): no fixes applied (already clean).
- File reads back as well-formed TypeScript; no heavy install or type-check run performed.