### PR TITLE
fix: dedupe @girs deps with release-only versions

### DIFF
--- a/packages/cli/src/config/options.ts
+++ b/packages/cli/src/config/options.ts
@@ -106,7 +106,7 @@ export const options: { [name: string]: Options } = {
 	depVersionFormat: {
 		type: "string",
 		description:
-			"Dependency version spec format in generated package.json files. Defaults to 'workspace' when --workspace, else 'exact'",
+			"Dependency version spec format in generated package.json files. Defaults to 'workspace' when --workspace, else 'caret'",
 		choices: ["workspace", "caret", "any", "exact"] as const,
 	},
 	onlyVersionPrefix: {

--- a/packages/generator-json/src/gir-metadata-types.ts
+++ b/packages/generator-json/src/gir-metadata-types.ts
@@ -107,7 +107,7 @@ export interface GirNamespaceMetadata {
 	cPrefixes: string[];
 	libraryVersion: string;
 	dependencies: Array<{ namespace: string; version: string }>;
-	/** NPM package version (e.g. "4.20.3-4.0.0-beta.44") */
+	/** NPM package version = the ts-for-gir release version (e.g. "4.0.0-beta.44"); the targeted library version is `libraryVersion` */
 	packageVersion?: string;
 	/** Human-readable display name, e.g. "GTK" */
 	displayName?: string;

--- a/packages/lib/src/dependency-manager.ts
+++ b/packages/lib/src/dependency-manager.ts
@@ -110,20 +110,10 @@ export class DependencyManager {
 		];
 	}
 
-	createImportProperties(namespace: string, packageName: string, version: string, libraryVersion?: LibraryVersion) {
+	createImportProperties(namespace: string, packageName: string, version: string) {
 		const importPath = this.createImportPath(packageName, namespace, version);
 		const importDef = this.createImportDef(namespace, importPath);
-
-		// For GObject and Gio, use GLib's library version if available
-		let effectiveLibraryVersion = libraryVersion;
-		if ((namespace === "GObject" || namespace === "Gio") && this._cache["GLib-2.0"]) {
-			const glibDep = this._cache["GLib-2.0"];
-			if (glibDep.libraryVersion.toString() !== "0.0.0") {
-				effectiveLibraryVersion = glibDep.libraryVersion;
-			}
-		}
-
-		const packageJsonImport = this.createPackageJsonImport(importPath, effectiveLibraryVersion);
+		const packageJsonImport = this.createPackageJsonImport(importPath);
 		return {
 			importPath,
 			importDef,
@@ -155,9 +145,18 @@ export class DependencyManager {
 			: `import type ${namespace} from '${importPath}';`;
 	}
 
-	createPackageJsonImport(importPath: string, libraryVersion?: LibraryVersion): string {
-		const pinnedVersion = libraryVersion ? `${libraryVersion.toString()}-${APP_VERSION}` : APP_VERSION;
-		const format = this.config.depVersionFormat ?? (this.config.workspace ? "workspace" : "exact");
+	createPackageJsonImport(importPath: string): string {
+		// @girs/* package versions are the ts-for-gir release version alone (e.g. `4.0.5`); the
+		// targeted library version lives in each package's `libraryVersion` field, not in the
+		// version string. It used to couple both as `<lib>-<app>` (e.g. `2.88.0-4.0.4`), which made
+		// the ts-for-gir version a semver PRERELEASE tag — so exact pins could not dedupe (any drift
+		// nested a second `@girs/gobject-2.0`: the "Incompatible GObject type" error, #431) and
+		// caret ranges floated onto rc/beta. With a plain release version the non-workspace default
+		// is `caret`: `^4.0.5` dedupes stable patches across ts-for-gir releases AND excludes
+		// prereleases. `--depVersionFormat=exact` stays as the strict-pin opt-in; `--workspace`
+		// still emits `workspace:^`.
+		const pinnedVersion = APP_VERSION;
+		const format = this.config.depVersionFormat ?? (this.config.workspace ? "workspace" : "caret");
 		let depVersion: string;
 		switch (format) {
 			case "workspace":
@@ -294,7 +293,7 @@ export class DependencyManager {
 			version,
 			libraryVersion,
 			girXML,
-			...this.createImportProperties(namespace, packageName, version, libraryVersion),
+			...this.createImportProperties(namespace, packageName, version),
 		};
 
 		// Special case for Cairo

--- a/packages/templates/templates/package.json
+++ b/packages/templates/templates/package.json
@@ -7,10 +7,9 @@ if (packageName === 'Gjs') {
 _%>
 {
     "name": "<%- npmScope %>/<%- importName %>",
-    <%_ if(typeof girModule !== "undefined"){ _%>
-    "version": "<%- girModule.libraryVersion %>-<%- APP_VERSION %>",
-    <%_ } else { _%>
     "version": "<%- APP_VERSION %>",
+    <%_ if(typeof girModule !== "undefined"){ _%>
+    "libraryVersion": "<%- girModule.libraryVersion %>",
     <%_ } _%>
     "description": "<%- PACKAGE_DESC %>",
     "type": "module",

--- a/tests/e2e/cli/run.mjs
+++ b/tests/e2e/cli/run.mjs
@@ -5,7 +5,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, existsSync, readdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -130,6 +130,65 @@ describe('ts-for-gir CLI E2E', { timeout: 10 * 60 * 1000 }, () => {
     const allFiles = readdirSync(outdir, { recursive: true });
     const pkgJsonFiles = allFiles.filter(f => f.endsWith('package.json'));
     assert.ok(pkgJsonFiles.length > 0, 'No package.json files were generated');
+
+    // Regression for #431 ("Incompatible GObject type"). The npm version is the
+    // ts-for-gir release alone (e.g. "4.0.4"); the targeted library version lives in a
+    // `libraryVersion` field, NOT coupled into the version as "<lib>-<app>". Keeping the
+    // version a plain release (not a semver prerelease) lets non-workspace --package emit
+    // caret ranges that pin the package's OWN version: npm/yarn dedupe inter-@girs deps to
+    // a single copy AND caret excludes rc/beta. A coupled "<lib>-<app>" version, or exact
+    // pins, would re-nest a second @girs/gobject-2.0 — the structural mismatch in #431.
+    let girsDepsChecked = 0;
+    let libVerFieldsChecked = 0;
+    for (const rel of pkgJsonFiles) {
+      const pkg = JSON.parse(readFileSync(join(outdir, rel), 'utf8'));
+      // The version must be a plain release, never "<libraryVersion>-<appVersion>".
+      if (pkg.libraryVersion) {
+        libVerFieldsChecked++;
+        assert.ok(!pkg.version.startsWith(`${pkg.libraryVersion}-`),
+          `${rel}: version "${pkg.version}" still couples library version "${pkg.libraryVersion}" (#431)`);
+      }
+      const specs = { ...pkg.dependencies, ...pkg.peerDependencies };
+      for (const [name, spec] of Object.entries(specs)) {
+        if (!name.startsWith('@girs/')) continue;
+        girsDepsChecked++;
+        assert.ok(!spec.startsWith('workspace:'),
+          `${rel}: "${name}" leaked the workspace: protocol in non-workspace mode`);
+        // Caret on the package's own release version: all @girs of one release share it,
+        // so the range dedupes across ts-for-gir releases and (the version being a plain
+        // release) excludes prereleases.
+        assert.equal(spec, `^${pkg.version}`,
+          `${rel}: "${name}" is "${spec}" — expected "^${pkg.version}" (caret on the release version, #431)`);
+      }
+    }
+    assert.ok(girsDepsChecked > 0, 'Expected at least one inter-@girs dependency to assert on');
+    assert.ok(libVerFieldsChecked > 0, 'Expected a libraryVersion field on at least one generated package');
+  });
+
+  it('generate Gtk-4.0 --package --depVersionFormat exact keeps bare pins', () => {
+    const outdir = join(projectWithPkg, 'types-pkg-exact');
+    const result = runCli(cliBin, projectWithPkg, [
+      'generate', 'Gtk-4.0',
+      '--girDirectories', GIRS_DIR,
+      '--outdir', outdir,
+      '--package',
+      '--depVersionFormat', 'exact',
+    ]);
+    assert.ok(!result.error, `generate --package --depVersionFormat exact failed: ${result.stderr}`);
+    const pkgJsonFiles = readdirSync(outdir, { recursive: true }).filter(f => f.endsWith('package.json'));
+    let girsDepsChecked = 0;
+    for (const rel of pkgJsonFiles) {
+      const pkg = JSON.parse(readFileSync(join(outdir, rel), 'utf8'));
+      const specs = { ...pkg.dependencies, ...pkg.peerDependencies };
+      for (const [name, spec] of Object.entries(specs)) {
+        if (!name.startsWith('@girs/')) continue;
+        girsDepsChecked++;
+        // Exact opt-in pins the package's own release version verbatim — no caret.
+        assert.equal(spec, pkg.version,
+          `${rel}: "${name}" is "${spec}" — expected the bare exact pin "${pkg.version}" under --depVersionFormat=exact`);
+      }
+    }
+    assert.ok(girsDepsChecked > 0, 'Expected at least one inter-@girs dependency to assert on');
   });
 
   it('generate with config file works', () => {


### PR DESCRIPTION
Fixes #431 ("Incompatible GObject type").

## Problem

Published `@girs/*` packages exact-pinned each other using a **coupled version** `<libVer>-<appVer>` (e.g. `@girs/gjs@4.0.4` → `"@girs/gobject-2.0": "2.88.0-4.0.4"`). The `-` makes the ts-for-gir version a semver **prerelease tag**, so `2.88.0-4.0.4` is, to npm, a prerelease of `2.88.0`.

With exact pins, any drift between a directly-installed `@girs/gobject-2.0` and the one pinned transitively (via `@girs/gjs`, `@girs/gio-2.0`, …) makes the package manager **nest a second copy**. A real `npm install` of `@girs/gjs@4.0.1` + `@girs/gobject-2.0@2.88.0-4.0.4` produces **six** physical `@girs/gobject-2.0` copies. The two `GObject.Object` types are then nominally (and, across versions, structurally) distinct → `TS2345`:

```
Argument of type '…/@girs/gjs/node_modules/@girs/gobject-2.0…GObject.Object' is not
assignable to parameter of type '…/@girs/gobject-2.0…GObject.Object'.
  Type 'Object' is missing the following properties …: connectObject, connect_object, …
```

Caret ranges would dedupe, **but** on the prerelease-tag scheme `^2.88.0-4.0.4` floats onto future rc/beta — `npm` picks `2.88.0-4.1.0-rc.2` — which can re-trigger the same mismatch with prerelease types. (Verified with the `semver` lib.)

## Fix

Stop encoding the library version as a semver prerelease tag:

- The npm **`version` is the ts-for-gir release alone** (e.g. `4.0.4`).
- The targeted library version moves to a structured **`libraryVersion`** field in each generated `package.json` (also already in the description).
- Because the version is now a plain release, the non-workspace **default dep format is `caret`**: `^4.0.4` **dedupes** stable patches across ts-for-gir releases **and excludes** prereleases (`4.1.0-rc.1` does not satisfy `^4.0.4`).
- `--depVersionFormat=exact` remains the strict-pin opt-in; `--workspace` still emits `workspace:^`.

This also **unifies the scheme** with `@girs/gjs`, which already versioned as the release alone (`4.0.4`).

### Generated output, before → after

```
# before
"version": "2.88.0-4.0.4"
"dependencies": { "@girs/glib-2.0": "2.88.0-4.0.4" }     # exact, coupled → duplicates

# after
"version": "4.0.4"
"libraryVersion": "2.88.0"
"dependencies": { "@girs/glib-2.0": "^4.0.4" }           # caret on the release → dedupes
```

## Migration / compatibility

- Existing `2.88.0-4.0.x` stay published; the next release (`4.0.x`) **outranks** them (`4.0.5 > 2.88.0-4.0.4`), and the publish script already force-sets `--tag latest`, so `latest` advances.
- New `^4.0.x` ranges resolve **only** among new release-versioned packages — they ignore the old prerelease-scheme versions and exclude rc.
- One-time **version decrease** for packages whose library major ≥ the ts-for-gir major: `@girs/gtk-4.0` `4.23.0-4.0.4 → 4.0.x`, `@girs/webkitgtk-6.0` `6.0.0-4.0.4 → 4.0.x`. Installs are unaffected (forced `--tag latest`); only a consumer who pinned a library line via an npm **range** (e.g. `@girs/glib-2.0@^2.88.0`) freezes on the last `2.88.0-*` — an illusory capability, since one ts-for-gir release only ever maps to one library version per package.

## Tests

- `tests/e2e/cli/run.mjs`: the `generate --package` case now asserts every inter-`@girs` dep is `^${pkg.version}` (caret on the release version), no `version` recouples its `libraryVersion`, and libVer'd packages carry the `libraryVersion` field. A sibling case locks the `--depVersionFormat=exact` opt-in to bare pins.
- Verified locally across all three modes (caret default / `exact` / `workspace`) and with `semver` that `^4.0.5` dedupes `4.0.6`/`4.1.0` and excludes `4.1.0-rc.1`/`5.0.0-beta.1`.