### PR TITLE
fix(lib): only claim a version the library states

### DIFF
--- a/packages/lib/src/constants.ts
+++ b/packages/lib/src/constants.ts
@@ -38,7 +38,11 @@ export const APP_SOURCE = "https://github.com/gjsify/ts-for-gir";
 export const APP_VERSION = getPackageVersion();
 
 export const PACKAGE_DESC = (packageName: string, libraryVersion?: LibraryVersion) => {
-	if (libraryVersion) {
+	// "generated from library version X" is a CLAIM, so it is only made when the library
+	// stated X itself. For a namespace-derived version it was false in every published
+	// description: `@girs/gdk-4.0` read "generated from library version 4.0.0" while the
+	// GIR it was generated from came with GTK 4.2x. See LibraryVersion.declaredByLibrary.
+	if (libraryVersion?.declaredByLibrary) {
 		return `GJS TypeScript type definitions for ${packageName}, generated from library version ${libraryVersion.toString()}`;
 	}
 	return `GJS TypeScript type definitions for ${packageName}`;

--- a/packages/lib/src/library-version.ts
+++ b/packages/lib/src/library-version.ts
@@ -5,6 +5,28 @@ export class LibraryVersion {
 	minor: number | undefined;
 	patch: number | undefined;
 
+	/**
+	 * Whether the library ITSELF stated this version, through `MAJOR_VERSION` /
+	 * `MINOR_VERSION` / `MICRO_VERSION` (or the `VERSION_*` spelling) constants in its
+	 * GIR — as opposed to it being derived from the NAMESPACE version in the filename.
+	 *
+	 * The distinction is the entire point, because the two render identically and mean
+	 * completely different things. `Gtk-4.0.gir` declares 4.23.0. `Gdk-4.0.gir` declares
+	 * nothing — GDK ships INSIDE GTK and has no version of its own — so the namespace
+	 * fallback below renders `4.0.0`, a string shaped exactly like a release that
+	 * corresponds to no release. Measured across 32 published `@girs/*` packages: 12
+	 * real, 17 of these, 3 absent.
+	 *
+	 * It only became visible once something tried to USE the field. `@gjsify/cli`'s
+	 * `system-check` compares it against the installed library to catch types describing
+	 * a newer API than the host has — a real defect, reproduced as `tsc` exit 0 beside a
+	 * runtime `TypeError`. Against `@girs/gdk-4.0`'s `4.0.0` and a host GTK 4.22.4 that
+	 * comparison reports an 18-minor skew that does not exist, so the consumer had to
+	 * carry its own list of which packages to believe. A value that must be
+	 * second-guessed per package is worse than no value: this makes absence the answer.
+	 */
+	declaredByLibrary = false;
+
 	constructor(constants: GirConstantElement[] = [], version = "0.0.0") {
 		const [_major, _minor, _micro] = version.split(".").filter((v) => v !== "");
 		if (_major) {
@@ -17,15 +39,26 @@ export class LibraryVersion {
 			this.patch = Number(_micro) || undefined;
 		}
 
+		// The `&& constant.$.value` guard used to bind to the SECOND name only —
+		// `name === "MAJOR_VERSION" || (name === "VERSION_MAJOR" && value)` — so a
+		// valueless `MAJOR_VERSION` constant took the first branch and assigned
+		// `Number(undefined) || undefined`, silently ERASING the component the
+		// namespace fallback had just supplied. Hoisted so the guard covers both
+		// spellings, which is what the shape was always reaching for.
 		for (const constant of constants) {
-			if (constant.$.name === "MAJOR_VERSION" || (constant.$.name === "VERSION_MAJOR" && constant.$.value)) {
-				this.major = Number(constant.$.value) || undefined;
+			const { name, value } = constant.$;
+			if (!value) continue;
+			if (name === "MAJOR_VERSION" || name === "VERSION_MAJOR") {
+				this.major = Number(value) || undefined;
+				this.declaredByLibrary = true;
 			}
-			if (constant.$.name === "MINOR_VERSION" || (constant.$.name === "VERSION_MINOR" && constant.$.value)) {
-				this.minor = Number(constant.$.value) || undefined;
+			if (name === "MINOR_VERSION" || name === "VERSION_MINOR") {
+				this.minor = Number(value) || undefined;
+				this.declaredByLibrary = true;
 			}
-			if (constant.$.name === "MICRO_VERSION" || (constant.$.name === "VERSION_MICRO" && constant.$.value)) {
-				this.patch = Number(constant.$.value) || undefined;
+			if (name === "MICRO_VERSION" || name === "VERSION_MICRO") {
+				this.patch = Number(value) || undefined;
+				this.declaredByLibrary = true;
 			}
 		}
 	}

--- a/packages/templates/templates/package.json
+++ b/packages/templates/templates/package.json
@@ -8,7 +8,11 @@ _%>
 {
     "name": "<%- npmScope %>/<%- importName %>",
     "version": "<%- APP_VERSION %>",
-    <%_ if(typeof girModule !== "undefined"){ _%>
+    <%_ /* Emitted ONLY when the library states its own version (LibraryVersion.declaredByLibrary).
+           Otherwise the value is the NAMESPACE version wearing a release's clothes — `4.0.0` for
+           Gdk-4.0, which ships inside GTK 4.2x — and a consumer comparing it against the installed
+           library reports a skew that does not exist. Absent is the honest answer. */ _%>
+    <%_ if(typeof girModule !== "undefined" && girModule.libraryVersion && girModule.libraryVersion.declaredByLibrary){ _%>
     "libraryVersion": "<%- girModule.libraryVersion %>",
     <%_ } _%>
     "description": "<%- PACKAGE_DESC %>",

--- a/tests/library-version/package.json
+++ b/tests/library-version/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ts-for-gir-test/library-version",
+  "description": "Tests for LibraryVersion — whether a library stated its own version or the namespace version was substituted",
+  "type": "module",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": ["gir", "testing", "version"],
+  "author": "Pascal Garber <pascal@mailfreun.de>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@ts-for-gir/lib": "workspace:^",
+    "vitest": "^4.1.9"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/tests/library-version/src/library-version.test.ts
+++ b/tests/library-version/src/library-version.test.ts
@@ -1,0 +1,133 @@
+// Tests for `LibraryVersion` — specifically the distinction between a version the
+// library STATED and one derived from the namespace in its filename.
+//
+// WHY THIS EXISTS
+//
+// `libraryVersion` is published on every `@girs/*` package and named in gjsify's ADR
+// 0008, and for a long time nothing read it. Once `@gjsify/cli`'s `system-check` began
+// comparing it against the installed library — to catch types that describe a newer API
+// than the host has, a defect reproduced as `tsc` exit 0 beside a runtime `TypeError` —
+// the field turned out to mean two different things with no way to tell them apart.
+//
+// Measured across 32 published `@girs/*` packages: 12 carried a real upstream release,
+// 17 carried the namespace version padded to three components (`@girs/gdk-4.0` →
+// `4.0.0`, while GDK ships inside GTK 4.2x), 3 carried nothing. Compared naively, the
+// middle group reports an 18-minor skew that does not exist, so the consumer had to
+// keep a hand-maintained list of which packages to believe — which is the thing a
+// declaration is supposed to remove.
+//
+// So the constructor now records WHERE the version came from, and the package template
+// omits the field entirely when the library did not state one. Absence is a fact a
+// consumer can act on; a plausible-looking wrong number is not.
+
+import { describe, expect, it } from "vitest";
+
+import { LibraryVersion, PACKAGE_DESC } from "@ts-for-gir/lib";
+import type { GirConstantElement } from "@ts-for-gir/lib";
+
+/** A GIR `<constant>` element, trimmed to the two attributes this reads. */
+function constant(name: string, value?: string): GirConstantElement {
+  return {
+    $: { name, ...(value === undefined ? {} : { value }) },
+  } as unknown as GirConstantElement;
+}
+
+const GTK_CONSTANTS = [
+  constant("MAJOR_VERSION", "4"),
+  constant("MINOR_VERSION", "23"),
+  constant("MICRO_VERSION", "0"),
+];
+
+describe("LibraryVersion", () => {
+  it("reports a version the library states as declared", () => {
+    const version = new LibraryVersion(GTK_CONSTANTS, "4.0");
+    expect(version.toString()).toBe("4.23.0");
+    expect(version.declaredByLibrary).toBe(true);
+  });
+
+  it("accepts the VERSION_MAJOR spelling too", () => {
+    const version = new LibraryVersion(
+      [
+        constant("VERSION_MAJOR", "1"),
+        constant("VERSION_MINOR", "10"),
+        constant("VERSION_MICRO", "0"),
+      ],
+      "1",
+    );
+    expect(version.toString()).toBe("1.10.0");
+    expect(version.declaredByLibrary).toBe(true);
+  });
+
+  it("does NOT report the namespace fallback as declared", () => {
+    // The Gdk-4.0 case: no version constants at all, so the only thing available is
+    // the namespace version from the filename. It still renders — callers that want
+    // a string get one — but it is marked as not the library's own claim.
+    const version = new LibraryVersion([], "4.0");
+    expect(version.toString()).toBe("4.0.0");
+    expect(version.declaredByLibrary).toBe(false);
+  });
+
+  it("treats a bare namespace with no constants as undeclared", () => {
+    const version = new LibraryVersion([], "1");
+    expect(version.declaredByLibrary).toBe(false);
+  });
+
+  it("does not let a VALUELESS constant erase the namespace fallback", () => {
+    // The regression this pins. The guard used to read
+    //   name === "MAJOR_VERSION" || (name === "VERSION_MAJOR" && value)
+    // so a `MAJOR_VERSION` with no value took the FIRST branch and assigned
+    // `Number(undefined) || undefined`, wiping the component the fallback had just
+    // supplied — turning 4.0 into 0.0.0 while looking like a version bump.
+    const version = new LibraryVersion([constant("MAJOR_VERSION")], "4.0");
+    expect(version.major).toBe(4);
+    expect(version.toString()).toBe("4.0.0");
+    // And a valueless constant is not a claim, so it must not flip the flag.
+    expect(version.declaredByLibrary).toBe(false);
+  });
+
+  it("keeps a partial declaration usable", () => {
+    // A GIR that states only the major: the stated part wins, the rest stays from the
+    // namespace. Marked declared because the library did state something.
+    const version = new LibraryVersion([constant("MAJOR_VERSION", "3")], "2.0");
+    expect(version.major).toBe(3);
+    expect(version.minor).toBe(undefined);
+    expect(version.declaredByLibrary).toBe(true);
+  });
+
+  it("still orders versions for the pick-the-newest-GIR comparison", () => {
+    // `DependencyManager` sorts candidate GIR files by this, so the flag must not
+    // disturb ordering.
+    const older = new LibraryVersion(GTK_CONSTANTS, "4.0");
+    const newer = new LibraryVersion(
+      [
+        constant("MAJOR_VERSION", "4"),
+        constant("MINOR_VERSION", "24"),
+        constant("MICRO_VERSION", "1"),
+      ],
+      "4.0",
+    );
+    expect(newer.compare(older)).toBe(-1);
+    expect(older.compare(newer)).toBe(1);
+    expect(older.compare(new LibraryVersion(GTK_CONSTANTS, "4.0"))).toBe(0);
+  });
+});
+
+describe("PACKAGE_DESC", () => {
+  it("names the version when the library stated it", () => {
+    expect(PACKAGE_DESC("gtk-4.0", new LibraryVersion(GTK_CONSTANTS, "4.0"))).toContain(
+      "generated from library version 4.23.0",
+    );
+  });
+
+  it("makes no version claim for a namespace-derived value", () => {
+    // Every published `@girs/gdk-4.0` said "generated from library version 4.0.0",
+    // which was not true of the GIR it was generated from.
+    const desc = PACKAGE_DESC("gdk-4.0", new LibraryVersion([], "4.0"));
+    expect(desc).not.toContain("library version");
+    expect(desc).toBe("GJS TypeScript type definitions for gdk-4.0");
+  });
+
+  it("makes no claim when there is no version at all", () => {
+    expect(PACKAGE_DESC("gjs")).toBe("GJS TypeScript type definitions for gjs");
+  });
+});

--- a/tests/library-version/tsconfig.json
+++ b/tests/library-version/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ESNext"],
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": false,
+    "types": ["node", "vitest/globals"],
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "diagnostics": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
`libraryVersion` is published on every `@girs/*` package and named in gjsify's ADR 0008 — and for a long time nothing read it. Once `@gjsify/cli`'s `system-check` began comparing it against the *installed* library, the field turned out to mean two different things with no way to tell them apart.

## Measured across 32 published `@girs/*` packages

| | |
|---|---|
| real upstream release | **12** (gtk-4.0 → 4.23.0, adw-1 → 1.10.0, glib/gio/gobject → 2.88.0, …) |
| the **namespace** version padded to three components | **17** (gdk-4.0 → `4.0.0`, cairo-1.0 → `1.0.0`, gsk-4.0 → `4.0.0`, …) |
| absent | 3 |

GDK ships *inside* GTK and states no version of its own, so `@girs/gdk-4.0` reads `4.0.0` — a string shaped exactly like a release that corresponds to none. Compared against a host GTK 4.22.4 that reports an 18-minor skew which does not exist, so the consumer had to carry a hand-maintained list of which packages to believe. **A value that must be second-guessed per package is worse than no value.**

## What changes

`LibraryVersion` records whether the library **itself** stated the version, via `MAJOR_VERSION`/`MINOR_VERSION`/`MICRO_VERSION` (or the `VERSION_*` spelling), and the package template omits the field when it did not. Absence is a fact a consumer can act on.

`PACKAGE_DESC` stops making the claim too: every `@girs/gdk-4.0` published so far said *"generated from library version 4.0.0"*, which was not true of the GIR it was generated from.

## An operator-precedence bug, found while reading it

```js
if (name === "MAJOR_VERSION" || (name === "VERSION_MAJOR" && value)) {
    this.major = Number(value) || undefined;
```

`&& value` binds to the **second** spelling only. A valueless `MAJOR_VERSION` constant therefore took the first branch and assigned `Number(undefined) || undefined`, **erasing** the component the namespace fallback had just supplied — turning `4.0` into `0.0.0` while looking like a version bump. Hoisted so the guard covers both spellings; pinned by a test.

Left alone deliberately: `Number("0") || undefined` coerces a legitimate zero component to `undefined`. `toString()`'s `|| "0"` masks it, and changing it would move `compare()`, which picks the newest GIR among duplicate candidates.

## Tests, and where they live

`tests/library-version/` — 10 cases: declared, `VERSION_*` spelling, namespace-only, bare namespace, the valueless-constant regression, partial declaration, ordering, and the three `PACKAGE_DESC` shapes. All verified locally against the real source.

They are **not** beside the source, because that is where this repo's runner looks: CI runs `test:tests` = `gjsify foreach test --include '@ts-for-gir-test/*'`, so a vitest suite under `packages/**` never executes. `packages/language-server/src/__tests__` is in exactly that position today — worth a separate look.

## Note on CI

A generation regression from this change would currently be **invisible** in CI: `build:types` runs through `bin/ts-for-gir-dev`, which discards its child's exit code (#435). That PR is the prerequisite for trusting a green run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)