### PR TITLE
fix(cli): deterministic gir discovery + Node 24 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,13 @@ jobs:
       - name: Install container prerequisites
         run: |
 
-          dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+          dnf install -y git tar xz findutils curl gjs libsoup3
 
           git config --global --add safe.directory "*"
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -76,8 +80,12 @@ jobs:
     steps:
       - name: Install container prerequisites
         run: |
-          dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+          dnf install -y git tar xz findutils curl gjs libsoup3
           git config --global --add safe.directory "*"
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -109,8 +117,12 @@ jobs:
     steps:
       - name: Install container prerequisites
         run: |
-          dnf install -y git tar xz findutils curl gjs libsoup3 nodejs npm
+          dnf install -y git tar xz findutils curl gjs libsoup3
           git config --global --add safe.directory "*"
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       # The e2e suite's `pack.mjs` now uses `gjsify pack` directly
       # (matches the production `gjsify run publish:app` chain) +
       # walks `package.json#workspaces` globs with Node-native fs,
@@ -162,9 +174,13 @@ jobs:
       - name: Install container prerequisites
         run: |
 
-          dnf install -y git tar xz findutils curl gjs libsoup3 nodejs
+          dnf install -y git tar xz findutils curl gjs libsoup3
 
           git config --global --add safe.directory "*"
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/packages/cli/src/module-loader/file-finder.ts
+++ b/packages/cli/src/module-loader/file-finder.ts
@@ -36,7 +36,16 @@ export class FileFinder {
 					return join(girDirectory, `${cleanIgnored}.gir`);
 				}),
 			);
-			const files = await glob(pattern, { ignore: ignoreGirs });
+			// Sort deterministically: `glob` (v9+) returns matches in the
+			// filesystem's readdir order, which differs between runtimes (Node's
+			// `fs.readdir` vs GJS's Gio-backed `@gjsify/fs.readdir`). When the gir
+			// directory holds case-variant filenames (e.g. `Colorhug-1.0.gir` +
+			// `ColorHug-1.0.gir`, `DMAP-3.0.gir` + `Dmap-4.0.gir`), the module
+			// grouper keeps whichever is seen first as the namespace representative,
+			// so an unsorted order makes `list`/`generate` non-deterministic across
+			// runtimes (the dual-runtime-parity regression). Sorting here makes
+			// discovery order — and thus the grouped output — identical everywhere.
+			const files = (await glob(pattern, { ignore: ignoreGirs })).sort();
 
 			for (const file of files) {
 				foundFiles.add(file);


### PR DESCRIPTION
Unblocks `main`, which has been red on two independent, deterministic CI failures under gjsify 0.14.0. Both are fixed here.

## 1. `test-e2e` — dual-runtime-parity (`fix(cli)`)

The "list: both runtimes agree on GIR namespaces" e2e failed deterministically: the GJS CLI bundle emitted `ColorHug` / `DMAP` while the Node bundle emitted `Colorhug` / `Dmap`.

Root cause: `FileFinder.findGirFiles` fed `glob()` results straight into a `Set` in filesystem readdir order. That order differs between runtimes (Node `fs.readdir` vs GJS's Gio-backed `@gjsify/fs.readdir`). The `./girs` catalog contains case-variant filenames for the same namespace — `Colorhug-1.0.gir` + `ColorHug-1.0.gir`, `DMAP-3.0.gir` + `Dmap-4.0.gir` — and the module grouper keeps whichever file it sees **first** as the namespace representative. Different discovery order → different representative → divergent `list`/`generate` output.

Fix: sort the glob result so discovery order (and thus the grouped output) is identical on every runtime and filesystem.

**Verified locally:** a full `./girs` `list` on freshly built Node and GJS bundles is now byte-identical — 1517 lines, 475 namespaces, zero diff.

## 2. `build-validate` — Node version (`ci`)

gjsify 0.14.0's native install backend is ABI-locked to Node ≥ 24 (it SIGSEGVs on older majors and now preflights with a clear error). `build:types` ends in `&& gjsify install`, which runs under the container's Node, so the Fedora 43 default (Node 22) failed the job.

Every job now pins **Node 24** via `actions/setup-node`, dropping the dnf `nodejs`/`npm` installs (setup-node bundles npm 11 for the `create` e2e scaffold subtests).

**Why Node 24 and not a newer major:** the repo runs its TypeScript directly through `.npmrc` `node-options=… --experimental-transform-types`. Node 26 removed that flag from the NODE_OPTIONS allowlist (`--experimental-transform-types is not allowed in NODE_OPTIONS`), which breaks every `tsc`/CLI invocation for the enum-heavy sources. Node 24 still accepts it and matches `.nvmrc`. Moving to Node 26 would require replacing the NODE_OPTIONS-based TS runner — a separate change.
