### PR TITLE
fix(ci): bump @gjsify/cli to 0.30.0 and install json-glib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install container prerequisites
         run: |
 
-          dnf install -y git tar xz findutils curl gjs libsoup3
+          dnf install -y git tar xz findutils curl gjs libsoup3 json-glib
 
           git config --global --add safe.directory "*"
       - name: Set up Node.js 24
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Install container prerequisites
         run: |
-          dnf install -y git tar xz findutils curl gjs libsoup3
+          dnf install -y git tar xz findutils curl gjs libsoup3 json-glib
           git config --global --add safe.directory "*"
       - name: Set up Node.js 24
         uses: actions/setup-node@v4
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: Install container prerequisites
         run: |
-          dnf install -y git tar xz findutils curl gjs libsoup3
+          dnf install -y git tar xz findutils curl gjs libsoup3 json-glib
           git config --global --add safe.directory "*"
       - name: Set up Node.js 24
         uses: actions/setup-node@v4
@@ -174,7 +174,7 @@ jobs:
       - name: Install container prerequisites
         run: |
 
-          dnf install -y git tar xz findutils curl gjs libsoup3
+          dnf install -y git tar xz findutils curl gjs libsoup3 json-glib
 
           git config --global --add safe.directory "*"
       - name: Set up Node.js 24

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -1,8 +1,8 @@
 {
-  "lockfileVersion": 2,
+  "lockfileVersion": 4,
   "requested": [
     "@biomejs/biome@^2.5.1",
-    "@gjsify/cli@^0.14.0",
+    "@gjsify/cli@^0.29.0",
     "@release-it/bumper@^7.0.6",
     "@release-it/conventional-changelog@^11.0.1",
     "concurrently@^10.0.3",
@@ -78,6 +78,16 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
       "integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
+      "optionalDependencies": {
+        "@biomejs/cli-linux-x64": "2.5.1",
+        "@biomejs/cli-win32-x64": "2.5.1",
+        "@biomejs/cli-darwin-x64": "2.5.1",
+        "@biomejs/cli-linux-arm64": "2.5.1",
+        "@biomejs/cli-win32-arm64": "2.5.1",
+        "@biomejs/cli-darwin-arm64": "2.5.1",
+        "@biomejs/cli-linux-x64-musl": "2.5.1",
+        "@biomejs/cli-linux-arm64-musl": "2.5.1"
+      },
       "bin": {
         "biome": "bin/biome"
       }
@@ -85,42 +95,110 @@
     "node_modules/@biomejs/cli-darwin-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
-      "integrity": "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="
+      "integrity": "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@biomejs/cli-darwin-x64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.1.tgz",
-      "integrity": "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="
+      "integrity": "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@biomejs/cli-linux-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.1.tgz",
-      "integrity": "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="
+      "integrity": "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.1.tgz",
-      "integrity": "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="
+      "integrity": "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@biomejs/cli-linux-x64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz",
-      "integrity": "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="
+      "integrity": "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.1.tgz",
-      "integrity": "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="
+      "integrity": "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@biomejs/cli-win32-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.1.tgz",
-      "integrity": "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="
+      "integrity": "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@biomejs/cli-win32-x64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
-      "integrity": "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="
+      "integrity": "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@conventional-changelog/git-client": {
       "version": "2.7.0",
@@ -173,12 +251,14 @@
       "dependencies": {
         "tslib": "^2.4.0",
         "@emnapi/wasi-threads": "1.2.2"
-      }
+      },
+      "optional": true
     },
     "node_modules/@emnapi/core/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "optional": true
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
@@ -186,12 +266,14 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "optional": true
     },
     "node_modules/@emnapi/runtime/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "optional": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -199,142 +281,326 @@
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "optional": true
     },
     "node_modules/@emnapi/wasi-threads/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "os": [
+        "aix"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "os": [
+        "netbsd"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "os": [
+        "netbsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "os": [
+        "openbsd"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "os": [
+        "openbsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "os": [
+        "openharmony"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "os": [
+        "sunos"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.23.0",
@@ -349,625 +615,1102 @@
       }
     },
     "node_modules/@gjsify/abort-controller": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.14.0.tgz",
-      "integrity": "sha512-cUMDQz/kMctvj0KEjcfzSvHn0PE68AkFCK5UVvDWWYp4K9mS3+sE7JYLFtAIgdtVB2YBBcnzCDG3JUvpJWUWqQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.29.0.tgz",
+      "integrity": "sha512-Q701KF06kU4xMcDaYVgbw0w8w5tO2G57W5pTEzjYWE/nYRV2YcM/KF07277oH00b1N+MJMRkp1uKLy3+DcGqkg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.14.0"
+        "@gjsify/dom-events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/assert": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.14.0.tgz",
-      "integrity": "sha512-ezU8CL12qht03y2/BJFpeFok2vn2NgYWtsLr3v0YdvaVftUxJ/dz1vHDZlrp45wcFIWTi2vysv7qqCKrHBveBw=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.29.0.tgz",
+      "integrity": "sha512-GVJwwPhZjVtX8JcIfhfVz7CkHCAAUFmo0GbMlju1l119xTLPil9GoMADHN4MSOSnMJfINmDdfulLYvrp/bRaUQ=="
     },
     "node_modules/@gjsify/async_hooks": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.14.0.tgz",
-      "integrity": "sha512-kJSAG+aa+mghHcsjxU12dQrrd7zanP2mCj6MwXJ8sB9sFrdNYN8Dm/j7LfjCxjQbBvtHKQI3LkLBMAKhCSc0lQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.29.0.tgz",
+      "integrity": "sha512-Q3x4VUKQ33WVPItUfOgt3VU0/O5veeP5UTKuIWIK5ms7ooCNBLB7xZLv+c13jLbth63pKFH7aSNBCSHnK3cKqA==",
       "dependencies": {
-        "@gjsify/events": "^0.14.0"
+        "@gjsify/events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/buffer": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.14.0.tgz",
-      "integrity": "sha512-JpNEW8aLwdUnDcuyfk11gEUvjRD9JGy8tCBhstF5V1xqPuTU2YfiJfl+jSr/LfR2V78UdGth7UUlrTupNOayTw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.29.0.tgz",
+      "integrity": "sha512-JExwAhfple9XaTrVwMBxY7EbeT423fB2LzXXtHeCLIgfScEnfKLudqWabmYr7qdFye0rFQaRUq6jMvW/4njdhQ==",
       "dependencies": {
-        "@gjsify/utils": "^0.14.0"
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/child_process": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.14.0.tgz",
-      "integrity": "sha512-ssqLMmQaZ5EfYtHVq2Ocjva1TSyhxlPrPKhww504VJ4SAz8pOWzwmSYgfgKeppspL2t0gQb0g3iO1sNuwcqtjA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.29.0.tgz",
+      "integrity": "sha512-UMJJNOSPApYNij+gkcY4drO5Ldd0DES2RIfpTXk/K1i4hDmIE1wGJsog4KKKYEY0c2pxXMIpmjCzIrIY1wBWUA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/events": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/cli": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.14.0.tgz",
-      "integrity": "sha512-1VK707DBNm0FE/f945g4udfQFl7TJrAe3KNupttoa5aJODADKwanlNaiegvUhuaEKubnMz8iu3HkeqFSf6eI6w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.29.0.tgz",
+      "integrity": "sha512-rs6T7slFWCgWLpGcY2q3dS9t8AxluNi8m2MuUykLNPQieMjFEOEft5W+goxznV7Bg3nEAZVB4naDYwBf5Qp/bw==",
       "dependencies": {
-        "yargs": "^18.0.0",
-        "rolldown": "^1.1.0",
-        "pkg-types": "^2.3.1",
-        "@gjsify/tar": "^0.14.0",
-        "@gjsify/tsc": "^0.14.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/create-app": "^0.29.0",
+        "@gjsify/node-globals": "^0.29.0",
+        "@gjsify/node-polyfills": "^0.29.0",
+        "@gjsify/npm-registry": "^0.29.0",
+        "@gjsify/resolve-npm": "^0.29.0",
+        "@gjsify/rolldown-plugin-gjsify": "^0.29.0",
+        "@gjsify/rolldown-plugin-pnp": "^0.29.0",
+        "@gjsify/semver": "^0.29.0",
+        "@gjsify/tar": "^0.29.0",
+        "@gjsify/tsc": "^0.29.0",
+        "@gjsify/web-polyfills": "^0.29.0",
+        "@gjsify/workspace": "^0.29.0",
         "cosmiconfig": "^9.0.2",
         "get-tsconfig": "^4.14.0",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/semver": "^0.14.0",
-        "@gjsify/workspace": "^0.14.0",
-        "@gjsify/create-app": "^0.14.0",
-        "@gjsify/resolve-npm": "^0.14.0",
-        "@gjsify/node-globals": "^0.14.0",
-        "@gjsify/npm-registry": "^0.14.0",
-        "@gjsify/web-polyfills": "^0.14.0",
-        "@gjsify/node-polyfills": "^0.14.0",
-        "@gjsify/rolldown-plugin-pnp": "^0.14.0",
-        "@gjsify/rolldown-plugin-gjsify": "^0.14.0"
+        "pkg-types": "^2.3.1",
+        "rolldown": "^1.1.4",
+        "yargs": "^18.0.0"
       },
       "bin": {
         "gjsify": "./lib/index.js"
       }
     },
     "node_modules/@gjsify/cluster": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.14.0.tgz",
-      "integrity": "sha512-BY28Gs65NtfGFwY1RwkoDt/iklfYLgQa3/T4FuqXoMbUdQxX5gD+BdL1z6ghtdnURVtVVlixHpA9IOW2YwypGg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.29.0.tgz",
+      "integrity": "sha512-scRO/3bbjfn4Nqfcaaw92CX3FqErx6BH46mdjNYoDysndy98mZXAnVpUTQkeaL0hUTIgRmMU8ZkDYtXV6JA0rg==",
       "dependencies": {
-        "@gjsify/events": "^0.14.0"
+        "@gjsify/events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/compression-streams": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.14.0.tgz",
-      "integrity": "sha512-U+xKGdF0pikHvWF3w5c7bMKmVxcYCToY9gQEDTGMpfkluK8jTw7TzxzVkfZpFGiqw4MXtkjB3jMzIEkhN0XYkQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.29.0.tgz",
+      "integrity": "sha512-aD8UXJgTj9u0ASxCvN6phVFosATj1dq7bXw45xxglEToLGvApSIZYJlRs7XpxniE4LdSdOi3Fh+4SLxHiEi91g==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.14.0"
+        "@gjsify/web-streams": "^0.29.0"
       }
     },
     "node_modules/@gjsify/console": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.14.0.tgz",
-      "integrity": "sha512-RwaYwsJwCmJX0GQC0ThdwCYsQwt6uUcJjfFAb4tPZCKasUF/T9Byv9OEBOO8kk6v30NHz54TbgBt+oYEgeO++w=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.29.0.tgz",
+      "integrity": "sha512-SEk1FMUylcfHzqQYKB0B9NojkH3BfWpitILHkC8/+j8j7OF93pOFj/qbd+rlbLUuJu7CNdC1i/DJXkrAU78vbQ=="
     },
     "node_modules/@gjsify/constants": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.14.0.tgz",
-      "integrity": "sha512-nBSQ4mbz5xttD0fh0UojwyKufk9efI4xkoHc6GZqni5W+0d4XzGmWHbbhcrUD4zwzMqx4lfMKlBpUUruE9PWLA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.29.0.tgz",
+      "integrity": "sha512-spGTOv4Eo6WLqXtnSRts0tCwUYJrjvS+2ZA9T0R5WSohnGk3VGmKHQuJORLbKQTg3yLPYWPjGQ1+Bvt6SmUCrA==",
       "dependencies": {
-        "@gjsify/fs": "^0.14.0",
-        "@gjsify/os": "^0.14.0",
-        "@gjsify/crypto": "^0.14.0"
+        "@gjsify/crypto": "^0.29.0",
+        "@gjsify/fs": "^0.29.0",
+        "@gjsify/os": "^0.29.0"
       }
     },
     "node_modules/@gjsify/create-app": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.14.0.tgz",
-      "integrity": "sha512-p4OJuHIwnHNBoYWnuddxIx45+ZZw1kxDOMCC4yjcurmu77xHa1ncu06fZREuKhpVuPNOqLvPEkFMksqkD12Fnw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.29.0.tgz",
+      "integrity": "sha512-dDm1WBYF71fOgUZvYo1dRPvsWbB4ySH2QXqp9yZkADIVW78Mm1MNbv7c/AjMaO1TZn6m2Xm4WjBC3iEf3h8MPQ==",
       "dependencies": {
         "yargs": "^18.0.0"
       },
       "bin": "./lib/index.js"
     },
     "node_modules/@gjsify/crypto": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.14.0.tgz",
-      "integrity": "sha512-G7MtqFNPMXH8BHvAzq236FvvvvLf3dA7ECSfdN++Zi1ncZqK14YZ9iRks3UVH01cg5+YhsSR7Nh7dHXMKd2MRQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.29.0.tgz",
+      "integrity": "sha512-0fA9VcAbFbQfGKp4efZek82Cp9n+NX2LQU7mlCu3JhurgzTChOCauodDI7z/gkt8W71wTTve85sqeZmgn210Aw==",
       "dependencies": {
-        "@gjsify/utils": "^0.14.0",
-        "@noble/hashes": "^1.5.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/stream": "^0.14.0"
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/stream": "^0.29.0",
+        "@gjsify/webcrypto": "^0.29.0",
+        "@noble/hashes": "^2.2.0"
       }
     },
     "node_modules/@gjsify/dgram": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.14.0.tgz",
-      "integrity": "sha512-qLzZfgYPIypxSzkomZj9evtTmv9XU9APJVYfgkZQJD/UY6A6C/hQR7VrFtTLdhwndbxMVTXyEPMspqQoeAHIBQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.29.0.tgz",
+      "integrity": "sha512-8yYm5CGmA9rJSr6N6achnCWvv6+VMou69vWNiKPdN7JdyTtEyX+8MPdFgMSvUY2Y9VlGOSHBXbk6ATRnyJuNXA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/events": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/diagnostics_channel": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.14.0.tgz",
-      "integrity": "sha512-z2V6iJ9VLEF3yW8oOk4tsBHxvZdKgaJ1b4VifD6SK8/PClph5eo7WY3kheSnR8CcyAEFaDapgw7Cnp1qxnj2bg=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.29.0.tgz",
+      "integrity": "sha512-/pG1DLOVYAqDYngrtTO2o9ODZUstMRZoREvK0xNu4VuDU2NihOxPsnw64dhHIKDVbVtUpu1exVdMwMcnA2/4nw=="
     },
     "node_modules/@gjsify/dns": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.14.0.tgz",
-      "integrity": "sha512-foejacOhOfz9i4FWCZgZyHWKhVAVPsSvEYPihwrdhajllaFsnU9/CEXuWB7g/oOpxLSwFGPqQIs968pB4kiQ7Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.29.0.tgz",
+      "integrity": "sha512-6BRxMD0JVCnxQkSxWxrS2uoBT06QzV7kxXa3atMjgW8Kphst3tX8lLQr/CTOhb/ReqNZ+qCv+8GWsafPUZ8Bvg==",
       "dependencies": {
-        "@gjsify/net": "^0.14.0",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/net": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/dom-events": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.14.0.tgz",
-      "integrity": "sha512-VeOO6lym8zwJMjFV20BJVCPvIJxpQV5yhq+1jDE5PyklGwKdGiyyN8ZqwPL+J0gZdM2b6YI0KRiTJ+GftK2D0A==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.29.0.tgz",
+      "integrity": "sha512-KegTMnate86oIx3Mzc04Hf2HhfJOykx/h5g7RNCYRWjzLAT/8nVa+V1rigHDoHpVv2z1+dJVwSnJNvLaRRTd6w==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.14.0"
+        "@gjsify/dom-exception": "^0.29.0"
       }
     },
     "node_modules/@gjsify/dom-exception": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.14.0.tgz",
-      "integrity": "sha512-Z7fDRxHhGuY/rUULKGFNM5d8QIUqqeIATwMXQNRkhsIddhu0EcI65AOTqNRVBYrgNxaP3JcMlgn8/G7FEvqiLw=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.29.0.tgz",
+      "integrity": "sha512-1UpoBJfTziP/ZMk2ZnSun8k8iwSZXjxnY39c1uT+Peg9vshg0EucHS2bk4nhEVzyQXXgZsk/oXDil6fKCflvSA=="
     },
     "node_modules/@gjsify/domain": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.14.0.tgz",
-      "integrity": "sha512-ClhmxXI0Ei0OSJpb8m3CAq5q9GRqfIA2CI6u11AWa7tdrv7DlJ6NCZxugC3HoVsaTqucJtQ7RQIAMgM0vM4b6g==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.29.0.tgz",
+      "integrity": "sha512-aDsvTqfJ/SpsRXRw7/hnuFA8wrDG6kW/Lq9gkDM1ZCTj6HNQl1T4udMY2D2km2pU4QOPjok9i++pNXIcpen9tQ==",
       "dependencies": {
-        "@gjsify/events": "^0.14.0"
+        "@gjsify/events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/domparser": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.14.0.tgz",
-      "integrity": "sha512-TDr3bVe7x7TcsjKoDx49s388RC/qUntlhYkdWLOewLV8Zo8lbNIV51ZgJlEZo8bRxXq/U9a6KaGr+bK+BrsnXA=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.29.0.tgz",
+      "integrity": "sha512-j+n9kZjd+AuJO/BiIP0fgzrFxuKIlhxAYlXJUTrjv69f1rox5qyGNzcw2xypexMp3/OJ6zWUPo92IUuMCRWofQ=="
     },
     "node_modules/@gjsify/events": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.14.0.tgz",
-      "integrity": "sha512-kLnSeOgzxpd614cZq9z8EprwE6AmHStomMcsfhOmpGaxepdE01cSf+mOicwxlQlu7e26gdWfSnwqMLcCFjAJMQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.29.0.tgz",
+      "integrity": "sha512-MT36Vag6tlhMzPsSZnj9/nsfMxp4u9t8DgvxZoXm8gNTD+IsoXKMMGleDDvqkHd03umXuLxbtV9OfrLe8br1ZA==",
       "dependencies": {
-        "@gjsify/utils": "^0.14.0"
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/eventsource": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.14.0.tgz",
-      "integrity": "sha512-j+ki9/J3t0S6hTmLjjIwfzJ6Mjcg+ME/oeqZh3B+fKwV+xS/sAgLauPTsgspSOwii8zfThF5cd/cZblUNV9jYQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.29.0.tgz",
+      "integrity": "sha512-1TdrooUBN7l/iWjiVTfo5SxwuGF6fdLXwiS9hwT/UwkZLtVM6sddTYBjeXc7lVTpyoQudHJKKAmZ5l80Ru+kQw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.14.0",
-        "@gjsify/web-streams": "^0.14.0"
+        "@gjsify/dom-events": "^0.29.0",
+        "@gjsify/web-streams": "^0.29.0"
       }
     },
     "node_modules/@gjsify/fetch": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.14.0.tgz",
-      "integrity": "sha512-QeGW8c3BqxHbsTDdfFLVlj3K820Knyfbh1TXZWrNIzi5oYcVccOFo/qImCZrOZBfdevzkykKhnL5l66cJmWh5A==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.29.0.tgz",
+      "integrity": "sha512-5GY9D2wqX5QNtWB63x3leVZtHlUvxVoheGgo24LC9AJgz31nfWuVWsntn29Q3wtBbFAjVoZ0Gdtbhy/TXLDPwA==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@gjsify/url": "^0.14.0",
-        "@gjsify/http": "^0.14.0",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/soup-3.0": "3.6.6-4.0.4",
-        "@gjsify/formdata": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/soup-3.0": "^4.1.0",
+        "@gjsify/dom-events": "^0.29.0",
+        "@gjsify/formdata": "^0.29.0",
+        "@gjsify/http": "^0.29.0",
+        "@gjsify/url": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/formdata": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.14.0.tgz",
-      "integrity": "sha512-/9dCdNzhY0BZfal/Z8gFcCNZ606QhDwPUYC5+34o7wQfbccqGhDY80AvV3jBoMH9l6w2nkMYTHUs6mc/nBtCGg=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.29.0.tgz",
+      "integrity": "sha512-zH2MUIpOwFYRUyNJcrb2UIyiI6guwt3hrZMfksSUDSWAhOMHMtgPciSwPZbRRIxeDfzw/essVFFMCNfRYMCt7w=="
     },
     "node_modules/@gjsify/fs": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.14.0.tgz",
-      "integrity": "sha512-vw/9jBZwr+7deKCaGCfnm6KmkHNf+ifG89yWE/Rc609dN0U5KIdZOG0B3C20HSK2KwP5ODrozuJ6szRXfpdHsg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.29.0.tgz",
+      "integrity": "sha512-zUARHL5at5s3cpBB02G11/zLye6Rnpq0IfBFFL5OALgcCjWdTkqvx4Kbv9iHTyTxxhFxQ64r8OZ242uJAkUgNQ==",
       "dependencies": {
-        "@gjsify/url": "^0.14.0",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/events": "^0.14.0",
-        "@gjsify/stream": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/giounix-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/stream": "^0.29.0",
+        "@gjsify/url": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/gamepad": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.14.0.tgz",
-      "integrity": "sha512-cm/NYpn44qoZ5M7bMC8TWGO0zExdl/PU6pApV96GX26ylcGwcZT7XGzA0UJfT9fssRVvP+CFZWV4iuHZvkM65w==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.29.0.tgz",
+      "integrity": "sha512-q6t2GcUcQapgYIbnoop6ffohlTpBHqf8hs/n9mUUzqeRY3RG/l4d3Q/2vByQ7lcvPZiSSLVFrCIeePf74wrlwQ==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.14.0"
+        "@gjsify/dom-events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/http": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.14.0.tgz",
-      "integrity": "sha512-I5x+WiuU3Mrk4nUEmDoyUeM5Ury89WWwmDyX+v+XYOjjx7+7brXhEIIh9TNYkXZikquKJtgLJ9HFH/2OydutUA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.29.0.tgz",
+      "integrity": "sha512-8KqmqN5YAtxC4gcnaIrUV+VWs61X1JLAo1b1SCbKb//LNhDwjpv2klNhlImBQLNjA0NcNlI8cayvQMF8Zm/nsw==",
       "dependencies": {
-        "@gjsify/net": "^0.14.0",
-        "@gjsify/url": "^0.14.0",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/soup-3.0": "3.6.6-4.0.4",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/events": "^0.14.0",
-        "@gjsify/stream": "^0.14.0",
-        "@gjsify/http-soup-bridge": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/soup-3.0": "^4.1.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/http-soup-bridge": "^0.29.0",
+        "@gjsify/net": "^0.29.0",
+        "@gjsify/stream": "^0.29.0",
+        "@gjsify/url": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.14.0.tgz",
-      "integrity": "sha512-qt7CcgBZieb9K2pfZJy+7B2neMyMTLN3GZMXLtG+C4p8hxYvibj41wBxySb7Tq4q9zlLpXokIQHY4s7QBm+JvA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.29.0.tgz",
+      "integrity": "sha512-xq0VlZvw3rbuhnlkuknups7G3Gq3iu9fh4WTK3Bm2x7fz8FA8/7AZm3G5WlcelZyG5tqXmBcwfA/Wq9iq19Q0A==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/soup-3.0": "3.6.6-4.0.4",
-        "@girs/gobject-2.0": "2.88.0-4.0.4"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/soup-3.0": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "@gjsify/http-soup-bridge-darwin-arm64": "0.29.0",
+        "@gjsify/http-soup-bridge-darwin-x64": "0.29.0",
+        "@gjsify/http-soup-bridge-linux-arm64": "0.29.0",
+        "@gjsify/http-soup-bridge-linux-ppc64": "0.29.0",
+        "@gjsify/http-soup-bridge-linux-riscv64": "0.29.0",
+        "@gjsify/http-soup-bridge-linux-s390x": "0.29.0",
+        "@gjsify/http-soup-bridge-linux-x64": "0.29.0"
       }
     },
+    "node_modules/@gjsify/http-soup-bridge-darwin-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-darwin-arm64/-/http-soup-bridge-darwin-arm64-0.29.0.tgz",
+      "integrity": "sha512-JSG946dQeTifCPsGkbsOw5NsM5PBZUf4OD4JT2rf02C+3IvxVOriHcdslNjqeY6hQr4uZFoBi8KwFdE8zg8dWA==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http-soup-bridge-darwin-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-darwin-x64/-/http-soup-bridge-darwin-x64-0.29.0.tgz",
+      "integrity": "sha512-DEva2yritxLUTrlnNMr5gYPidYisO4wdmwa+mx7EaiuL+sAqtBvtP2SwA2TC2KiSfDOzmQLJateBc6mq7EFX7g==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http-soup-bridge-linux-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-arm64/-/http-soup-bridge-linux-arm64-0.29.0.tgz",
+      "integrity": "sha512-lPW0D0z6+hyLotufZ1yfjuXNDHcpfciGlj9M9SICfctAAuIzmVSva3/lLFtlJzPb7Z7FFTRKzybJ3qIVJXUJDw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http-soup-bridge-linux-ppc64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-ppc64/-/http-soup-bridge-linux-ppc64-0.29.0.tgz",
+      "integrity": "sha512-CTwwPlelUQQ8xSEjyNCDmAp4gOeuJz4DkxR8Hcad60dHzWLlrd3luEg5NPKa91QqxV0/7PVjniZPAE8SkMmxvw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http-soup-bridge-linux-riscv64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-riscv64/-/http-soup-bridge-linux-riscv64-0.29.0.tgz",
+      "integrity": "sha512-YKG9LKWbnOWVe2Ecwk38vmGVqmWd+49j2AaCuH+Mtl7TUYY/e587k9cSPFeTAKyZ995mI1xwU3dKD01Nb7sC9w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http-soup-bridge-linux-s390x": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-s390x/-/http-soup-bridge-linux-s390x-0.29.0.tgz",
+      "integrity": "sha512-/X7z9+KTHNoVCOIwzZhQzuHFps97soOuWOUeD6hq03LjfiHxED4H0kAZlCGQIu14O7BTHeMnICmWGM+DO6F4aA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http-soup-bridge-linux-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-x64/-/http-soup-bridge-linux-x64-0.29.0.tgz",
+      "integrity": "sha512-jRXLIIJF9ip5ClpwCJkAnWY3Y4HcF/Ic/8gDBuh1rg9JPNrAqEkR1NRtOUsBcavpYWxG9k0WdrSl81zCAPOBwA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
     "node_modules/@gjsify/http2": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.14.0.tgz",
-      "integrity": "sha512-PdS4HiDSGVxJLBC3UIK4EraKEeh3LpkwQeJQPlxM9bxgv+Xyv6Byi0gfrmSNCDQoUl1VI8MGezvDNvm4tmh6lw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.29.0.tgz",
+      "integrity": "sha512-N4I4c2U1bebRnabOymF3dt8iMNpT4fBATGwT20TZrq+WHQqkT6SrhrGqn+0mxVtrbn/dQ/ZkR5mQFVxmxJjMUg==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/soup-3.0": "3.6.6-4.0.4",
-        "@gjsify/events": "^0.14.0",
-        "@girs/gobject-2.0": "2.88.0-4.0.4",
-        "@gjsify/http2-native": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/soup-3.0": "^4.1.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/http2-native": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/http2-native": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.14.0.tgz",
-      "integrity": "sha512-OCfaQ/YyrFmlagVWOSGYO4htfguGutOmdfVbknoEnippoOeM5+j1bP9pTav+2ZIQzfkpBdja7Se9vtXh7ohhtw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.29.0.tgz",
+      "integrity": "sha512-N3lp67rbI2hZ7VSPLdmkBUcWCSl+8mND9ZbinIFQLoOVqrTMSUtqNd5r9Xx9xyHTY+sjSHH0Yaye12cdlnr7iw==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/gobject-2.0": "2.88.0-4.0.4"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "@gjsify/http2-native-darwin-arm64": "0.29.0",
+        "@gjsify/http2-native-darwin-x64": "0.29.0",
+        "@gjsify/http2-native-linux-arm64": "0.29.0",
+        "@gjsify/http2-native-linux-ppc64": "0.29.0",
+        "@gjsify/http2-native-linux-riscv64": "0.29.0",
+        "@gjsify/http2-native-linux-s390x": "0.29.0",
+        "@gjsify/http2-native-linux-x64": "0.29.0"
       }
     },
+    "node_modules/@gjsify/http2-native-darwin-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-darwin-arm64/-/http2-native-darwin-arm64-0.29.0.tgz",
+      "integrity": "sha512-sr8iSsD+XPDEgRQlqyisDWW0qVorUcyOFedE3ocNR0fM7SDNHW76CkGjy91E+I/Q/19gw4WzJSQQh8WNFqUw/w==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http2-native-darwin-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-darwin-x64/-/http2-native-darwin-x64-0.29.0.tgz",
+      "integrity": "sha512-WTrYjin5HmlEIyKGq51b7jZXgSC2oP0/X0Sk1v2JWkaNfke/MAIfVZmb+OM4ju7c8wJcUAkIuN5/tGEHZl31ZQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http2-native-linux-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-arm64/-/http2-native-linux-arm64-0.29.0.tgz",
+      "integrity": "sha512-scuDYJeuLXjM52rgWaac5Vi7HU0WYzzN4P7cWVAyZV8I8dIzcMTEVbCZMrQwC5wVA9qBeVkH6ImNzaU7lYyBYA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http2-native-linux-ppc64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-ppc64/-/http2-native-linux-ppc64-0.29.0.tgz",
+      "integrity": "sha512-jfzA9eHXxqcDOSqwv2Squc/RH0KBf3P2dJOalxBbLMZKXfkhRWCyK7/ugffbAz3NsIeayAvH8hM6LQUqnXt5GA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http2-native-linux-riscv64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-riscv64/-/http2-native-linux-riscv64-0.29.0.tgz",
+      "integrity": "sha512-MTvH//LipoaAwYEjkjAOkaYWqQ3tX0P1g3eKu5o3NOJay1s6KcVCFJrHwj/Wo6zk9DeBQAJNsB/2y0qIwzLDQw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http2-native-linux-s390x": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-s390x/-/http2-native-linux-s390x-0.29.0.tgz",
+      "integrity": "sha512-K2E6w0g/5+rHFRQYIaRKC+TZUEl0su6UaGEDgfAq05a6AJ8HfJe1nMGKTElUWXtXIccZxTbsmiVZR9d+FfbJ/A==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/http2-native-linux-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-x64/-/http2-native-linux-x64-0.29.0.tgz",
+      "integrity": "sha512-piXzMZeEMJYha/hl6BwuyISVoAuEGpNGsJtzZtjqe/Eze/XK+bdn/Sg3GXlwmajaBdl0cKBKHUUVq70dYJ0CwQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
     "node_modules/@gjsify/https": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.14.0.tgz",
-      "integrity": "sha512-AtG+8fYA/gghzS9E9QeEW1D2wXucAm0eQe+fwDCmYl/euFAJbz/9qdPsfahZFf6A+GajbRbNhVUbgx8szXnw4A==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.29.0.tgz",
+      "integrity": "sha512-I+wviwkxOVxNSDE6A+rpCDHlzJnf9NvmEN0b9IgBhNQDWQZ39N1mh3/Ikx4LUXSst830W9PBgs8Yz0bxEYuFGA==",
       "dependencies": {
-        "@gjsify/tls": "^0.14.0",
-        "@gjsify/http": "^0.14.0"
+        "@gjsify/http": "^0.29.0",
+        "@gjsify/tls": "^0.29.0"
       }
     },
     "node_modules/@gjsify/inspector": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.14.0.tgz",
-      "integrity": "sha512-9SmRFyguj/3Ho+pPJPIZgbnE3tDtpHr/ZGv5dKZFPt2lheYXd1yrO4+9aiHnMLFZZp1yy36Bb1ztKFjLn5gggA=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.29.0.tgz",
+      "integrity": "sha512-Dnstvw6G+eBR5cDTAd7LAm1jAn8evYntfIVFQW7GpQx19w/4+3Kto+XHDQpcEc4JRXokNiGzLjFdMWSYK9dQZA=="
     },
     "node_modules/@gjsify/message-channel": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.14.0.tgz",
-      "integrity": "sha512-jHgWcmYJm/pYEMVr+iNE8W9HBnrvSUYnS2xRbdYzf95fWBKeNUL7AfphJtyR1qIeEqvbzddR3Da3137YQyp/Xg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.29.0.tgz",
+      "integrity": "sha512-aAOfxijLWFbHbB5Ct63PIQG7ok0MfFxVw3NTF7V5iS5sZ4PuCj7Ec6hWH1w7YuIxyX8BmkZc+m3MvMDSr+FRXw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.14.0"
+        "@gjsify/dom-events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/module": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.14.0.tgz",
-      "integrity": "sha512-rX8Q7tgdiHmdBRbrHeDppO5foyroJGabYlxZCo1TTqMUK03rtN84PbzBcnkFDIx7YWRXrdER67dr2IG8t9ikag==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.29.0.tgz",
+      "integrity": "sha512-phM0nykMo3Aa2d+jW3zlzZz6SIeRUwjCd5oCugvL2vIOOaYeAgThUKwMFSWj2SPYwU5UmjWtjoj3WZOxiLU8Ig==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/net": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.14.0.tgz",
-      "integrity": "sha512-gYvt/wv6uD1RBAFM30GsPX+zElf7Ziy2/V/rh322IWcz569tjjpYgIwd2KI+5muxGeiUcK5Sxv10PzbF3kjilw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.29.0.tgz",
+      "integrity": "sha512-l/j5Whh7IwNK7oVVtkSPrwh6Iw3yaEqxnQ/dKu6pnlyvykt+yggnxK64C5SYUv3Xqmu33NNvoUnTke2ZDkMSGg==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/events": "^0.14.0",
-        "@gjsify/stream": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/stream": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/node-globals": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.14.0.tgz",
-      "integrity": "sha512-rbiJS8L2Rptom69DdIWFCNJTulauVFN8convXFGDkTejhnwTd62W34Ya8v5hvhrMReTMYj+69IWr3guTjnXTcw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.29.0.tgz",
+      "integrity": "sha512-g3YI6ANvJMyZT8Vcd/JtXl+1wWRqdnLOeMBp+xptnwn0JDCc9JRfdPMkmE+4vQU59ZEcY5G2dVBEqwKa4ezjvg==",
       "dependencies": {
-        "@gjsify/url": "^0.14.0",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/process": "^0.14.0"
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/process": "^0.29.0",
+        "@gjsify/url": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/node-polyfills": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.14.0.tgz",
-      "integrity": "sha512-xC2HWwq57KiIYnmND4oPGspxE+l5hdg4ANh7hrkTp+V6vGj6zt6cTKMCdUAlO19CKC/ACmbIZsqcAKUcQKLRog==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.29.0.tgz",
+      "integrity": "sha512-sYpVC/6lKWGlXpeO9eQ/rBBIohYJcyaD5DTCAVtwgPFTmQzCySDkgRm7aqBJc77Yu5gIOuzH3xqb3WY6uRZP+w==",
       "dependencies": {
-        "@gjsify/fs": "^0.14.0",
-        "@gjsify/os": "^0.14.0",
-        "@gjsify/v8": "^0.14.0",
-        "@gjsify/vm": "^0.14.0",
-        "@gjsify/dns": "^0.14.0",
-        "@gjsify/net": "^0.14.0",
-        "@gjsify/sys": "^0.14.0",
-        "@gjsify/tls": "^0.14.0",
-        "@gjsify/tty": "^0.14.0",
-        "@gjsify/url": "^0.14.0",
-        "@gjsify/http": "^0.14.0",
-        "@gjsify/path": "^0.14.0",
-        "@gjsify/util": "^0.14.0",
-        "@gjsify/zlib": "^0.14.0",
-        "@gjsify/dgram": "^0.14.0",
-        "@gjsify/http2": "^0.14.0",
-        "@gjsify/https": "^0.14.0",
-        "@gjsify/assert": "^0.14.0",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/crypto": "^0.14.0",
-        "@gjsify/domain": "^0.14.0",
-        "@gjsify/events": "^0.14.0",
-        "@gjsify/module": "^0.14.0",
-        "@gjsify/sqlite": "^0.14.0",
-        "@gjsify/stream": "^0.14.0",
-        "@gjsify/timers": "^0.14.0",
-        "@gjsify/cluster": "^0.14.0",
-        "@gjsify/console": "^0.14.0",
-        "@gjsify/process": "^0.14.0",
-        "@gjsify/readline": "^0.14.0",
-        "@gjsify/constants": "^0.14.0",
-        "@gjsify/inspector": "^0.14.0",
-        "@gjsify/perf_hooks": "^0.14.0",
-        "@gjsify/async_hooks": "^0.14.0",
-        "@gjsify/querystring": "^0.14.0",
-        "@gjsify/node-globals": "^0.14.0",
-        "@gjsify/child_process": "^0.14.0",
-        "@gjsify/string_decoder": "^0.14.0",
-        "@gjsify/worker_threads": "^0.14.0",
-        "@gjsify/diagnostics_channel": "^0.14.0"
+        "@gjsify/assert": "^0.29.0",
+        "@gjsify/async_hooks": "^0.29.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/child_process": "^0.29.0",
+        "@gjsify/cluster": "^0.29.0",
+        "@gjsify/console": "^0.29.0",
+        "@gjsify/constants": "^0.29.0",
+        "@gjsify/crypto": "^0.29.0",
+        "@gjsify/dgram": "^0.29.0",
+        "@gjsify/diagnostics_channel": "^0.29.0",
+        "@gjsify/dns": "^0.29.0",
+        "@gjsify/domain": "^0.29.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/fs": "^0.29.0",
+        "@gjsify/http": "^0.29.0",
+        "@gjsify/http2": "^0.29.0",
+        "@gjsify/https": "^0.29.0",
+        "@gjsify/inspector": "^0.29.0",
+        "@gjsify/module": "^0.29.0",
+        "@gjsify/net": "^0.29.0",
+        "@gjsify/node-globals": "^0.29.0",
+        "@gjsify/os": "^0.29.0",
+        "@gjsify/path": "^0.29.0",
+        "@gjsify/perf_hooks": "^0.29.0",
+        "@gjsify/process": "^0.29.0",
+        "@gjsify/querystring": "^0.29.0",
+        "@gjsify/readline": "^0.29.0",
+        "@gjsify/sqlite": "^0.29.0",
+        "@gjsify/stream": "^0.29.0",
+        "@gjsify/string_decoder": "^0.29.0",
+        "@gjsify/sys": "^0.29.0",
+        "@gjsify/timers": "^0.29.0",
+        "@gjsify/tls": "^0.29.0",
+        "@gjsify/tty": "^0.29.0",
+        "@gjsify/url": "^0.29.0",
+        "@gjsify/util": "^0.29.0",
+        "@gjsify/v8": "^0.29.0",
+        "@gjsify/vm": "^0.29.0",
+        "@gjsify/worker_threads": "^0.29.0",
+        "@gjsify/zlib": "^0.29.0"
       }
     },
     "node_modules/@gjsify/npm-registry": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.14.0.tgz",
-      "integrity": "sha512-pHTrVJLjCJK9+DKGTejvZ9YiBR+6tqZK4q+dcDFdt1ULNaSEY1pxlEcgDsJa3j6rRf/F77rjZ0JpZyfBZVj4Cg=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.29.0.tgz",
+      "integrity": "sha512-cMxqcnmW28YAL6YTWIAMT3dmDwNnj/rXjiINydSqaJW6ijU9lqleoU3YJ4pBGc5Iy7iX0OotMGfHFFbHv8EcRA=="
     },
     "node_modules/@gjsify/os": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.14.0.tgz",
-      "integrity": "sha512-eVqgm8v2R0cP0B0kmKs7jOygL9hz0cpE+vcL7j7CI71EOSab7muqhB9Y04FeI5RlP+O00ZPh4L/HMccyhoiHeg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.29.0.tgz",
+      "integrity": "sha512-6CYjbgaSCyvXcV8zl11k/0PYYxm8d18lLnNMSeQPNDaaNTYCq4wMLzWcXrHVKYqFYfUF/lPPHZYTg6LEqMQj1Q==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/path": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.14.0.tgz",
-      "integrity": "sha512-UdGMEMS6W8i72c5BnzYZTbR6BvKUnbsBeJ98D7V9HIJeUdnYV7Irssob9vMCIOVlPiKY/DhlKA2l8RP3p3j21Q=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.29.0.tgz",
+      "integrity": "sha512-zy6vRg6n7ol9/e33afeGzBh3OP9FUMov5V7a79gDqnqbC4UURQTSTk7PifG6nqJNtb79fPPPInBsotawbA3ECQ=="
     },
     "node_modules/@gjsify/perf_hooks": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.14.0.tgz",
-      "integrity": "sha512-/REbMpdozs+nV2ehvSWLizeJZg8X3V7hjBu0WWV/ToqjusinvSmfW/fFi5f8rrKpik2K9X3Ak+vNmzkzUU+yJQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.29.0.tgz",
+      "integrity": "sha512-KUgqq0OabW9NDDeCzwT1nxOIwPA1tTiLA+r7isCXKlhjDgtviWy+gkELR6gyceVCEnPQeHaGGMCFvpUYqg/89g=="
     },
     "node_modules/@gjsify/process": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.14.0.tgz",
-      "integrity": "sha512-XJOtc33gZnkeoybX/qjPxMOGX6/V7ZoY5ksxAbexR9USBJ131EmUBIBdzDsrvNIxhAJV0wIXwuwdtyjivcDJuw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.29.0.tgz",
+      "integrity": "sha512-5UmOQBZXt9sRqGR008cjR7fDSgO7a5tI4X9A4jGqD5hhgWVe1cVA9EQGnXmOAdqgJHO9WlThonXx6Y+w7P5n4g==",
       "dependencies": {
-        "@gjsify/utils": "^0.14.0",
-        "@gjsify/events": "^0.14.0",
-        "@gjsify/string_decoder": "^0.14.0",
-        "@gjsify/terminal-native": "^0.14.0"
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/string_decoder": "^0.29.0",
+        "@gjsify/terminal-native": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/querystring": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.14.0.tgz",
-      "integrity": "sha512-aIxlb/DzO+UrjWxcHA6oqrheSh2UA6bPhMystgBU4zNJFTSiT4h6tQiGyFoRjCgmYYHNfHJ65zRx25T5dMXHPw=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.29.0.tgz",
+      "integrity": "sha512-MbAH+WgQkqRFN3wJE1IhOH53d6dmboTxVDDu3jehlmmaArv6cRBN8JOUusO7KdKegg427pCG8kj7KWgprcqZqg=="
     },
     "node_modules/@gjsify/readline": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.14.0.tgz",
-      "integrity": "sha512-apOIZuSHHxWQ/1d9J6bDnQt0ioaJn6levJ1J6AdXSi9ECCsjJ329QIjnB1IlO8i2Yufoz7rKUh1sfyDwnL2wFw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.29.0.tgz",
+      "integrity": "sha512-+plrQpSBMhxw4JV4AETDAoR9VAgqw9GFl+jrTyJwsF4bRaDvaLYuKMCbQWp5eA+BgGYH+ZS0fVlQ6U8XJaFaxA==",
       "dependencies": {
-        "@gjsify/events": "^0.14.0"
+        "@gjsify/events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/resolve-npm": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.14.0.tgz",
-      "integrity": "sha512-tNSSmmjaW5Ksa5orkOQ8XpGtSWUUDRJRjWYmImmHVI2mSyN9VKo3mFtubUdLIn+QB9ALOie/F8x91eomvKyagA=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.29.0.tgz",
+      "integrity": "sha512-KfqfQ4llyWiO+4pA5cNLj+reHU4gbmgBhSwrStwwLaJ5kwLeukXCeQQtWqMLJWUlBRSg/UMluYAIrIntdr/tsQ=="
     },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.14.0.tgz",
-      "integrity": "sha512-WW5ZpcE8Fr7EK39Slws0wAaepF8bnuO90o0WN9rBGcGX+KqpZJZBhsv13cNOY0dhQmmjGcfnBG+GRH6tyKlIkA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.29.0.tgz",
+      "integrity": "sha512-/Dc/pSGXfye5Dt2e2syearn95zggx9FiXWKJCiiNDbObBR5klsLYdd/G6evpLjyWGBONZzZ/s2YJrY5z6vl9uA==",
       "dependencies": {
-        "typescript": "^6.0.3",
-        "@deepkit/type-compiler": "^1.0.19"
+        "@deepkit/type-compiler": "^1.0.19",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.14.0.tgz",
-      "integrity": "sha512-DoB+Us/SqQQGjY//OQ6OVcOBwlHGbvhL07ma84rKe7LjSp5bMR70PC2sQnqWCq3/j5WXyKyJtWAcob0lX6cyUg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.29.0.tgz",
+      "integrity": "sha512-lGQvF2kHefjYUiG2E0XJilXxeHRY+8l+AQwp/Hr8Dz8sgwm6JYXYu9svSquPUIuU0sQiS47aa4PHSu7TxO6hDQ==",
       "dependencies": {
-        "acorn": "^8.16.0",
-        "fast-glob": "^3.3.3",
-        "acorn-walk": "^8.3.5",
-        "lightningcss": "^1.32.0",
-        "@gjsify/console": "^0.14.0",
-        "@gjsify/resolve-npm": "^0.14.0",
+        "@gjsify/console": "^0.29.0",
+        "@gjsify/resolve-npm": "^0.29.0",
+        "@gjsify/rolldown-plugin-deepkit": "^0.29.0",
+        "@gjsify/rolldown-plugin-pnp": "^0.29.0",
+        "@gjsify/vite-plugin-blueprint": "^0.29.0",
         "@rollup/pluginutils": "^5.4.0",
-        "@gjsify/rolldown-plugin-pnp": "^0.14.0",
-        "@gjsify/vite-plugin-blueprint": "^0.14.0",
-        "@gjsify/rolldown-plugin-deepkit": "^0.14.0"
+        "acorn": "^8.17.0",
+        "acorn-walk": "^8.3.5",
+        "fast-glob": "^3.3.3",
+        "lightningcss": "^1.32.0",
+        "sass": "^1.101.0"
+      }
+    },
+    "node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/vite-plugin-blueprint": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.29.0.tgz",
+      "integrity": "sha512-HinytTTWeWOkoLepi2G+REi1dHXR/+vvXkJdE6Wb4FPClOXv5nmFYe2yDo+aVpl4SLj1gfRfs4NBzZlSJcGJeA==",
+      "dependencies": {
+        "execa": "^9.6.1",
+        "minify-xml": "^4.5.2"
+      }
+    },
+    "node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "bin": {
+        "acorn": "bin/acorn"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.14.0.tgz",
-      "integrity": "sha512-krzUo3vN3FWvBOW642m0kVwBITyPN4CwD08Lc9ZNDJS2y6MOclZhmpZb02Zj4sZHRrIbcD+2Ob28w78wvZD5vg=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.29.0.tgz",
+      "integrity": "sha512-dXX2IH281/8eQmJ+1zM7OUeGjKqcCq/+RPZLmb+TlRncJgIzRhpttWUxBYZb6yqHErkpkTcEmmWX1CEWJYiRyw=="
     },
     "node_modules/@gjsify/sab-native": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.14.0.tgz",
-      "integrity": "sha512-3wktvDdn51gtgS5UXIF/+/JGeBvuzGcE9kPKkEMN6JKoA+I58L26TXaZdkNR7G0uVFa0evpvT5nxhRyl/YCf0Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.29.0.tgz",
+      "integrity": "sha512-jFJBA+BoM2F2gPB1dN1v6vLvUSHRT3LBxV+MmVJRLcF3NOb3AMGPWrmQfoxEhSbuLZM+n1LAADzQzLDQ/8YImA==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/gobject-2.0": "2.88.0-4.0.4"
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/gio-2.0": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "@gjsify/sab-native-linux-arm64": "0.29.0",
+        "@gjsify/sab-native-linux-ppc64": "0.29.0",
+        "@gjsify/sab-native-linux-riscv64": "0.29.0",
+        "@gjsify/sab-native-linux-s390x": "0.29.0",
+        "@gjsify/sab-native-linux-x64": "0.29.0"
       }
     },
+    "node_modules/@gjsify/sab-native-linux-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-arm64/-/sab-native-linux-arm64-0.29.0.tgz",
+      "integrity": "sha512-C2vcTQunBerrT+ckWM2xRz7ixSnMkMQhTv5eEVTVIWKkfJKnkoKmAuBf6F0/xE/d4ORRpzMFx5bIaFh/9T/rrA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/sab-native-linux-ppc64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-ppc64/-/sab-native-linux-ppc64-0.29.0.tgz",
+      "integrity": "sha512-Vjv8z7B0Ip2lyJB1/IFTclJKiyJph3rfQHTph2FsVvlTANLBWTbKvn/FV4LMnlb+vSY7ect/zPqUPlmorES3Tg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/sab-native-linux-riscv64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-riscv64/-/sab-native-linux-riscv64-0.29.0.tgz",
+      "integrity": "sha512-cnOzg9RwT+5GP/G9Kz5/o5ZFMGB79Kkm+3ps9oNfdivUnZNvuZdKHuwJYW57Ys7+9dSsgWCJrO5QT9a/aCo2xg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/sab-native-linux-s390x": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-s390x/-/sab-native-linux-s390x-0.29.0.tgz",
+      "integrity": "sha512-cc0JV/I/TmFf/wKCtlDOPkuuWzaXQB0gbiheaBw0gyC+d4D1nskQ3m0BtopOviSxnE7sBagAQ1ZSEwttsnuPew==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/sab-native-linux-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-x64/-/sab-native-linux-x64-0.29.0.tgz",
+      "integrity": "sha512-AXCKlfUNVnxhMxw69K5huCZhiHpnCvG8f5FcwrgV7F3OWRG/gMKE7/aLJCJDleT9Iuga8QT75FrHliRuVMUAmQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
     "node_modules/@gjsify/semver": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.14.0.tgz",
-      "integrity": "sha512-1z+W180zst1cNaNKNApmKqmO3jRPVjStEJxRTnUVNil7ec/2j1/eCtA3eUT3pzkkJtY+VFVOxBZwk/8Wwc4+Fw=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.29.0.tgz",
+      "integrity": "sha512-ypXwc/b8+pNC8PjxORhFeaTG8noy6Jw2TzwZuFMlcx7rS4XEet9ucy1DAegyrVpNdZHsXHavP7YqZmIFNcd3UQ=="
     },
     "node_modules/@gjsify/sqlite": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.14.0.tgz",
-      "integrity": "sha512-x4I9utRR+QaZqi7iubEfjVmjPO7/WEshd/7NVhd9FEiK8zsNyAvmeDNulA+tPYKnMAgPzPe3naPxavk4M2uaqQ==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.29.0.tgz",
+      "integrity": "sha512-vjN0gYd7kW+REc8MEyNdu/93K05GH4SORgezjwQT+fcS6bIUrEaw0ypzC+ivFA6GzDlzgaEgIAIcMNeIkPM2eA==",
       "dependencies": {
-        "@girs/gda-6.0": "6.0.0-4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/gobject-2.0": "2.88.0-4.0.4"
+        "@girs/gda-6.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/stream": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.14.0.tgz",
-      "integrity": "sha512-+csw5aZfPmHwtrtUxtMxNxlK70dfaRFNBf98QiuT9y3ruihtFpXYVBdt1Zhc0h1q+z5Odhw3HaL6VA0zN41DDA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.29.0.tgz",
+      "integrity": "sha512-KdZt1UcGN2lwI4l2PfOjZ9TfmWlqK6R7fyNsN8UdXyFy76JVJrW8PHEZaT6GAYbwMb/uEm3xn9H3+/DVwuUbxw==",
       "dependencies": {
-        "@gjsify/utils": "^0.14.0",
-        "@gjsify/events": "^0.14.0",
-        "@gjsify/web-streams": "^0.14.0"
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/utils": "^0.29.0",
+        "@gjsify/web-streams": "^0.29.0"
       }
     },
     "node_modules/@gjsify/string_decoder": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.14.0.tgz",
-      "integrity": "sha512-UIOqFtZGyw7Tmt4qWDcd5D53N/alXMjo55n1qwGNh16h2T07vvDS75XxeMSNlDUKgYkzTCMQ2Nvr/A77mLmNAg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.29.0.tgz",
+      "integrity": "sha512-6sgOZVQYSMU9rR9pnpf403VTOR57ubobMHdDfr/svoJxuMm7yNZgk1/AnMLptSli2FldCTFZ+Rjw9ToCgKbZ+A==",
       "dependencies": {
-        "@gjsify/buffer": "^0.14.0"
+        "@gjsify/buffer": "^0.29.0"
       }
     },
     "node_modules/@gjsify/sys": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.14.0.tgz",
-      "integrity": "sha512-MQMgK1XI6lCI7OBmhlEcPbpMe/4FbxOmtRwaxaZflnZcIANfdeUbzRc9jzPRlwZlxBq0e4Dx/pkEWySpSLjYjg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.29.0.tgz",
+      "integrity": "sha512-jrfrinHcUHGSRvPIiNLaI9uTWlY1iJgou0s0l7y+ZN5dIVpa+diUuHck5XGinU5+v0iNi7uKz5Js9DsaFOy3ug==",
       "dependencies": {
-        "@gjsify/util": "^0.14.0"
+        "@gjsify/util": "^0.29.0"
       }
     },
     "node_modules/@gjsify/tar": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.14.0.tgz",
-      "integrity": "sha512-4QyI8mBnhydNA32c1mDviQE8DflHqTv3cxQokZR0KXnS5BRMoNS4hOUM8j0eySP3oSUBRdVd2PU2SvlB+nZOPQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.29.0.tgz",
+      "integrity": "sha512-jWlleBSQoQWMqvwmMPLfMNGGJpouzzlBITemxGrT/whAKclqrDNpzT9vKuE0n6Yr8p4IvqSROd00/3ZPBJqo+Q=="
     },
     "node_modules/@gjsify/terminal-native": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.14.0.tgz",
-      "integrity": "sha512-VuJ3/cxbi7WWqejNPJz0pPTTp7ZvZq+x0ibNipNfnvw9cYJGJmqBeEl0aRexN+i+vwv0Y4BCOZgrjH51qaedmw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.29.0.tgz",
+      "integrity": "sha512-8ykYmWFWheVuPiVwkIe9wezmoBeYF1ttaBHmWPvjDsM3Uj+NDLdkfBFXxsguGZ3Pzl6C7J/qxHBaDwnm5DivFA==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/gobject-2.0": "2.88.0-4.0.4"
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "@gjsify/terminal-native-darwin-arm64": "0.29.0",
+        "@gjsify/terminal-native-darwin-x64": "0.29.0",
+        "@gjsify/terminal-native-linux-arm64": "0.29.0",
+        "@gjsify/terminal-native-linux-ppc64": "0.29.0",
+        "@gjsify/terminal-native-linux-riscv64": "0.29.0",
+        "@gjsify/terminal-native-linux-s390x": "0.29.0",
+        "@gjsify/terminal-native-linux-x64": "0.29.0"
       }
     },
+    "node_modules/@gjsify/terminal-native-darwin-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-darwin-arm64/-/terminal-native-darwin-arm64-0.29.0.tgz",
+      "integrity": "sha512-+i6aeBjVjeiY4t5awNkaNz03UtXf4MFItyavJ9YWsbDNB/JllIGN3g4m1Nan6B06SAB/1qmEj2eSuG+vtIdL8A==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/terminal-native-darwin-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-darwin-x64/-/terminal-native-darwin-x64-0.29.0.tgz",
+      "integrity": "sha512-L0yjNFlpGiezpLgS4hpTvlmDyxS4m0lLdZFS6NZ7XEot/gvEPufmy5XS0Nw2FqS+TKnuHTy8szAKvmoMWfHhow==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/terminal-native-linux-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-arm64/-/terminal-native-linux-arm64-0.29.0.tgz",
+      "integrity": "sha512-MCbTaGuh1xs0LOWDUjRw7dGRTDqOus7Tk+5ythDZq0poxRoWB39p+AMyzhd2cvCxsqvxpTx+BvfTHKfEBUSF/g==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/terminal-native-linux-ppc64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-ppc64/-/terminal-native-linux-ppc64-0.29.0.tgz",
+      "integrity": "sha512-cBgsdySevc2hnBgoHij0Pqt8V13o0m48TC3bYSPIboWSpHY8PzO4pYY/Orhcj/qp4X9KwzVc1LWv+ovo97vaRQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/terminal-native-linux-riscv64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-riscv64/-/terminal-native-linux-riscv64-0.29.0.tgz",
+      "integrity": "sha512-ZMtiQA9vJcVFjjRGOkWDtypKkyyS6aTjfQrClGm9A3uoAmgWH38XKsbHR+iOP9ZnL4RWhGNVLt3yDdvhn/uH3w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/terminal-native-linux-s390x": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-s390x/-/terminal-native-linux-s390x-0.29.0.tgz",
+      "integrity": "sha512-mGQwlGAnPRIngXcMO1jTfckCCzGRTCOITIzKMW7suvxIUWnzbKOJlkVoLW/ywc5Pr1khEBfM66OGYLBGJFKDaQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/terminal-native-linux-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-x64/-/terminal-native-linux-x64-0.29.0.tgz",
+      "integrity": "sha512-1P+wuy7KH54sWENLQr+6JQ32PJrzLvhu2TXQId0mvsyp+kDZtUTKkWZQxTswm9inz7YXETgVZzfdisrAvaUzTg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
     "node_modules/@gjsify/timers": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.14.0.tgz",
-      "integrity": "sha512-it7WAWSNFeQnMBFHYV539soKWmwgy7B5qseNmYeNXSUegnDiEU72duL1M2G761fuhqzXfyIg3VIvDJn1/xywfg=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.29.0.tgz",
+      "integrity": "sha512-tICAxMiTPTeklJ23iyRqwqasPz7QXluRcsEHG7kEYz41ppH0KP6G88T8rrBsGNz6S6j3xahtkbQ70Tdw9x/liA=="
     },
     "node_modules/@gjsify/tls": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.14.0.tgz",
-      "integrity": "sha512-KGSTG2l01ANk5Xv1TdJ5K1sKPwxyWq0zG/0wcQQwTw+lzRrKm5ith3SyLpbAP66oGE2OpMFXvKm6bt40xtvnjA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.29.0.tgz",
+      "integrity": "sha512-CDm/rpsKLxHf+M226w/8GhbQvTfueYXqWleonRtHxWcCKTwbECWxBn0kE9wvqn/UivxruBkNnf5byYQmZ6KgOQ==",
       "dependencies": {
-        "@gjsify/net": "^0.14.0",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/utils": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/tls-native": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/net": "^0.29.0",
+        "@gjsify/tls-native": "^0.29.0",
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/tls-native": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.14.0.tgz",
-      "integrity": "sha512-k646a1KNR/4atfCYM0lPOlmKjY/ZgveQvc9BbvMul3qgcZ0N/blPIzQaGIqRuz0d1aoM1OTadnJkKj4hNQeLhA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.29.0.tgz",
+      "integrity": "sha512-xcZSiFlfDjHS9gMPBDobTM0UHTlwtIEAMfH/9IpRtRxsmYB4huFjmvm9pmdiZkH+VIZW5pGyjSqkbiDhkphfAQ==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/gobject-2.0": "2.88.0-4.0.4"
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "@gjsify/tls-native-darwin-arm64": "0.29.0",
+        "@gjsify/tls-native-darwin-x64": "0.29.0",
+        "@gjsify/tls-native-linux-arm64": "0.29.0",
+        "@gjsify/tls-native-linux-ppc64": "0.29.0",
+        "@gjsify/tls-native-linux-riscv64": "0.29.0",
+        "@gjsify/tls-native-linux-s390x": "0.29.0",
+        "@gjsify/tls-native-linux-x64": "0.29.0"
       }
     },
+    "node_modules/@gjsify/tls-native-darwin-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-darwin-arm64/-/tls-native-darwin-arm64-0.29.0.tgz",
+      "integrity": "sha512-nKsFnS0KCnFcPN+TLsoEKF1gaXTg/ZbOc5yDLRFraD0cP+3cHnlcOmVQzweCSUUW3K8wHCkU3SFE6pl4Y0ZTIg==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/tls-native-darwin-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-darwin-x64/-/tls-native-darwin-x64-0.29.0.tgz",
+      "integrity": "sha512-p/Za5fuv5lbyDIolnQhIJjMiS0kVAuGVE5A8C4zT2RCr97N6DB6J71osdt60ERm/HNdc2bOA+e68FTVoI29C1A==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/tls-native-linux-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-arm64/-/tls-native-linux-arm64-0.29.0.tgz",
+      "integrity": "sha512-9Cc/wni8WPY+qattUxNWtJpiWnmZBNsSxpE5645/7ilRXzntePHIeyLGatC0Kk7r1NCv+CMaasDNyxgv3UaNOw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/tls-native-linux-ppc64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-ppc64/-/tls-native-linux-ppc64-0.29.0.tgz",
+      "integrity": "sha512-R0eZSBAsX/zSU5W8IHmDgROliTkibS4etpi/DmFKCCBFQA4e6cUEoSGAkiT+3LxYmo30mBPaeQG7JH21YGPW2g==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/tls-native-linux-riscv64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-riscv64/-/tls-native-linux-riscv64-0.29.0.tgz",
+      "integrity": "sha512-lHmYkOkTJMv554amxyDbBW1zzW/4z8sgTrvR2Jrx1ystAZ29QCLL7aQXyda/mrSiKJargyX5wXwnVfh4Zq50Bg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/tls-native-linux-s390x": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-s390x/-/tls-native-linux-s390x-0.29.0.tgz",
+      "integrity": "sha512-hECkbAk4iEJq+7E560HhLZrpaPP77PUjDd12QFJhyMmIj4pAAPh8jXy/KoksDSFhtHaaDndTMpt9AAzlp2byMg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/tls-native-linux-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-x64/-/tls-native-linux-x64-0.29.0.tgz",
+      "integrity": "sha512-UD10rSNgSgz77+XedkRQ5QhnIbOML4MUmXUYhnavJfUz/WeMI/07GaQncAaeDypuOuqd2pAVrhixIQmEwyEHEg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
     "node_modules/@gjsify/tsc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.14.0.tgz",
-      "integrity": "sha512-jTvv1/b00Bkizas8l2R1MvceeQK4peuyulFqcKlOWGBin1ZErmb5nDY/BeZ4auQeM+m9d6JgjwV6US8mYX5FWg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.29.0.tgz",
+      "integrity": "sha512-uPgI3TBqxF4HPm98k8M692aYQZNEAlmbINZbO/0ehwQwfYljewm7zSlk8FS97WwsYHsFw40hBM5zJPNJWAzAWA==",
       "dependencies": {
-        "@gjsify/console": "^0.14.0",
-        "@gjsify/web-globals": "^0.14.0",
-        "@gjsify/node-globals": "^0.14.0"
+        "@gjsify/console": "^0.29.0",
+        "@gjsify/node-globals": "^0.29.0",
+        "@gjsify/web-globals": "^0.29.0"
       },
       "bin": {
         "gjsify-tsc": "./dist/tsc.gjs.mjs"
       }
     },
     "node_modules/@gjsify/tty": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.14.0.tgz",
-      "integrity": "sha512-He2D/WCVFxWljufaNm9kZb1PszShYWO91NGcX93Kyy9P3pOpLVjgv4SdCrMciAuMSIlMXlCVOE6y8xwwzGu5cg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.29.0.tgz",
+      "integrity": "sha512-WS9n0c7XFUBF8iX61UZkM9d3+1pc7XtFpPE/E+//rMv6Xpn4eiabtPANIgl7o1zefbdqwotley6vjYFPyoW6mA==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/stream": "^0.14.0",
-        "@gjsify/terminal-native": "^0.14.0"
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/stream": "^0.29.0",
+        "@gjsify/terminal-native": "^0.29.0"
       }
     },
     "node_modules/@gjsify/url": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.14.0.tgz",
-      "integrity": "sha512-MsFcD5sZcfrm6F9/EETfEqRj3+jBeVrmKcBFQ3U346PAUKaOJZyNcL0EkmlG0izrauEecuZX6P0pTaU7hZjB8Q==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.29.0.tgz",
+      "integrity": "sha512-5YRTnCNJyol2RS+2ad8sGsp/y2olIrXUr/dZ57Yj56tmKe68Me0akBZLz0J7D+jh6wxVIgIGKI03I3sqiWNt/w==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.4"
+        "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/util": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.14.0.tgz",
-      "integrity": "sha512-sesQg17o401aosrYgw4xqOBkTNs3jRtX0wNry0DhAb32soFF/0li61dowoUeeS3g6yxqtJk+oDn/Ke9f0ZbuuA=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.29.0.tgz",
+      "integrity": "sha512-t/X8c0NjT/ji/QlixeYDmZcvEBzzG/muMEojXjuHFVb7/wYoV2IP+wjs44RtcGvqH2KLdmx29R9PR5ycFGAWqw=="
     },
     "node_modules/@gjsify/utils": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.14.0.tgz",
-      "integrity": "sha512-HezQef9keCHtri2HsUW8F+ebR2EzwTZAJi/oR/EImbVbbgOvVMCTS3SZLxungN00LppGv4nsv1jxIm5EUSs9ng==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.29.0.tgz",
+      "integrity": "sha512-dVBdlvkp33W4C1MGc8LAL6tXEA2Ml8TZMqVmycd6JFCrNlgTrJe8FwB4Od0Qd0bOC38MqjplxgbsRKUx0Kqnbw==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/giounix-2.0": "2.0.0-4.0.4"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/giounix-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/v8": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.14.0.tgz",
-      "integrity": "sha512-l/9bT9Rfbj0UkQq4RFp+aupJeveYqLSaE0MIGHMUYTwSzn9Zs0ZHQFuiXuLnPBsM6sIGLN0YodPoUo+hyHxpoA=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.29.0.tgz",
+      "integrity": "sha512-9Pa+R6cX9skYocrezr7tCgMEiWffR1FGRHM9N6anfaGjZ/5Vcz513eoX7E2weO+kNs0AaFb3nPfmXnwVMt4rmw==",
+      "dependencies": {
+        "@girs/glib-2.0": "^4.1.0"
+      }
     },
     "node_modules/@gjsify/vite-plugin-blueprint": {
       "version": "0.14.0",
@@ -979,137 +1722,136 @@
       }
     },
     "node_modules/@gjsify/vm": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.14.0.tgz",
-      "integrity": "sha512-w6wYD0ydIPV2KKlvGJi7ubUUM9xFpJ7vSvDEedRXJUKJgYletrTdaTKA5Qs9LF9aKaomr5AyOga8jKY8oEPy2g=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.29.0.tgz",
+      "integrity": "sha512-odxFhh6pJdmqnt12d4dqphkezlOexUqU7ny7MYOIBAUaS2GfTXG/Yttb5yyo0oZTHdZA8ElmqupQUqHtok6iNA=="
     },
     "node_modules/@gjsify/web-globals": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.14.0.tgz",
-      "integrity": "sha512-Sk4XKYkBC0KLXsA0KQ7zKRB96XjyloC0hgDQrlPQ5YNyupfwx505YB2f/pkZF/nhknbKhqcAy1FLb2rKSggEaw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.29.0.tgz",
+      "integrity": "sha512-4QnMfTPe24Kvh9sAoqUyY1Vxu9f+kq6PUYtewtzuz5X6qgR2DTQznLvD5aO53dj2yBx1AGyz3lpLZ3QQe/b/Mw==",
       "dependencies": {
-        "@gjsify/url": "^0.14.0",
-        "@gjsify/buffer": "^0.14.0",
-        "@gjsify/gamepad": "^0.14.0",
-        "@gjsify/formdata": "^0.14.0",
-        "@gjsify/webaudio": "^0.14.0",
-        "@gjsify/webcrypto": "^0.14.0",
-        "@gjsify/dom-events": "^0.14.0",
-        "@gjsify/perf_hooks": "^0.14.0",
-        "@gjsify/eventsource": "^0.14.0",
-        "@gjsify/web-streams": "^0.14.0",
-        "@gjsify/dom-exception": "^0.14.0",
-        "@gjsify/abort-controller": "^0.14.0",
-        "@gjsify/compression-streams": "^0.14.0"
+        "@gjsify/abort-controller": "^0.29.0",
+        "@gjsify/buffer": "^0.29.0",
+        "@gjsify/compression-streams": "^0.29.0",
+        "@gjsify/dom-events": "^0.29.0",
+        "@gjsify/dom-exception": "^0.29.0",
+        "@gjsify/eventsource": "^0.29.0",
+        "@gjsify/formdata": "^0.29.0",
+        "@gjsify/gamepad": "^0.29.0",
+        "@gjsify/perf_hooks": "^0.29.0",
+        "@gjsify/url": "^0.29.0",
+        "@gjsify/web-streams": "^0.29.0",
+        "@gjsify/webcrypto": "^0.29.0"
       }
     },
     "node_modules/@gjsify/web-polyfills": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.14.0.tgz",
-      "integrity": "sha512-DdG1dm+cybMJSqwUQhuXLIObqq5I5hFPUbEOJJmiFQ7A3ryi+iV4s5DsWjMIUp7px8T2lWvE6+nqNgLSK6AGEw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.29.0.tgz",
+      "integrity": "sha512-JPJBBRC1lRbMrS6dJOrIaibD2G0M5CM3RWu/UBW/isYUbXWAe1V0cZwL3hruZMSyy6Y2FFDskkTQKw1LD/8Z5Q==",
       "dependencies": {
-        "@gjsify/fetch": "^0.14.0",
-        "@gjsify/gamepad": "^0.14.0",
-        "@gjsify/formdata": "^0.14.0",
-        "@gjsify/webaudio": "^0.14.0",
-        "@gjsify/domparser": "^0.14.0",
-        "@gjsify/webcrypto": "^0.14.0",
-        "@gjsify/websocket": "^0.14.0",
-        "@gjsify/dom-events": "^0.14.0",
-        "@gjsify/webstorage": "^0.14.0",
-        "@gjsify/eventsource": "^0.14.0",
-        "@gjsify/web-globals": "^0.14.0",
-        "@gjsify/web-streams": "^0.14.0",
-        "@gjsify/webassembly": "^0.14.0",
-        "@gjsify/dom-exception": "^0.14.0",
-        "@gjsify/xmlhttprequest": "^0.14.0",
-        "@gjsify/message-channel": "^0.14.0",
-        "@gjsify/abort-controller": "^0.14.0",
-        "@gjsify/compression-streams": "^0.14.0"
+        "@gjsify/abort-controller": "^0.29.0",
+        "@gjsify/compression-streams": "^0.29.0",
+        "@gjsify/dom-events": "^0.29.0",
+        "@gjsify/dom-exception": "^0.29.0",
+        "@gjsify/domparser": "^0.29.0",
+        "@gjsify/eventsource": "^0.29.0",
+        "@gjsify/fetch": "^0.29.0",
+        "@gjsify/formdata": "^0.29.0",
+        "@gjsify/gamepad": "^0.29.0",
+        "@gjsify/message-channel": "^0.29.0",
+        "@gjsify/web-globals": "^0.29.0",
+        "@gjsify/web-streams": "^0.29.0",
+        "@gjsify/webassembly": "^0.29.0",
+        "@gjsify/webaudio": "^0.29.0",
+        "@gjsify/webcrypto": "^0.29.0",
+        "@gjsify/websocket": "^0.29.0",
+        "@gjsify/webstorage": "^0.29.0",
+        "@gjsify/xmlhttprequest": "^0.29.0"
       }
     },
     "node_modules/@gjsify/web-streams": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.14.0.tgz",
-      "integrity": "sha512-B9S5nQ/mS3O+lFIzdWKgQHOmuU1IPGioTHeKv9BUcaPOfMfBoSBN2iZwGlYcZjkKf/U9zl7TsIMhBriJuvSCKw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.29.0.tgz",
+      "integrity": "sha512-CohqBvkwNcTyd4BI5+uh5PdcLGbDI4M5YIa5DFUS/axbavGhhhgvvgXvPuAgiIg4JpIB27y5OZLeNX/5iZuxGQ==",
       "dependencies": {
-        "@gjsify/utils": "^0.14.0"
+        "@gjsify/utils": "^0.29.0"
       }
     },
     "node_modules/@gjsify/webassembly": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.14.0.tgz",
-      "integrity": "sha512-DRUAneVPfIiIeA6pNv2zyoQnNh9NOtvhZqUhHsJjZOnEkyBMOmgUQAoYt26ykZiDrdgCJ0w81G6MUQSXcDz6Yg=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.29.0.tgz",
+      "integrity": "sha512-xnF8gSlXRt/1xZnWN6wPKlFprExe4mdxPFN791QKH3D/5zHZ1yYAOuz3FM5w6djWdHF4JpBXI8pQHLWK5+i6cg=="
     },
     "node_modules/@gjsify/webaudio": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.14.0.tgz",
-      "integrity": "sha512-RRteS4NO7xxocUYQXylFy6x7xUq/tZ+L7gcogJVH4m6ZHZwrpHgLRamHn5FTGlpcBAKWGncUIJ5gzRFKuojMow==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.29.0.tgz",
+      "integrity": "sha512-zEc+8IWQsPcN3Q45liqSYV5YajYCbcPBIeCWbEwWoZrWSDhW7u/oRFuDG+JjS8rrAUVdMEuG5zHAzmqv0Ehorg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.14.0"
+        "@gjsify/dom-events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/webcrypto": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.14.0.tgz",
-      "integrity": "sha512-SDUX7BSJWF/J4B8Fu1R4qfgVyjKa1p7HLoL9aXL0PZJz4R62/rOReAERdgblllMSNGSWzPa7LqShs1fBFJ5AoA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.29.0.tgz",
+      "integrity": "sha512-vZw2XJBZZ7qMbvfxYbOznmLTuEwb3SmTz5zjAymRbgMBVveNrZ0HeG+ziEAPEhW+O62sY+V18ar574vUSFccIg==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.14.0"
+        "@gjsify/dom-exception": "^0.29.0"
       }
     },
     "node_modules/@gjsify/websocket": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.14.0.tgz",
-      "integrity": "sha512-sdYi7gaYYGxUQS2jY0lm8zRt9uLa25F4Ttk9DGFBockF+YQzeaw8wWqsYxCttWc8k5M57RJkRSnFBUAVo9egrg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.29.0.tgz",
+      "integrity": "sha512-9tEvdSjoQExckAOi4PRE6r4RpgPczGrrLv2pgtTXBjmsLoCXupuxPINPVk6MWBn0KoWQkPV4YpxW5YnFHXmSkA==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@girs/soup-3.0": "3.6.6-4.0.4",
-        "@gjsify/dom-events": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/soup-3.0": "^4.1.0",
+        "@gjsify/dom-events": "^0.29.0"
       }
     },
     "node_modules/@gjsify/webstorage": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.14.0.tgz",
-      "integrity": "sha512-6lOl2JD7JKxcfpXusjbC+2Jej+IEb6IFfVzT/94g6McOpA0MKItR2ojCbbcRQMlX1rVBLUowgGR/dJyXF8NQSg=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.29.0.tgz",
+      "integrity": "sha512-EdspmWzRf9FaZyEx1wMshTyWe5GZqGv4lZHDWNuuuYF6ft1SXCNF3UUqPgCg1iGokvQfgd7FWdmbomL4EoNLnA=="
     },
     "node_modules/@gjsify/worker_threads": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.14.0.tgz",
-      "integrity": "sha512-qOaZnCm+/PRUM2mK2IhnBz+ZKhi1G3oP3QzPbaJhfEqez1ASP/WTc9FOm/72ZJgU5bW38IDldRT9iddmzg//ZA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.29.0.tgz",
+      "integrity": "sha512-biC3jeMkdsdTBpSSL79cs5W6DtMtLrq2/RFDME05W14xMl3ufDj0VZnQeqUHZupd33mwdQuOzE9ICGIwU+J19A==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/events": "^0.14.0",
-        "@gjsify/sab-native": "^0.14.0",
-        "@gjsify/message-channel": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/events": "^0.29.0",
+        "@gjsify/message-channel": "^0.29.0",
+        "@gjsify/sab-native": "^0.29.0"
       }
     },
     "node_modules/@gjsify/workspace": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.14.0.tgz",
-      "integrity": "sha512-HUH1WUCQhd3pFQZ8KDhv1HUA8HAdlW+eHHfs34aQpX0kmXKee+GsqiOs1C/0gtUyPuGt7SIXEBZzVUgTtFzVyQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.29.0.tgz",
+      "integrity": "sha512-Uil8hMx+2hZgAHeoouspajlvjyGkzntxMw2dAZwgAQOi+bV4ZDrVF/G5QE0vAgYtanwxpGhbvla0MNrCgzFv1A=="
     },
     "node_modules/@gjsify/xmlhttprequest": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.14.0.tgz",
-      "integrity": "sha512-HrUuSF91xiR5K7noevY8cPRodFKF2L6uVUcpWcZVs6HjPXE0oDTTPkDfEo3mH5nDRgiYx1ElpsI6z8We6X4Ebg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.29.0.tgz",
+      "integrity": "sha512-/5HzY9C2NZcqBAYMrTEbA98rBN6y4qoIQJg0mBYptIskG/hRxDe86XTQrCw8Jr4Opr4JCOObCaqM8WnCVGIdZw==",
       "dependencies": {
-        "@girs/gjs": "4.0.4",
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@gjsify/fetch": "^0.14.0",
-        "@girs/glib-2.0": "2.88.0-4.0.4"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/fetch": "^0.29.0"
       }
     },
     "node_modules/@gjsify/zlib": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.14.0.tgz",
-      "integrity": "sha512-FeyQm2a8U1vQ4BgwMwDG/Nvi3XYpL8HwAGOO6xnuboQaGY8nN9oTRAXYI3yKYJaPw6qYQr2LiONbKv1xI4USTw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.29.0.tgz",
+      "integrity": "sha512-f9sVbCz7DLmrfiDJXlLV/HQHgMil7gOSZzNPn1RtMq/6yA4sH8wb2yJu8dcSONxDv6JZvMXw6dF+7GiL+Jb9gw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.4",
-        "@girs/glib-2.0": "2.88.0-4.0.4",
-        "@gjsify/stream": "^0.14.0"
+        "@girs/gio-2.0": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@gjsify/stream": "^0.29.0"
       }
     },
     "node_modules/@iarna/toml": {
@@ -1330,32 +2072,74 @@
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.8.5.tgz",
-      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw=="
+      "integrity": "sha512-KPDeVScZgA1oq0CiPBcOa3kHIqU+pTOwRFDIhxvmf8CTNvqdZQYp5cCKW0bUk69VygB2PuTiINFWbY78aR2pQw==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.8.5.tgz",
-      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug=="
+      "integrity": "sha512-w/sLhN4T7MW1nB3R/U8WK5BgQLz904wh+/SmA2jD8NnF7BLLoUgflCNxOeSPOWp8geP6nP/+VjWzZVip7rZ1ug==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.8.5.tgz",
-      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg=="
+      "integrity": "sha512-c0TGMbm2M55pwTDIfkDLB6BpIsgxV4PjYck2HiOX+cy/JWiBXz32lYbarPqejKs9Flm7YVAKSILUducU9g2RVg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.8.5.tgz",
-      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww=="
+      "integrity": "sha512-vtbZRHH5UDlL01TT5jB576Zox3+hdyogvpcbvVJlmU5PdL3c5V7cj1EODdh1CHPksRl+cws/58ugEHi8bcj4Ww==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.8.5.tgz",
-      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ=="
+      "integrity": "sha512-Xkc8IUx9aEhP0zvgeKy7IQ3ReX2N8N1L0WPcQwnZweWmOuKfwpS3GRIYqLtK5za/w3E60zhFfNdS+3pBZPytqQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.8.5.tgz",
-      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ=="
+      "integrity": "sha512-4wvrf5BgnR8RpogHhtpCPJMKBmvyZPhhUtEwMJbXh0ni2BucpfF07jlmyM11zRqQ2XIq6PbC2j7W7UCCcm1rRQ==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@marcj/ts-clone-node": {
       "version": "2.2.0",
@@ -1378,32 +2162,74 @@
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
-      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
-      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
-      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
-      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
-      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
-      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1411,7 +2237,8 @@
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
-      }
+      },
+      "optional": true
     },
     "node_modules/@needle-di/core": {
       "version": "1.1.2",
@@ -1419,9 +2246,9 @@
       "integrity": "sha512-9CVnXjK33JeqUwAz5k/D+ti4ZfJ17m5AXsUcOwErbQ8baTNDPt1erVFGjipxxwcUj86Oxap3dALz6U70xsUsFg=="
     },
     "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
     },
     "node_modules/@nodable/entities": {
       "version": "2.2.0",
@@ -1461,13 +2288,13 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dependencies": {
-        "@octokit/auth-token": "^6.0.0",
+        "@octokit/types": "^16.0.0",
         "@octokit/graphql": "^9.0.3",
         "@octokit/request": "^10.0.6",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
         "before-after-hook": "^4.0.0",
-        "universal-user-agent": "^7.0.0"
+        "@octokit/auth-token": "^6.0.0",
+        "universal-user-agent": "^7.0.0",
+        "@octokit/request-error": "^7.0.2"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -1484,8 +2311,8 @@
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "dependencies": {
-        "@octokit/request": "^10.0.6",
         "@octokit/types": "^16.0.0",
+        "@octokit/request": "^10.0.6",
         "universal-user-agent": "^7.0.0"
       }
     },
@@ -1542,8 +2369,8 @@
       "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
       "dependencies": {
         "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
         "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
         "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
       }
     },
@@ -1556,104 +2383,261 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA=="
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.72.0.tgz",
-      "integrity": "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA=="
+      "integrity": "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-android-arm64": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.72.0.tgz",
-      "integrity": "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ=="
+      "integrity": "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.72.0.tgz",
-      "integrity": "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ=="
+      "integrity": "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-darwin-x64": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.72.0.tgz",
-      "integrity": "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ=="
+      "integrity": "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.72.0.tgz",
-      "integrity": "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag=="
+      "integrity": "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.72.0.tgz",
-      "integrity": "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A=="
+      "integrity": "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.72.0.tgz",
-      "integrity": "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ=="
+      "integrity": "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.72.0.tgz",
-      "integrity": "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ=="
+      "integrity": "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.72.0.tgz",
-      "integrity": "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg=="
+      "integrity": "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.72.0.tgz",
-      "integrity": "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg=="
+      "integrity": "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.72.0.tgz",
-      "integrity": "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA=="
+      "integrity": "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.72.0.tgz",
-      "integrity": "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ=="
+      "integrity": "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.72.0.tgz",
-      "integrity": "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w=="
+      "integrity": "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.72.0.tgz",
-      "integrity": "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw=="
+      "integrity": "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.72.0.tgz",
-      "integrity": "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA=="
+      "integrity": "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.72.0.tgz",
-      "integrity": "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg=="
+      "integrity": "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==",
+      "os": [
+        "openharmony"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.72.0.tgz",
-      "integrity": "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg=="
+      "integrity": "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.72.0.tgz",
-      "integrity": "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ=="
+      "integrity": "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.72.0.tgz",
-      "integrity": "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA=="
+      "integrity": "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/bundler-default": {
       "version": "2.16.4",
@@ -2166,47 +3150,125 @@
         "@parcel/rust-linux-arm64-gnu": "2.16.4",
         "@parcel/rust-linux-arm64-musl": "2.16.4",
         "@parcel/rust-linux-arm-gnueabihf": "2.16.4"
+      },
+      "optionalDependencies": {
+        "@parcel/rust-darwin-x64": "2.16.4",
+        "@parcel/rust-darwin-arm64": "2.16.4",
+        "@parcel/rust-linux-x64-gnu": "2.16.4",
+        "@parcel/rust-linux-x64-musl": "2.16.4",
+        "@parcel/rust-win32-x64-msvc": "2.16.4",
+        "@parcel/rust-linux-arm64-gnu": "2.16.4",
+        "@parcel/rust-linux-arm64-musl": "2.16.4",
+        "@parcel/rust-linux-arm-gnueabihf": "2.16.4"
       }
     },
     "node_modules/@parcel/rust-darwin-arm64": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-arm64/-/rust-darwin-arm64-2.16.4.tgz",
-      "integrity": "sha512-P3Se36H9EO1fOlwXqQNQ+RsVKTGn5ztRSUGbLcT8ba6oOMmU1w7J4R810GgsCbwCuF10TJNUMkuD3Q2Sz15Q3Q=="
+      "integrity": "sha512-P3Se36H9EO1fOlwXqQNQ+RsVKTGn5ztRSUGbLcT8ba6oOMmU1w7J4R810GgsCbwCuF10TJNUMkuD3Q2Sz15Q3Q==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/rust-darwin-x64": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-darwin-x64/-/rust-darwin-x64-2.16.4.tgz",
-      "integrity": "sha512-8aNKNyPIx3EthYpmVJevIdHmFsOApXAEYGi3HU69jTxLgSIfyEHDdGE9lEsMvhSrd/SSo4/euAtiV+pqK04wnA=="
+      "integrity": "sha512-8aNKNyPIx3EthYpmVJevIdHmFsOApXAEYGi3HU69jTxLgSIfyEHDdGE9lEsMvhSrd/SSo4/euAtiV+pqK04wnA==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/rust-linux-arm-gnueabihf": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm-gnueabihf/-/rust-linux-arm-gnueabihf-2.16.4.tgz",
-      "integrity": "sha512-QrvqiSHaWRLc0JBHgUHVvDthfWSkA6AFN+ikV1UGENv4j2r/QgvuwJiG0VHrsL6pH5dRqj0vvngHzEgguke9DA=="
+      "integrity": "sha512-QrvqiSHaWRLc0JBHgUHVvDthfWSkA6AFN+ikV1UGENv4j2r/QgvuwJiG0VHrsL6pH5dRqj0vvngHzEgguke9DA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/rust-linux-arm64-gnu": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-gnu/-/rust-linux-arm64-gnu-2.16.4.tgz",
-      "integrity": "sha512-f3gBWQHLHRUajNZi3SMmDQiEx54RoRbXtZYQNuBQy7+NolfFcgb1ik3QhkT7xovuTF/LBmaqP3UFy0PxvR/iwQ=="
+      "integrity": "sha512-f3gBWQHLHRUajNZi3SMmDQiEx54RoRbXtZYQNuBQy7+NolfFcgb1ik3QhkT7xovuTF/LBmaqP3UFy0PxvR/iwQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/rust-linux-arm64-musl": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-linux-arm64-musl/-/rust-linux-arm64-musl-2.16.4.tgz",
-      "integrity": "sha512-cwml18RNKsBwHyZnrZg4jpecXkWjaY/mCArocWUxkFXjjB97L56QWQM9W86f2/Y3HcFcnIGJwx1SDDKJrV6OIA=="
+      "integrity": "sha512-cwml18RNKsBwHyZnrZg4jpecXkWjaY/mCArocWUxkFXjjB97L56QWQM9W86f2/Y3HcFcnIGJwx1SDDKJrV6OIA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/rust-linux-x64-gnu": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-gnu/-/rust-linux-x64-gnu-2.16.4.tgz",
-      "integrity": "sha512-0xIjQaN8hiG0F9R8coPYidHslDIrbfOS/qFy5GJNbGA3S49h61wZRBMQqa7JFW4+2T8R0J9j0SKHhLXpbLXrIg=="
+      "integrity": "sha512-0xIjQaN8hiG0F9R8coPYidHslDIrbfOS/qFy5GJNbGA3S49h61wZRBMQqa7JFW4+2T8R0J9j0SKHhLXpbLXrIg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/rust-linux-x64-musl": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-linux-x64-musl/-/rust-linux-x64-musl-2.16.4.tgz",
-      "integrity": "sha512-fYn21GIecHK9RoZPKwT9NOwxwl3Gy3RYPR6zvsUi0+hpFo19Ph9EzFXN3lT8Pi5KiwQMCU4rsLb5HoWOBM1FeA=="
+      "integrity": "sha512-fYn21GIecHK9RoZPKwT9NOwxwl3Gy3RYPR6zvsUi0+hpFo19Ph9EzFXN3lT8Pi5KiwQMCU4rsLb5HoWOBM1FeA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/rust-win32-x64-msvc": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/@parcel/rust-win32-x64-msvc/-/rust-win32-x64-msvc-2.16.4.tgz",
-      "integrity": "sha512-TcpWC3I1mJpfP2++018lgvM7UX0P8IrzNxceBTHUKEIDMwmAYrUKAQFiaU0j1Ldqk6yP8SPZD3cvphumsYpJOQ=="
+      "integrity": "sha512-TcpWC3I1mJpfP2++018lgvM7UX0P8IrzNxceBTHUKEIDMwmAYrUKAQFiaU0j1Ldqk6yP8SPZD3cvphumsYpJOQ==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/source-map": {
       "version": "2.1.1",
@@ -2419,76 +3481,200 @@
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
       "dependencies": {
-        "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
-        "node-addon-api": "^7.0.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.3",
+        "detect-libc": "^2.0.3",
+        "node-addon-api": "^7.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-win32-x64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-darwin-x64": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-linux-arm-musl": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-win32-arm64": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-win32-ia32": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/watcher-win32-x64": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@parcel/workers": {
       "version": "2.16.4",
@@ -2513,15 +3699,15 @@
       "resolved": "https://registry.npmjs.org/@release-it/bumper/-/bumper-7.0.6.tgz",
       "integrity": "sha512-vzKrEGPac/yim5WUjMmIQ9k+n3NlWHYraUIlLkHna2Ka0+zmmB1peW8POMjA6Fb7TwcIsNMuoXj2wLc8NFzgRg==",
       "dependencies": {
-        "@decimalturn/toml-patch": "^1.3.0",
-        "@iarna/toml": "^3.0.0",
-        "cheerio": "^1.2.0",
-        "detect-indent": "7.0.2",
-        "fast-glob": "^3.3.3",
         "ini": "^6.0.0",
+        "semver": "^7.8.1",
+        "cheerio": "^1.2.0",
         "js-yaml": "^4.1.1",
+        "fast-glob": "^3.3.3",
         "lodash-es": "^4.18.1",
-        "semver": "^7.8.1"
+        "@iarna/toml": "^3.0.0",
+        "detect-indent": "7.0.2",
+        "@decimalturn/toml-patch": "^1.3.0"
       }
     },
     "node_modules/@release-it/conventional-changelog": {
@@ -2529,74 +3715,176 @@
       "resolved": "https://registry.npmjs.org/@release-it/conventional-changelog/-/conventional-changelog-11.0.1.tgz",
       "integrity": "sha512-SHAnHfOFhazpDeYuQSqH8Qm8RJa2oREn2ILSod+9s8dqiA18mBgpPyYlpvRaqISCVerSmLzEZghQBKphkrf4IQ==",
       "dependencies": {
-        "@conventional-changelog/git-client": "^2.7.0",
+        "semver": "^7.7.4",
         "concat-stream": "^2.0.0",
         "conventional-changelog": "^7.2.0",
-        "conventional-changelog-angular": "^8.3.1",
-        "conventional-changelog-conventionalcommits": "^9.3.1",
         "conventional-recommended-bump": "^11.2.0",
-        "semver": "^7.7.4"
+        "conventional-changelog-angular": "^8.3.1",
+        "@conventional-changelog/git-client": "^2.7.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "os": [
+        "openharmony"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.3",
@@ -2606,17 +3894,35 @@
         "@emnapi/core": "1.11.1",
         "@emnapi/runtime": "1.11.1",
         "@napi-rs/wasm-runtime": "^1.1.6"
-      }
+      },
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
@@ -2648,127 +3954,341 @@
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw=="
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A=="
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA=="
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw=="
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg=="
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg=="
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA=="
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA=="
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ=="
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg=="
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ=="
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A=="
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w=="
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg=="
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q=="
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg=="
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A=="
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg=="
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg=="
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "os": [
+        "openbsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA=="
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "os": [
+        "openharmony"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg=="
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q=="
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg=="
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -2847,69 +4367,185 @@
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
       "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.27"
+        "@swc/types": "^0.1.27",
+        "@swc/counter": "^0.1.3"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-x64": "1.15.43",
+        "@swc/core-darwin-arm64": "1.15.43",
+        "@swc/core-linux-x64-gnu": "1.15.43",
+        "@swc/core-linux-x64-musl": "1.15.43",
+        "@swc/core-win32-x64-msvc": "1.15.43",
+        "@swc/core-linux-arm64-gnu": "1.15.43",
+        "@swc/core-linux-ppc64-gnu": "1.15.43",
+        "@swc/core-linux-s390x-gnu": "1.15.43",
+        "@swc/core-win32-ia32-msvc": "1.15.43",
+        "@swc/core-linux-arm64-musl": "1.15.43",
+        "@swc/core-win32-arm64-msvc": "1.15.43",
+        "@swc/core-linux-arm-gnueabihf": "1.15.43"
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
-      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA=="
+      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-darwin-x64": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
-      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ=="
+      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
-      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA=="
+      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
-      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw=="
+      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-linux-arm64-musl": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
-      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ=="
+      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
-      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg=="
+      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
-      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA=="
+      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-linux-x64-gnu": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
-      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg=="
+      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-linux-x64-musl": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
-      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ=="
+      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
-      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw=="
+      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
-      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g=="
+      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true
     },
     "node_modules/@swc/core-win32-x64-msvc": {
       "version": "1.15.43",
       "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
-      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg=="
+      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -2943,12 +4579,14 @@
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "optional": true
     },
     "node_modules/@tybys/wasm-util/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "optional": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4030,8 +5668,8 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
       "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
       "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
+        "tapable": "^2.3.3",
+        "graceful-fs": "^4.2.4"
       }
     },
     "node_modules/entities": {
@@ -4074,6 +5712,34 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      },
       "bin": {
         "esbuild": "bin/esbuild"
       }
@@ -4098,6 +5764,9 @@
         "esprima": "^4.0.1",
         "source-map": "~0.6.1"
       },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      },
       "bin": {
         "esgenerate": "bin/esgenerate.js",
         "escodegen": "bin/escodegen.js"
@@ -4111,7 +5780,8 @@
     "node_modules/escodegen/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -4174,18 +5844,18 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
       "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
         "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
         "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
         "pretty-ms": "^9.2.0",
+        "get-stream": "^9.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.1.0",
+        "yoctocolors": "^2.1.1",
+        "is-plain-obj": "^4.1.0",
+        "npm-run-path": "^6.0.0",
+        "human-signals": "^8.0.1",
         "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
+        "@sindresorhus/merge-streams": "^4.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -4328,7 +5998,11 @@
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "os": [
+        "darwin"
+      ],
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -4457,6 +6131,9 @@
         "wordwrap": "^1.0.0",
         "uglify-js": "^3.1.4"
       },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      },
       "bin": {
         "handlebars": "bin/handlebars"
       }
@@ -4551,6 +6228,11 @@
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
+    },
+    "node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4823,62 +6505,164 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dependencies": {
         "detect-libc": "^2.0.3"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -4909,6 +6693,14 @@
         "@lmdb/lmdb-linux-arm64": "2.8.5",
         "@lmdb/lmdb-darwin-arm64": "2.8.5",
         "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-linux-arm": "2.8.5",
+        "@lmdb/lmdb-linux-x64": "2.8.5",
+        "@lmdb/lmdb-win32-x64": "2.8.5",
+        "@lmdb/lmdb-darwin-x64": "2.8.5",
+        "@lmdb/lmdb-linux-arm64": "2.8.5",
+        "@lmdb/lmdb-darwin-arm64": "2.8.5"
       },
       "bin": {
         "download-lmdb-prebuilds": "bin/download-prebuilds.js"
@@ -5153,7 +6945,10 @@
     "node_modules/msgpackr": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.12.1.tgz",
-      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="
+      "integrity": "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
     },
     "node_modules/msgpackr-extract": {
       "version": "3.0.4",
@@ -5162,9 +6957,18 @@
       "dependencies": {
         "node-gyp-build-optional-packages": "5.2.2"
       },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      },
       "bin": {
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
-      }
+      },
+      "optional": true
     },
     "node_modules/mute-stream": {
       "version": "3.0.0",
@@ -5218,7 +7022,8 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
-      }
+      },
+      "optional": true
     },
     "node_modules/node-releases": {
       "version": "2.0.50",
@@ -5344,8 +7149,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
+        "strip-ansi": "^7.1.2",
+        "get-east-asian-width": "^1.5.0"
       }
     },
     "node_modules/ordered-binary": {
@@ -5366,6 +7171,27 @@
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.72.0.tgz",
       "integrity": "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==",
+      "optionalDependencies": {
+        "@oxlint/binding-darwin-x64": "1.72.0",
+        "@oxlint/binding-freebsd-x64": "1.72.0",
+        "@oxlint/binding-darwin-arm64": "1.72.0",
+        "@oxlint/binding-android-arm64": "1.72.0",
+        "@oxlint/binding-linux-x64-gnu": "1.72.0",
+        "@oxlint/binding-linux-x64-musl": "1.72.0",
+        "@oxlint/binding-win32-x64-msvc": "1.72.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.72.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.72.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.72.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.72.0",
+        "@oxlint/binding-android-arm-eabi": "1.72.0",
+        "@oxlint/binding-linux-arm64-musl": "1.72.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.72.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.72.0",
+        "@oxlint/binding-openharmony-arm64": "1.72.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.72.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.72.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.72.0"
+      },
       "bin": {
         "oxlint": "bin/oxlint"
       }
@@ -5963,12 +7789,28 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "dependencies": {
-        "@oxc-project/types": "=0.137.0",
+        "@oxc-project/types": "=0.143.0",
         "@rolldown/pluginutils": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3"
       },
       "bin": {
         "rolldown": "./bin/cli.mjs"
@@ -5980,6 +7822,34 @@
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "dependencies": {
         "@types/estree": "1.0.9"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -6025,6 +7895,22 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sass": {
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
+      "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      },
+      "bin": {
+        "sass": "sass.js"
+      }
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -6251,10 +8137,10 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
         "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
+        "source-map-support": "~0.5.20",
+        "@jridgewell/source-map": "^0.3.3"
       },
       "bin": {
         "terser": "bin/terser"
@@ -6360,11 +8246,11 @@
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
       "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
-        "markdown-it": "^14.1.1",
+        "yaml": "^2.8.3",
         "minimatch": "^10.2.5",
-        "yaml": "^2.8.3"
+        "markdown-it": "^14.1.1",
+        "@gerrit0/mini-shiki": "^3.23.0"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -6390,7 +8276,8 @@
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "bin": {
         "uglifyjs": "bin/uglifyjs"
-      }
+      },
+      "optional": true
     },
     "node_modules/undici": {
       "version": "7.28.0",
@@ -6467,9 +8354,232 @@
         "tinyglobby": "^0.2.17",
         "lightningcss": "^1.32.0"
       },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
       "bin": {
         "vite": "bin/vite.js"
       }
+    },
+    "node_modules/vite/node_modules/rolldown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
+      "dependencies": {
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3"
+      },
+      "bin": {
+        "rolldown": "./bin/cli.mjs"
+      }
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
+      "os": [
+        "android"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
+      "os": [
+        "freebsd"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
+      "os": [
+        "openharmony"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
     },
     "node_modules/vite/node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -6533,28 +8643,28 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.3.tgz",
       "integrity": "sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==",
       "dependencies": {
+        "acorn": "^8.16.0",
+        "events": "^3.2.0",
+        "mime-db": "^1.54.0",
+        "tapable": "^2.3.0",
+        "neo-async": "^2.6.2",
+        "watchpack": "^2.5.2",
+        "graceful-fs": "^4.2.11",
+        "browserslist": "^4.28.1",
+        "eslint-scope": "5.1.1",
+        "schema-utils": "^4.3.3",
         "@types/estree": "^1.0.8",
+        "loader-runner": "^4.3.2",
+        "es-module-lexer": "^2.1.0",
+        "webpack-sources": "^3.5.0",
+        "enhanced-resolve": "^5.22.2",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.2",
-        "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.2",
-        "mime-db": "^1.54.0",
+        "acorn-import-phases": "^1.0.3",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
         "minimizer-webpack-plugin": "^5.6.1",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "watchpack": "^2.5.2",
-        "webpack-sources": "^3.5.0"
+        "@webassemblyjs/wasm-parser": "^1.14.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -6565,14 +8675,14 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.1.0.tgz",
       "integrity": "sha512-pSJ5p5PkXRD88sfCq5Wo+coc42QykwRu5Md0DyESj0rT6PPPA2wTNabpHPKgqH8EMkfTDo3IWx3iiNXMu8XDBQ==",
       "dependencies": {
-        "@discoveryjs/json-ext": "^1.1.0",
-        "commander": "^14.0.3",
-        "cross-spawn": "^7.0.6",
         "envinfo": "^7.21.0",
-        "import-local": "^3.2.0",
-        "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
-        "webpack-merge": "^6.0.1"
+        "commander": "^14.0.3",
+        "interpret": "^3.1.1",
+        "cross-spawn": "^7.0.6",
+        "import-local": "^3.2.0",
+        "webpack-merge": "^6.0.1",
+        "@discoveryjs/json-ext": "^1.1.0"
       },
       "bin": {
         "webpack-cli": "bin/cli.js"

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -3,6 +3,7 @@
   "requested": [
     "@biomejs/biome@^2.5.1",
     "@gjsify/cli@^0.29.0",
+    "@gjsify/rolldown-native@^0.29.0",
     "@release-it/bumper@^7.0.6",
     "@release-it/conventional-changelog@^11.0.1",
     "concurrently@^10.0.3",
@@ -1254,6 +1255,73 @@
       "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.29.0.tgz",
       "integrity": "sha512-KfqfQ4llyWiO+4pA5cNLj+reHU4gbmgBhSwrStwwLaJ5kwLeukXCeQQtWqMLJWUlBRSg/UMluYAIrIntdr/tsQ=="
     },
+    "node_modules/@gjsify/rolldown-native": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native/-/rolldown-native-0.29.0.tgz",
+      "integrity": "sha512-bx1MgBUHz9G/h4h+brIRdaVTnLQWJY9NIIt5XeuMIdMKM/HE3scMitd9KfCty6IZNLz5zcpw8pcm+4bj8ZJqkA==",
+      "dependencies": {
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "@gjsify/rolldown-native-darwin-arm64": "0.29.0",
+        "@gjsify/rolldown-native-darwin-x64": "0.29.0",
+        "@gjsify/rolldown-native-linux-arm64": "0.29.0",
+        "@gjsify/rolldown-native-linux-x64": "0.29.0"
+      }
+    },
+    "node_modules/@gjsify/rolldown-native-darwin-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-darwin-arm64/-/rolldown-native-darwin-arm64-0.29.0.tgz",
+      "integrity": "sha512-Eq+IatupBVG+eRx12HrxeQVjcMwdpUbv2fj6uOsFxtWCgpqcp8fhSiq5EMd9Y762z23lRvLorzS9UNCQh0WdWQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/rolldown-native-darwin-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-darwin-x64/-/rolldown-native-darwin-x64-0.29.0.tgz",
+      "integrity": "sha512-4KxQefa3UT3hNhv+/lUvJBQNN6OByS+nG2YqOkYWCKvxW7tyrcinlmm33NxvaNTxwFWyB9Cx9Pn4BulA2AePiQ==",
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/rolldown-native-linux-arm64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-linux-arm64/-/rolldown-native-linux-arm64-0.29.0.tgz",
+      "integrity": "sha512-DwgFIcdBBQpGkX8de+oRuRDF/6ffi9ddKBbUZj88rgQ2IyoshOPLEZAKWiX5sgr/564zdj0leCIABJ9w5c85UA==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true
+    },
+    "node_modules/@gjsify/rolldown-native-linux-x64": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-linux-x64/-/rolldown-native-linux-x64-0.29.0.tgz",
+      "integrity": "sha512-s97JQvx8pDy1851SICpuWLfOjFxFA8qjV9HmX5FyojGIZvx4DtNJK9moUYjKbEPkRmcbheFZopnZir2ddXo7SQ==",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true
+    },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.29.0.tgz",
@@ -1288,14 +1356,6 @@
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
-      }
-    },
-    "node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/acorn": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-      "bin": {
-        "acorn": "bin/acorn"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-pnp": {
@@ -4928,9 +4988,9 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "bin": {
         "acorn": "bin/acorn"
       }

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -2,8 +2,8 @@
   "lockfileVersion": 4,
   "requested": [
     "@biomejs/biome@^2.5.1",
-    "@gjsify/cli@^0.29.0",
-    "@gjsify/rolldown-native@^0.29.0",
+    "@gjsify/cli@^0.30.0",
+    "@gjsify/rolldown-native@^0.30.0",
     "@release-it/bumper@^7.0.6",
     "@release-it/conventional-changelog@^11.0.1",
     "concurrently@^10.0.3",
@@ -616,64 +616,64 @@
       }
     },
     "node_modules/@gjsify/abort-controller": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.29.0.tgz",
-      "integrity": "sha512-Q701KF06kU4xMcDaYVgbw0w8w5tO2G57W5pTEzjYWE/nYRV2YcM/KF07277oH00b1N+MJMRkp1uKLy3+DcGqkg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.30.0.tgz",
+      "integrity": "sha512-G2Kw8K+mdg/hRl6Pjr5AxekUsytIlWDiVDk1L3bEDyCZabRD+piN4bMGOGLPbpPQFrxjXMR22g3wggpKa/aCIw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.29.0"
+        "@gjsify/dom-events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/assert": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.29.0.tgz",
-      "integrity": "sha512-GVJwwPhZjVtX8JcIfhfVz7CkHCAAUFmo0GbMlju1l119xTLPil9GoMADHN4MSOSnMJfINmDdfulLYvrp/bRaUQ=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.30.0.tgz",
+      "integrity": "sha512-vNLTzT9TQxAekl1uXAKM7sIRbuUGV1PsuDTXoWYy21d677pOIrs4OpIZ9z28uvz46vmChcNF6Am+GAchhhF/NA=="
     },
     "node_modules/@gjsify/async_hooks": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.29.0.tgz",
-      "integrity": "sha512-Q3x4VUKQ33WVPItUfOgt3VU0/O5veeP5UTKuIWIK5ms7ooCNBLB7xZLv+c13jLbth63pKFH7aSNBCSHnK3cKqA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.30.0.tgz",
+      "integrity": "sha512-kZwFrBBe+B4MDqoRg7TkSialOoSJNd1XLVvUg3DNdOI28VtPieWhMxN99zjCacAf55PWBzk20MvNDPdholHsOg==",
       "dependencies": {
-        "@gjsify/events": "^0.29.0"
+        "@gjsify/events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/buffer": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.29.0.tgz",
-      "integrity": "sha512-JExwAhfple9XaTrVwMBxY7EbeT423fB2LzXXtHeCLIgfScEnfKLudqWabmYr7qdFye0rFQaRUq6jMvW/4njdhQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.30.0.tgz",
+      "integrity": "sha512-ri6EZ3jGvyJuhTrZuXT+DiOPQbeduz77m86/K80x5JsM1NOOX35/HlmjwEgv4OtdbexHJ6pswTS7+Kh0wVyTaA==",
       "dependencies": {
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/child_process": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.29.0.tgz",
-      "integrity": "sha512-UMJJNOSPApYNij+gkcY4drO5Ldd0DES2RIfpTXk/K1i4hDmIE1wGJsog4KKKYEY0c2pxXMIpmjCzIrIY1wBWUA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.30.0.tgz",
+      "integrity": "sha512-Y0K1K6SLuWyULA3YAzlFeSFVkxkBEv9cqojJfoA92Rndeu45DO6oHN37pimQpH1Rdz7VrpuXoK7S3EXjgLd/rw==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-rs6T7slFWCgWLpGcY2q3dS9t8AxluNi8m2MuUykLNPQieMjFEOEft5W+goxznV7Bg3nEAZVB4naDYwBf5Qp/bw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.30.0.tgz",
+      "integrity": "sha512-ZvCbEjiab/yBzpj9nMWEx29Jzo+bHplW+kOPXk3gJwyThdR80Ape7CqpSep57m48/DOsBGtE7IG32X4Ip07JXg==",
       "dependencies": {
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/create-app": "^0.29.0",
-        "@gjsify/node-globals": "^0.29.0",
-        "@gjsify/node-polyfills": "^0.29.0",
-        "@gjsify/npm-registry": "^0.29.0",
-        "@gjsify/resolve-npm": "^0.29.0",
-        "@gjsify/rolldown-plugin-gjsify": "^0.29.0",
-        "@gjsify/rolldown-plugin-pnp": "^0.29.0",
-        "@gjsify/semver": "^0.29.0",
-        "@gjsify/tar": "^0.29.0",
-        "@gjsify/tsc": "^0.29.0",
-        "@gjsify/web-polyfills": "^0.29.0",
-        "@gjsify/workspace": "^0.29.0",
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/create-app": "^0.30.0",
+        "@gjsify/node-globals": "^0.30.0",
+        "@gjsify/node-polyfills": "^0.30.0",
+        "@gjsify/npm-registry": "^0.30.0",
+        "@gjsify/resolve-npm": "^0.30.0",
+        "@gjsify/rolldown-plugin-gjsify": "^0.30.0",
+        "@gjsify/rolldown-plugin-pnp": "^0.30.0",
+        "@gjsify/semver": "^0.30.0",
+        "@gjsify/tar": "^0.30.0",
+        "@gjsify/tsc": "^0.30.0",
+        "@gjsify/web-polyfills": "^0.30.0",
+        "@gjsify/workspace": "^0.30.0",
         "cosmiconfig": "^9.0.2",
         "get-tsconfig": "^4.14.0",
         "pkg-types": "^2.3.1",
@@ -685,193 +685,193 @@
       }
     },
     "node_modules/@gjsify/cluster": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.29.0.tgz",
-      "integrity": "sha512-scRO/3bbjfn4Nqfcaaw92CX3FqErx6BH46mdjNYoDysndy98mZXAnVpUTQkeaL0hUTIgRmMU8ZkDYtXV6JA0rg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.30.0.tgz",
+      "integrity": "sha512-ChsyeQuIGCfuLZNIa29v134eIYyeDeJ/edfcfdjZDLmmrn6fWRgfnwF7hn0BgT6zII0zCUmukwRa2Aauftx85w==",
       "dependencies": {
-        "@gjsify/events": "^0.29.0"
+        "@gjsify/events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/compression-streams": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.29.0.tgz",
-      "integrity": "sha512-aD8UXJgTj9u0ASxCvN6phVFosATj1dq7bXw45xxglEToLGvApSIZYJlRs7XpxniE4LdSdOi3Fh+4SLxHiEi91g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.30.0.tgz",
+      "integrity": "sha512-ud10PT+kQZDLrBH3MU77MTFKqP6ySVOcgTynK863a0rInfwylKtJk+tHeUyPINzjbpp16v2S7rV0GITE5XEeaQ==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.29.0"
+        "@gjsify/web-streams": "^0.30.0"
       }
     },
     "node_modules/@gjsify/console": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.29.0.tgz",
-      "integrity": "sha512-SEk1FMUylcfHzqQYKB0B9NojkH3BfWpitILHkC8/+j8j7OF93pOFj/qbd+rlbLUuJu7CNdC1i/DJXkrAU78vbQ=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.30.0.tgz",
+      "integrity": "sha512-KLMj03D0jNn/tqgvG3CuGs8RzpeIAnQQAOlciAZxplppeGAYouVVtncFiAe9di4H8eVpH7/pENJWYH9S1G8Kyw=="
     },
     "node_modules/@gjsify/constants": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.29.0.tgz",
-      "integrity": "sha512-spGTOv4Eo6WLqXtnSRts0tCwUYJrjvS+2ZA9T0R5WSohnGk3VGmKHQuJORLbKQTg3yLPYWPjGQ1+Bvt6SmUCrA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.30.0.tgz",
+      "integrity": "sha512-AVVcI2gxrGVdrd7xMvfQmJTxk3l5qrg/7xWeqExF+mbgRaHOqI/jleN31W+IecQSixVU/O7m2nYxKbTT2TVjyg==",
       "dependencies": {
-        "@gjsify/crypto": "^0.29.0",
-        "@gjsify/fs": "^0.29.0",
-        "@gjsify/os": "^0.29.0"
+        "@gjsify/crypto": "^0.30.0",
+        "@gjsify/fs": "^0.30.0",
+        "@gjsify/os": "^0.30.0"
       }
     },
     "node_modules/@gjsify/create-app": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.29.0.tgz",
-      "integrity": "sha512-dDm1WBYF71fOgUZvYo1dRPvsWbB4ySH2QXqp9yZkADIVW78Mm1MNbv7c/AjMaO1TZn6m2Xm4WjBC3iEf3h8MPQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.30.0.tgz",
+      "integrity": "sha512-/eWiVwxfBbAfZSQZYohLWX3CduEDWIW4+JzAy8OB1Opw35f3D4V5327j6o68H8BlvDsMtqE4E3Ro4oYCCPLrdw==",
       "dependencies": {
         "yargs": "^18.0.0"
       },
       "bin": "./lib/index.js"
     },
     "node_modules/@gjsify/crypto": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.29.0.tgz",
-      "integrity": "sha512-0fA9VcAbFbQfGKp4efZek82Cp9n+NX2LQU7mlCu3JhurgzTChOCauodDI7z/gkt8W71wTTve85sqeZmgn210Aw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.30.0.tgz",
+      "integrity": "sha512-k6ViQsH1QWZCAe3irgmPl604+bbX9xx0epTjG+zRplg/GJOPHIcqRWdqQnHETtA2NdtSuFElbBqdh0Ke9kYfBw==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/stream": "^0.29.0",
-        "@gjsify/webcrypto": "^0.29.0",
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/stream": "^0.30.0",
+        "@gjsify/webcrypto": "^0.30.0",
         "@noble/hashes": "^2.2.0"
       }
     },
     "node_modules/@gjsify/dgram": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.29.0.tgz",
-      "integrity": "sha512-8yYm5CGmA9rJSr6N6achnCWvv6+VMou69vWNiKPdN7JdyTtEyX+8MPdFgMSvUY2Y9VlGOSHBXbk6ATRnyJuNXA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.30.0.tgz",
+      "integrity": "sha512-wTdIvIY7a4yuKh8mg3vs64kZrscm1RPRvB+HRhWU0p9gUmIAwO4gPWKWloIymIiGdTPGxmdhy55VNfDfCOaPPA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/diagnostics_channel": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.29.0.tgz",
-      "integrity": "sha512-/pG1DLOVYAqDYngrtTO2o9ODZUstMRZoREvK0xNu4VuDU2NihOxPsnw64dhHIKDVbVtUpu1exVdMwMcnA2/4nw=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.30.0.tgz",
+      "integrity": "sha512-/Mc8u2fVJ303WVc2oA6mAK6SdPHB+7Khu4oCrlHwQLDviHQyKKRxUjeR0SMG8Cmr6QjZ5yLW37pxLNk8CDDlHg=="
     },
     "node_modules/@gjsify/dns": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.29.0.tgz",
-      "integrity": "sha512-6BRxMD0JVCnxQkSxWxrS2uoBT06QzV7kxXa3atMjgW8Kphst3tX8lLQr/CTOhb/ReqNZ+qCv+8GWsafPUZ8Bvg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.30.0.tgz",
+      "integrity": "sha512-uIIMHLArcVer2Eh2WaUC7Rms67eCtHz86U/A+tfnOyoxXViRwGSvkII0VGigPpVNXb/Qv4y8bcwVkm2fYoAz7A==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/net": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/net": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/dom-events": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.29.0.tgz",
-      "integrity": "sha512-KegTMnate86oIx3Mzc04Hf2HhfJOykx/h5g7RNCYRWjzLAT/8nVa+V1rigHDoHpVv2z1+dJVwSnJNvLaRRTd6w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.30.0.tgz",
+      "integrity": "sha512-ouuYCcH/F+gv6Jtz5M3uRe10F4Gg4j0EipC4J3atoUFEiC3DX5jNEw0YQfKOLLulk73vTx156GJppxuZ8hV2dA==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.29.0"
+        "@gjsify/dom-exception": "^0.30.0"
       }
     },
     "node_modules/@gjsify/dom-exception": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.29.0.tgz",
-      "integrity": "sha512-1UpoBJfTziP/ZMk2ZnSun8k8iwSZXjxnY39c1uT+Peg9vshg0EucHS2bk4nhEVzyQXXgZsk/oXDil6fKCflvSA=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.30.0.tgz",
+      "integrity": "sha512-bjawGRw1mhf/lZ6nxX9jrcZY2fIkhLcsvEJGY/JOkYuzQdJOUuiPHuR64pZ5W7+iTVEMllCQfGRtzaqGVXJZhA=="
     },
     "node_modules/@gjsify/domain": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.29.0.tgz",
-      "integrity": "sha512-aDsvTqfJ/SpsRXRw7/hnuFA8wrDG6kW/Lq9gkDM1ZCTj6HNQl1T4udMY2D2km2pU4QOPjok9i++pNXIcpen9tQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.30.0.tgz",
+      "integrity": "sha512-J4fUozcMKA3D38hD/ufqlashWSI3pgnfMEgE1cPQGoo/x8SOQRsF4tqaGJMgR+1Dy6rsKkELESYVtaPxLYsBsg==",
       "dependencies": {
-        "@gjsify/events": "^0.29.0"
+        "@gjsify/events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/domparser": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.29.0.tgz",
-      "integrity": "sha512-j+n9kZjd+AuJO/BiIP0fgzrFxuKIlhxAYlXJUTrjv69f1rox5qyGNzcw2xypexMp3/OJ6zWUPo92IUuMCRWofQ=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.30.0.tgz",
+      "integrity": "sha512-2CWNimCgLBRhbM9ASuhw0GryKJAw8Xh/Odc5L6clqi/QGpQLloMknFlxX77yjBjk/5W5AGcWp3GTrUsFJL/pSA=="
     },
     "node_modules/@gjsify/events": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.29.0.tgz",
-      "integrity": "sha512-MT36Vag6tlhMzPsSZnj9/nsfMxp4u9t8DgvxZoXm8gNTD+IsoXKMMGleDDvqkHd03umXuLxbtV9OfrLe8br1ZA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.30.0.tgz",
+      "integrity": "sha512-xeeYq+aigazF7dYChB0qcyU/Idiuly7Un+HwiucK0256u5Qn0YI6/lPCQzxZRTXu+GVdTcQ4+cfOjdqJsF7oZg==",
       "dependencies": {
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/eventsource": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.29.0.tgz",
-      "integrity": "sha512-1TdrooUBN7l/iWjiVTfo5SxwuGF6fdLXwiS9hwT/UwkZLtVM6sddTYBjeXc7lVTpyoQudHJKKAmZ5l80Ru+kQw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.30.0.tgz",
+      "integrity": "sha512-fkPyMqXRcneax7Bk+4sVem3lKsaw9wSkIp2C501nsbJEMz3Jol+cPpSP10knznA11rVfXX51lBunlMALUx4b/w==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.29.0",
-        "@gjsify/web-streams": "^0.29.0"
+        "@gjsify/dom-events": "^0.30.0",
+        "@gjsify/web-streams": "^0.30.0"
       }
     },
     "node_modules/@gjsify/fetch": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.29.0.tgz",
-      "integrity": "sha512-5GY9D2wqX5QNtWB63x3leVZtHlUvxVoheGgo24LC9AJgz31nfWuVWsntn29Q3wtBbFAjVoZ0Gdtbhy/TXLDPwA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.30.0.tgz",
+      "integrity": "sha512-SYiZHgTvw6KC1/wCYRnKEi2rrJRRyIKak8rbhk30/oja7/7+LzWp+O4f8hmRbEvtqY7BJZAOAEcLWenzNf3A1Q==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/dom-events": "^0.29.0",
-        "@gjsify/formdata": "^0.29.0",
-        "@gjsify/http": "^0.29.0",
-        "@gjsify/url": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/dom-events": "^0.30.0",
+        "@gjsify/formdata": "^0.30.0",
+        "@gjsify/http": "^0.30.0",
+        "@gjsify/url": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/formdata": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.29.0.tgz",
-      "integrity": "sha512-zH2MUIpOwFYRUyNJcrb2UIyiI6guwt3hrZMfksSUDSWAhOMHMtgPciSwPZbRRIxeDfzw/essVFFMCNfRYMCt7w=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.30.0.tgz",
+      "integrity": "sha512-DV5Na7hNE2ymYqvE47vA1h9AeVSV0JzH8dNZr8QYzkyO4j2axMYeu45/wyMZN0GTjT586XTutahA6xx3v8rBUA=="
     },
     "node_modules/@gjsify/fs": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.29.0.tgz",
-      "integrity": "sha512-zUARHL5at5s3cpBB02G11/zLye6Rnpq0IfBFFL5OALgcCjWdTkqvx4Kbv9iHTyTxxhFxQ64r8OZ242uJAkUgNQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.30.0.tgz",
+      "integrity": "sha512-fv+RGT9qlpx59UA1F4kpm8fExYeoLLKq3om6p55kw+/3FyWv1p3esW+oZC6rVHIu1zNf9NojKkZNOCAVLJZ/ow==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/stream": "^0.29.0",
-        "@gjsify/url": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/stream": "^0.30.0",
+        "@gjsify/url": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/gamepad": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.29.0.tgz",
-      "integrity": "sha512-q6t2GcUcQapgYIbnoop6ffohlTpBHqf8hs/n9mUUzqeRY3RG/l4d3Q/2vByQ7lcvPZiSSLVFrCIeePf74wrlwQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.30.0.tgz",
+      "integrity": "sha512-HFgJz2DxYA329aiABrBwzDc/T+EPHrSakIEtVcX/Gz2BG+sz/HNjZUMmQFo03wOSzy8q620vJFEAE13TfBF9Aw==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.29.0"
+        "@gjsify/dom-events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/http": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.29.0.tgz",
-      "integrity": "sha512-8KqmqN5YAtxC4gcnaIrUV+VWs61X1JLAo1b1SCbKb//LNhDwjpv2klNhlImBQLNjA0NcNlI8cayvQMF8Zm/nsw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.30.0.tgz",
+      "integrity": "sha512-khiPDQUOT2IXT4lz/K1paZVqmE1tUiKiw1yRB1/cyhIrQmDqEpnQbY7lP8yzdlsEk73W6S980wvvGM0VM6r9tQ==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/http-soup-bridge": "^0.29.0",
-        "@gjsify/net": "^0.29.0",
-        "@gjsify/stream": "^0.29.0",
-        "@gjsify/url": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/http-soup-bridge": "^0.30.0",
+        "@gjsify/net": "^0.30.0",
+        "@gjsify/stream": "^0.30.0",
+        "@gjsify/url": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.29.0.tgz",
-      "integrity": "sha512-xq0VlZvw3rbuhnlkuknups7G3Gq3iu9fh4WTK3Bm2x7fz8FA8/7AZm3G5WlcelZyG5tqXmBcwfA/Wq9iq19Q0A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.30.0.tgz",
+      "integrity": "sha512-nOa2NaoklIGWfS9yDMzDax9AzE9feCZWEZFygT+2ZngjaBGf6W8FB3JyEod8K4qlpd6OFnW9HmGX9kqM70hcNw==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
@@ -880,19 +880,19 @@
         "@girs/soup-3.0": "^4.1.0"
       },
       "optionalDependencies": {
-        "@gjsify/http-soup-bridge-darwin-arm64": "0.29.0",
-        "@gjsify/http-soup-bridge-darwin-x64": "0.29.0",
-        "@gjsify/http-soup-bridge-linux-arm64": "0.29.0",
-        "@gjsify/http-soup-bridge-linux-ppc64": "0.29.0",
-        "@gjsify/http-soup-bridge-linux-riscv64": "0.29.0",
-        "@gjsify/http-soup-bridge-linux-s390x": "0.29.0",
-        "@gjsify/http-soup-bridge-linux-x64": "0.29.0"
+        "@gjsify/http-soup-bridge-darwin-arm64": "0.30.0",
+        "@gjsify/http-soup-bridge-darwin-x64": "0.30.0",
+        "@gjsify/http-soup-bridge-linux-arm64": "0.30.0",
+        "@gjsify/http-soup-bridge-linux-ppc64": "0.30.0",
+        "@gjsify/http-soup-bridge-linux-riscv64": "0.30.0",
+        "@gjsify/http-soup-bridge-linux-s390x": "0.30.0",
+        "@gjsify/http-soup-bridge-linux-x64": "0.30.0"
       }
     },
     "node_modules/@gjsify/http-soup-bridge-darwin-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-darwin-arm64/-/http-soup-bridge-darwin-arm64-0.29.0.tgz",
-      "integrity": "sha512-JSG946dQeTifCPsGkbsOw5NsM5PBZUf4OD4JT2rf02C+3IvxVOriHcdslNjqeY6hQr4uZFoBi8KwFdE8zg8dWA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-darwin-arm64/-/http-soup-bridge-darwin-arm64-0.30.0.tgz",
+      "integrity": "sha512-DgfozfosEAlcUO2+8dD5r4EyQg+J3XcqjDdVtQI1ldGC2b4P7zhbhKnjvIRLV2SKXNyO55hgSuUuQTQeql8A3g==",
       "os": [
         "darwin"
       ],
@@ -902,9 +902,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http-soup-bridge-darwin-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-darwin-x64/-/http-soup-bridge-darwin-x64-0.29.0.tgz",
-      "integrity": "sha512-DEva2yritxLUTrlnNMr5gYPidYisO4wdmwa+mx7EaiuL+sAqtBvtP2SwA2TC2KiSfDOzmQLJateBc6mq7EFX7g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-darwin-x64/-/http-soup-bridge-darwin-x64-0.30.0.tgz",
+      "integrity": "sha512-4vSghlWgw3MlMLmjw1CJtQ9WxgeaxhgQv+87V0T8lHgutwOQKT85FEXXzXFuy8pUitpJ/JIdebrgnR/MIBUBjQ==",
       "os": [
         "darwin"
       ],
@@ -914,9 +914,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http-soup-bridge-linux-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-arm64/-/http-soup-bridge-linux-arm64-0.29.0.tgz",
-      "integrity": "sha512-lPW0D0z6+hyLotufZ1yfjuXNDHcpfciGlj9M9SICfctAAuIzmVSva3/lLFtlJzPb7Z7FFTRKzybJ3qIVJXUJDw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-arm64/-/http-soup-bridge-linux-arm64-0.30.0.tgz",
+      "integrity": "sha512-17ieowdncfgI/khNJXRfWxr5+XK3WaegT5ushCvrTI1uiRUtksDZBCoO4KhOXJUxj2N+Z8VR9Jvgsyuv0UdzIQ==",
       "os": [
         "linux"
       ],
@@ -926,9 +926,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http-soup-bridge-linux-ppc64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-ppc64/-/http-soup-bridge-linux-ppc64-0.29.0.tgz",
-      "integrity": "sha512-CTwwPlelUQQ8xSEjyNCDmAp4gOeuJz4DkxR8Hcad60dHzWLlrd3luEg5NPKa91QqxV0/7PVjniZPAE8SkMmxvw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-ppc64/-/http-soup-bridge-linux-ppc64-0.30.0.tgz",
+      "integrity": "sha512-QkIEhCa0WnrXIM068JTuY0Bum7vnGTr9sEFYa+FrF1w6ZGOKkoZv+ganryuUvsLembZHn9yvkKX5Pf7yjvaZPw==",
       "os": [
         "linux"
       ],
@@ -938,9 +938,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http-soup-bridge-linux-riscv64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-riscv64/-/http-soup-bridge-linux-riscv64-0.29.0.tgz",
-      "integrity": "sha512-YKG9LKWbnOWVe2Ecwk38vmGVqmWd+49j2AaCuH+Mtl7TUYY/e587k9cSPFeTAKyZ995mI1xwU3dKD01Nb7sC9w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-riscv64/-/http-soup-bridge-linux-riscv64-0.30.0.tgz",
+      "integrity": "sha512-fjVLWvijnnai1Hnbc8tfy75RdWESA6CKEIwxuGB873RwTB/XqeZ5k2NcF9EtMwhgqNownw4r11Jdb0cRur2jcA==",
       "os": [
         "linux"
       ],
@@ -953,9 +953,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http-soup-bridge-linux-s390x": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-s390x/-/http-soup-bridge-linux-s390x-0.29.0.tgz",
-      "integrity": "sha512-/X7z9+KTHNoVCOIwzZhQzuHFps97soOuWOUeD6hq03LjfiHxED4H0kAZlCGQIu14O7BTHeMnICmWGM+DO6F4aA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-s390x/-/http-soup-bridge-linux-s390x-0.30.0.tgz",
+      "integrity": "sha512-Xcrkfl09qC85FTrqD8un2dfBx3T6Owuii9mrInMRGg2ixLGefRc8XG10OjyfOcwrsgUYKF3MD0E4o6XSQUpi8w==",
       "os": [
         "linux"
       ],
@@ -965,9 +965,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http-soup-bridge-linux-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-x64/-/http-soup-bridge-linux-x64-0.29.0.tgz",
-      "integrity": "sha512-jRXLIIJF9ip5ClpwCJkAnWY3Y4HcF/Ic/8gDBuh1rg9JPNrAqEkR1NRtOUsBcavpYWxG9k0WdrSl81zCAPOBwA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge-linux-x64/-/http-soup-bridge-linux-x64-0.30.0.tgz",
+      "integrity": "sha512-GdlkUz4qvVX1vmxMLLcHM25/tC/Wq7duMImNwm6cN7rqYSi35xyGj93dxfFkKa8jCYU7rhcy6pPY3QG6+Qz0iw==",
       "os": [
         "linux"
       ],
@@ -977,42 +977,42 @@
       "optional": true
     },
     "node_modules/@gjsify/http2": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.29.0.tgz",
-      "integrity": "sha512-N4I4c2U1bebRnabOymF3dt8iMNpT4fBATGwT20TZrq+WHQqkT6SrhrGqn+0mxVtrbn/dQ/ZkR5mQFVxmxJjMUg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.30.0.tgz",
+      "integrity": "sha512-Pjo3GqDQeZ4RFzOR/bap1wPBRxFxVan7Fyp5DI+lRHDAbCoBPo1CkxFcxk9/32RGzPyX0vIHQtXMZg/QZmGDKg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/http2-native": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/http2-native": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/http2-native": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.29.0.tgz",
-      "integrity": "sha512-N3lp67rbI2hZ7VSPLdmkBUcWCSl+8mND9ZbinIFQLoOVqrTMSUtqNd5r9Xx9xyHTY+sjSHH0Yaye12cdlnr7iw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.30.0.tgz",
+      "integrity": "sha512-LHIzpoDtUC40gM2ypf843HB96OhHgaAcICnOOS1+Y52h5NtJ3uUlkv6+iEzlf/T8qbANizbFoiynA4IWAA1T1A==",
       "dependencies": {
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
       },
       "optionalDependencies": {
-        "@gjsify/http2-native-darwin-arm64": "0.29.0",
-        "@gjsify/http2-native-darwin-x64": "0.29.0",
-        "@gjsify/http2-native-linux-arm64": "0.29.0",
-        "@gjsify/http2-native-linux-ppc64": "0.29.0",
-        "@gjsify/http2-native-linux-riscv64": "0.29.0",
-        "@gjsify/http2-native-linux-s390x": "0.29.0",
-        "@gjsify/http2-native-linux-x64": "0.29.0"
+        "@gjsify/http2-native-darwin-arm64": "0.30.0",
+        "@gjsify/http2-native-darwin-x64": "0.30.0",
+        "@gjsify/http2-native-linux-arm64": "0.30.0",
+        "@gjsify/http2-native-linux-ppc64": "0.30.0",
+        "@gjsify/http2-native-linux-riscv64": "0.30.0",
+        "@gjsify/http2-native-linux-s390x": "0.30.0",
+        "@gjsify/http2-native-linux-x64": "0.30.0"
       }
     },
     "node_modules/@gjsify/http2-native-darwin-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-darwin-arm64/-/http2-native-darwin-arm64-0.29.0.tgz",
-      "integrity": "sha512-sr8iSsD+XPDEgRQlqyisDWW0qVorUcyOFedE3ocNR0fM7SDNHW76CkGjy91E+I/Q/19gw4WzJSQQh8WNFqUw/w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-darwin-arm64/-/http2-native-darwin-arm64-0.30.0.tgz",
+      "integrity": "sha512-d5TVJ6Oii+Q5kBSlACwL8nqz4AXC+ZfCrlxKgCiac5l3+eMX57lFMk6rg6uHHsTMBlX2G7EZGXPbd0myAwHY8w==",
       "os": [
         "darwin"
       ],
@@ -1022,9 +1022,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http2-native-darwin-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-darwin-x64/-/http2-native-darwin-x64-0.29.0.tgz",
-      "integrity": "sha512-WTrYjin5HmlEIyKGq51b7jZXgSC2oP0/X0Sk1v2JWkaNfke/MAIfVZmb+OM4ju7c8wJcUAkIuN5/tGEHZl31ZQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-darwin-x64/-/http2-native-darwin-x64-0.30.0.tgz",
+      "integrity": "sha512-VoLNnNiRnVLoT8WuHP81vn+WnvctNBkhZUQexsLTMx5Zz4TK4W99/Pt37gG3kod5BItocV47XRh8upUYztb/2w==",
       "os": [
         "darwin"
       ],
@@ -1034,9 +1034,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http2-native-linux-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-arm64/-/http2-native-linux-arm64-0.29.0.tgz",
-      "integrity": "sha512-scuDYJeuLXjM52rgWaac5Vi7HU0WYzzN4P7cWVAyZV8I8dIzcMTEVbCZMrQwC5wVA9qBeVkH6ImNzaU7lYyBYA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-arm64/-/http2-native-linux-arm64-0.30.0.tgz",
+      "integrity": "sha512-66koFe3di7SwYAfropqdKKKBPLjRJafXQfdU4Y/mo5ORoF6EbqFhbglFKnmz6St4PTDVhgCpmnnpNlx1Yh4S+Q==",
       "os": [
         "linux"
       ],
@@ -1046,9 +1046,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http2-native-linux-ppc64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-ppc64/-/http2-native-linux-ppc64-0.29.0.tgz",
-      "integrity": "sha512-jfzA9eHXxqcDOSqwv2Squc/RH0KBf3P2dJOalxBbLMZKXfkhRWCyK7/ugffbAz3NsIeayAvH8hM6LQUqnXt5GA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-ppc64/-/http2-native-linux-ppc64-0.30.0.tgz",
+      "integrity": "sha512-imJMrKIyIaZId8nlKcD4xOazGJUg66o+bz30J/MrTYlQLnfVGQVwWt8TT3fL5CkB3dD/M1ImV9In+QlJH0B6CQ==",
       "os": [
         "linux"
       ],
@@ -1058,9 +1058,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http2-native-linux-riscv64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-riscv64/-/http2-native-linux-riscv64-0.29.0.tgz",
-      "integrity": "sha512-MTvH//LipoaAwYEjkjAOkaYWqQ3tX0P1g3eKu5o3NOJay1s6KcVCFJrHwj/Wo6zk9DeBQAJNsB/2y0qIwzLDQw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-riscv64/-/http2-native-linux-riscv64-0.30.0.tgz",
+      "integrity": "sha512-UkusfS8uSUL4ydMtypuXSAcfHRFAvwqZCdoJCpgyh102QusruO/3e5WjNOtGmpiHrqaJL0YkMIV+NPZ1IUtDwg==",
       "os": [
         "linux"
       ],
@@ -1073,9 +1073,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http2-native-linux-s390x": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-s390x/-/http2-native-linux-s390x-0.29.0.tgz",
-      "integrity": "sha512-K2E6w0g/5+rHFRQYIaRKC+TZUEl0su6UaGEDgfAq05a6AJ8HfJe1nMGKTElUWXtXIccZxTbsmiVZR9d+FfbJ/A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-s390x/-/http2-native-linux-s390x-0.30.0.tgz",
+      "integrity": "sha512-biPDHNlmnRWPCjj/B8XioqCuzBVoiC5NaDQIDDPPeNzL88XvGxUwzEbyTeal0gXpz0B84k1k5c4CrsbbK645Cw==",
       "os": [
         "linux"
       ],
@@ -1085,9 +1085,9 @@
       "optional": true
     },
     "node_modules/@gjsify/http2-native-linux-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-x64/-/http2-native-linux-x64-0.29.0.tgz",
-      "integrity": "sha512-piXzMZeEMJYha/hl6BwuyISVoAuEGpNGsJtzZtjqe/Eze/XK+bdn/Sg3GXlwmajaBdl0cKBKHUUVq70dYJ0CwQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native-linux-x64/-/http2-native-linux-x64-0.30.0.tgz",
+      "integrity": "sha512-lrTiFsZfytltvUbtREBfXaURR3IR7dvuqtrZ/6Mck4LJQ9BOrZRbkG26WgholIWxJsX9QxCkijZhgE7NnS3mXg==",
       "os": [
         "linux"
       ],
@@ -1097,184 +1097,184 @@
       "optional": true
     },
     "node_modules/@gjsify/https": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.29.0.tgz",
-      "integrity": "sha512-I+wviwkxOVxNSDE6A+rpCDHlzJnf9NvmEN0b9IgBhNQDWQZ39N1mh3/Ikx4LUXSst830W9PBgs8Yz0bxEYuFGA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.30.0.tgz",
+      "integrity": "sha512-jyugtjNShxXKi6wsTlyJ+pstPcoO1LILc0aVolypz+sYX7Y9nDKM+A+Y96x36B1Wfq3j3rg8/LjGudRrobKw4w==",
       "dependencies": {
-        "@gjsify/http": "^0.29.0",
-        "@gjsify/tls": "^0.29.0"
+        "@gjsify/http": "^0.30.0",
+        "@gjsify/tls": "^0.30.0"
       }
     },
     "node_modules/@gjsify/inspector": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.29.0.tgz",
-      "integrity": "sha512-Dnstvw6G+eBR5cDTAd7LAm1jAn8evYntfIVFQW7GpQx19w/4+3Kto+XHDQpcEc4JRXokNiGzLjFdMWSYK9dQZA=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.30.0.tgz",
+      "integrity": "sha512-b9LH8m7BjVol7UdjrkMBvJRI7kfTwTbzCsnKjROLXeT5UjBOLaK3YzeJnLhNFpA2/u4ArSJcROqq7K4f0ndgVg=="
     },
     "node_modules/@gjsify/message-channel": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.29.0.tgz",
-      "integrity": "sha512-aAOfxijLWFbHbB5Ct63PIQG7ok0MfFxVw3NTF7V5iS5sZ4PuCj7Ec6hWH1w7YuIxyX8BmkZc+m3MvMDSr+FRXw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.30.0.tgz",
+      "integrity": "sha512-j/CTSLPszP88XbiGxYBSZrm490nRH4Hjsrm9IqaIHgk3W0kgIhKYMBlfpy18SihhRcGYLhiVcjf19gu/xI5vHg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.29.0"
+        "@gjsify/dom-events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/module": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.29.0.tgz",
-      "integrity": "sha512-phM0nykMo3Aa2d+jW3zlzZz6SIeRUwjCd5oCugvL2vIOOaYeAgThUKwMFSWj2SPYwU5UmjWtjoj3WZOxiLU8Ig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.30.0.tgz",
+      "integrity": "sha512-eYf2PPMgeb9KXfdISWRy327v8xBaAOvLTESciShUTXN2WrPveXBDGLvwrM25okj4L799XKgPUbGvS8IWTX7RPA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/net": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.29.0.tgz",
-      "integrity": "sha512-l/j5Whh7IwNK7oVVtkSPrwh6Iw3yaEqxnQ/dKu6pnlyvykt+yggnxK64C5SYUv3Xqmu33NNvoUnTke2ZDkMSGg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.30.0.tgz",
+      "integrity": "sha512-e5UMvWwMFyVFGrDXjmtoSau/3cYiZMqGquLjdB85iicdVcmYEmb3dM36i5n8qGyMcI0YrgHeZpw5VKJbjhwd1w==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/stream": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/stream": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/node-globals": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.29.0.tgz",
-      "integrity": "sha512-g3YI6ANvJMyZT8Vcd/JtXl+1wWRqdnLOeMBp+xptnwn0JDCc9JRfdPMkmE+4vQU59ZEcY5G2dVBEqwKa4ezjvg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.30.0.tgz",
+      "integrity": "sha512-g+HBa/Wr+EjbfQwxomv2mZWKjtFmlrx8zG+NPNDJ/ft0C2qPGbx3EyZG0EJP1RkvnexWqVm1KIJg52EzGYH3Fg==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/process": "^0.29.0",
-        "@gjsify/url": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/process": "^0.30.0",
+        "@gjsify/url": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/node-polyfills": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.29.0.tgz",
-      "integrity": "sha512-sYpVC/6lKWGlXpeO9eQ/rBBIohYJcyaD5DTCAVtwgPFTmQzCySDkgRm7aqBJc77Yu5gIOuzH3xqb3WY6uRZP+w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.30.0.tgz",
+      "integrity": "sha512-msLEDQBTYLSpjGr7OIw9zom/TrToAHNaLasuuoBDmmDiD9FY0OwiaaDfcbHH0hSElDWqpvFeYjvHVXDr7J7gJA==",
       "dependencies": {
-        "@gjsify/assert": "^0.29.0",
-        "@gjsify/async_hooks": "^0.29.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/child_process": "^0.29.0",
-        "@gjsify/cluster": "^0.29.0",
-        "@gjsify/console": "^0.29.0",
-        "@gjsify/constants": "^0.29.0",
-        "@gjsify/crypto": "^0.29.0",
-        "@gjsify/dgram": "^0.29.0",
-        "@gjsify/diagnostics_channel": "^0.29.0",
-        "@gjsify/dns": "^0.29.0",
-        "@gjsify/domain": "^0.29.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/fs": "^0.29.0",
-        "@gjsify/http": "^0.29.0",
-        "@gjsify/http2": "^0.29.0",
-        "@gjsify/https": "^0.29.0",
-        "@gjsify/inspector": "^0.29.0",
-        "@gjsify/module": "^0.29.0",
-        "@gjsify/net": "^0.29.0",
-        "@gjsify/node-globals": "^0.29.0",
-        "@gjsify/os": "^0.29.0",
-        "@gjsify/path": "^0.29.0",
-        "@gjsify/perf_hooks": "^0.29.0",
-        "@gjsify/process": "^0.29.0",
-        "@gjsify/querystring": "^0.29.0",
-        "@gjsify/readline": "^0.29.0",
-        "@gjsify/sqlite": "^0.29.0",
-        "@gjsify/stream": "^0.29.0",
-        "@gjsify/string_decoder": "^0.29.0",
-        "@gjsify/sys": "^0.29.0",
-        "@gjsify/timers": "^0.29.0",
-        "@gjsify/tls": "^0.29.0",
-        "@gjsify/tty": "^0.29.0",
-        "@gjsify/url": "^0.29.0",
-        "@gjsify/util": "^0.29.0",
-        "@gjsify/v8": "^0.29.0",
-        "@gjsify/vm": "^0.29.0",
-        "@gjsify/worker_threads": "^0.29.0",
-        "@gjsify/zlib": "^0.29.0"
+        "@gjsify/assert": "^0.30.0",
+        "@gjsify/async_hooks": "^0.30.0",
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/child_process": "^0.30.0",
+        "@gjsify/cluster": "^0.30.0",
+        "@gjsify/console": "^0.30.0",
+        "@gjsify/constants": "^0.30.0",
+        "@gjsify/crypto": "^0.30.0",
+        "@gjsify/dgram": "^0.30.0",
+        "@gjsify/diagnostics_channel": "^0.30.0",
+        "@gjsify/dns": "^0.30.0",
+        "@gjsify/domain": "^0.30.0",
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/fs": "^0.30.0",
+        "@gjsify/http": "^0.30.0",
+        "@gjsify/http2": "^0.30.0",
+        "@gjsify/https": "^0.30.0",
+        "@gjsify/inspector": "^0.30.0",
+        "@gjsify/module": "^0.30.0",
+        "@gjsify/net": "^0.30.0",
+        "@gjsify/node-globals": "^0.30.0",
+        "@gjsify/os": "^0.30.0",
+        "@gjsify/path": "^0.30.0",
+        "@gjsify/perf_hooks": "^0.30.0",
+        "@gjsify/process": "^0.30.0",
+        "@gjsify/querystring": "^0.30.0",
+        "@gjsify/readline": "^0.30.0",
+        "@gjsify/sqlite": "^0.30.0",
+        "@gjsify/stream": "^0.30.0",
+        "@gjsify/string_decoder": "^0.30.0",
+        "@gjsify/sys": "^0.30.0",
+        "@gjsify/timers": "^0.30.0",
+        "@gjsify/tls": "^0.30.0",
+        "@gjsify/tty": "^0.30.0",
+        "@gjsify/url": "^0.30.0",
+        "@gjsify/util": "^0.30.0",
+        "@gjsify/v8": "^0.30.0",
+        "@gjsify/vm": "^0.30.0",
+        "@gjsify/worker_threads": "^0.30.0",
+        "@gjsify/zlib": "^0.30.0"
       }
     },
     "node_modules/@gjsify/npm-registry": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.29.0.tgz",
-      "integrity": "sha512-cMxqcnmW28YAL6YTWIAMT3dmDwNnj/rXjiINydSqaJW6ijU9lqleoU3YJ4pBGc5Iy7iX0OotMGfHFFbHv8EcRA=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.30.0.tgz",
+      "integrity": "sha512-WAqRrtp34XsvGEkODloVIeCDpvmDsBdntT5NcIjjngIKdyxJYS4IpdOm4Zp7737vrqf20X44v+9qIDptxOqSzw=="
     },
     "node_modules/@gjsify/os": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.29.0.tgz",
-      "integrity": "sha512-6CYjbgaSCyvXcV8zl11k/0PYYxm8d18lLnNMSeQPNDaaNTYCq4wMLzWcXrHVKYqFYfUF/lPPHZYTg6LEqMQj1Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.30.0.tgz",
+      "integrity": "sha512-nesld29PjjBguDGERIjvLJymbBqf2Icr/M3LpyhS3Bh9sVNf5AsRoUbC5Bf2nf5JyZhlk+T0f2cKnvlK7WnnrA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/path": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.29.0.tgz",
-      "integrity": "sha512-zy6vRg6n7ol9/e33afeGzBh3OP9FUMov5V7a79gDqnqbC4UURQTSTk7PifG6nqJNtb79fPPPInBsotawbA3ECQ=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.30.0.tgz",
+      "integrity": "sha512-CUQzEz7zGKt6Da66FfWESNUgILCmwcaCUD2HGXRJNjruXbJnYTwZnkrQAYvOWehROxtyzAnJXfIa2DbLku5Gow=="
     },
     "node_modules/@gjsify/perf_hooks": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.29.0.tgz",
-      "integrity": "sha512-KUgqq0OabW9NDDeCzwT1nxOIwPA1tTiLA+r7isCXKlhjDgtviWy+gkELR6gyceVCEnPQeHaGGMCFvpUYqg/89g=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.30.0.tgz",
+      "integrity": "sha512-Z9kMX24dEY7iUlfkrT6QENHLCTRoPCARaRN+TjmJFoVwfLE4r4uKousEzqazUlW+4o42xEJsRoR3GG0YtA37pw=="
     },
     "node_modules/@gjsify/process": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.29.0.tgz",
-      "integrity": "sha512-5UmOQBZXt9sRqGR008cjR7fDSgO7a5tI4X9A4jGqD5hhgWVe1cVA9EQGnXmOAdqgJHO9WlThonXx6Y+w7P5n4g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.30.0.tgz",
+      "integrity": "sha512-ycyvmcqBIdcZUtq5YlUGkhIgE+zVCFYlN7pQ8pFaAlPcvu62g4e+30NHY9D7Lzvrmq+XGp07vLtWrc0LELrS7Q==",
       "dependencies": {
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/string_decoder": "^0.29.0",
-        "@gjsify/terminal-native": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/string_decoder": "^0.30.0",
+        "@gjsify/terminal-native": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/querystring": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.29.0.tgz",
-      "integrity": "sha512-MbAH+WgQkqRFN3wJE1IhOH53d6dmboTxVDDu3jehlmmaArv6cRBN8JOUusO7KdKegg427pCG8kj7KWgprcqZqg=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.30.0.tgz",
+      "integrity": "sha512-a6tt45gWjvjyYJgb19AsaprUVY4fKMRLob3P2tnALLman2VcgGTHNUqJlTnAWC1hA+LH+hgSMojUXr/dUniOlg=="
     },
     "node_modules/@gjsify/readline": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.29.0.tgz",
-      "integrity": "sha512-+plrQpSBMhxw4JV4AETDAoR9VAgqw9GFl+jrTyJwsF4bRaDvaLYuKMCbQWp5eA+BgGYH+ZS0fVlQ6U8XJaFaxA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.30.0.tgz",
+      "integrity": "sha512-DZkbveWr/fJXGsLwdJOBgBGeBvKIyMu7bWGPX0c74h1JZpTivxYnxre6qqvKmANSMZlwa3uwA7Nf3+WSQqVCgQ==",
       "dependencies": {
-        "@gjsify/events": "^0.29.0"
+        "@gjsify/events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/resolve-npm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.29.0.tgz",
-      "integrity": "sha512-KfqfQ4llyWiO+4pA5cNLj+reHU4gbmgBhSwrStwwLaJ5kwLeukXCeQQtWqMLJWUlBRSg/UMluYAIrIntdr/tsQ=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.30.0.tgz",
+      "integrity": "sha512-ZPMZyfANPStB4eCvQQARxGGqVO5gV7SHqcF2365UbO34UlmoKGJj0MdB3A0eYJgFngVKFLWGAWUwiKhoTOaRCw=="
     },
     "node_modules/@gjsify/rolldown-native": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native/-/rolldown-native-0.29.0.tgz",
-      "integrity": "sha512-bx1MgBUHz9G/h4h+brIRdaVTnLQWJY9NIIt5XeuMIdMKM/HE3scMitd9KfCty6IZNLz5zcpw8pcm+4bj8ZJqkA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native/-/rolldown-native-0.30.0.tgz",
+      "integrity": "sha512-jyrqxWXnR5DG1FvzTyjYlDQttTtW6p9tE+fc47ZzfJ7dTVamcYwD/va30ABI2OUdzXWM2p4f1OBWCWqfCZBKYA==",
       "dependencies": {
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
       },
       "optionalDependencies": {
-        "@gjsify/rolldown-native-darwin-arm64": "0.29.0",
-        "@gjsify/rolldown-native-darwin-x64": "0.29.0",
-        "@gjsify/rolldown-native-linux-arm64": "0.29.0",
-        "@gjsify/rolldown-native-linux-x64": "0.29.0"
+        "@gjsify/rolldown-native-darwin-arm64": "0.30.0",
+        "@gjsify/rolldown-native-darwin-x64": "0.30.0",
+        "@gjsify/rolldown-native-linux-arm64": "0.30.0",
+        "@gjsify/rolldown-native-linux-x64": "0.30.0"
       }
     },
     "node_modules/@gjsify/rolldown-native-darwin-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-darwin-arm64/-/rolldown-native-darwin-arm64-0.29.0.tgz",
-      "integrity": "sha512-Eq+IatupBVG+eRx12HrxeQVjcMwdpUbv2fj6uOsFxtWCgpqcp8fhSiq5EMd9Y762z23lRvLorzS9UNCQh0WdWQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-darwin-arm64/-/rolldown-native-darwin-arm64-0.30.0.tgz",
+      "integrity": "sha512-6z3sgp9Jf6rapFsnZg7wbpDJ97oJzgoCApoZSZuCwA9VrhIu0tuYOht/gYZOG7ZnNDJNk4YJd141wMIT5+0rXw==",
       "os": [
         "darwin"
       ],
@@ -1284,9 +1284,9 @@
       "optional": true
     },
     "node_modules/@gjsify/rolldown-native-darwin-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-darwin-x64/-/rolldown-native-darwin-x64-0.29.0.tgz",
-      "integrity": "sha512-4KxQefa3UT3hNhv+/lUvJBQNN6OByS+nG2YqOkYWCKvxW7tyrcinlmm33NxvaNTxwFWyB9Cx9Pn4BulA2AePiQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-darwin-x64/-/rolldown-native-darwin-x64-0.30.0.tgz",
+      "integrity": "sha512-rbYu5gWX8pKx3MY7aSoyC5XygbAgYAQ2jk3963a41WUmEpLZ9PDArbRPzha/1M6jMqrEBz9W5hUL3GqDuBG4Gg==",
       "os": [
         "darwin"
       ],
@@ -1296,9 +1296,9 @@
       "optional": true
     },
     "node_modules/@gjsify/rolldown-native-linux-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-linux-arm64/-/rolldown-native-linux-arm64-0.29.0.tgz",
-      "integrity": "sha512-DwgFIcdBBQpGkX8de+oRuRDF/6ffi9ddKBbUZj88rgQ2IyoshOPLEZAKWiX5sgr/564zdj0leCIABJ9w5c85UA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-linux-arm64/-/rolldown-native-linux-arm64-0.30.0.tgz",
+      "integrity": "sha512-zozoRry/KQzK4GR9cajkadgpteEFksJy8DNmCG8mHNwsBtmmuIwf8AuAGhuDADd88jekyxdl2m7BQjYxJxvzEQ==",
       "os": [
         "linux"
       ],
@@ -1308,9 +1308,9 @@
       "optional": true
     },
     "node_modules/@gjsify/rolldown-native-linux-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-linux-x64/-/rolldown-native-linux-x64-0.29.0.tgz",
-      "integrity": "sha512-s97JQvx8pDy1851SICpuWLfOjFxFA8qjV9HmX5FyojGIZvx4DtNJK9moUYjKbEPkRmcbheFZopnZir2ddXo7SQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-native-linux-x64/-/rolldown-native-linux-x64-0.30.0.tgz",
+      "integrity": "sha512-QsRzsAL1k7/IWZ2Eac1nUmrGMKKvq3qS2gdNWNYsofxKYd+4iLrty3TMDog8xgi/PVLidZSYJmhkqZEplQyLJA==",
       "os": [
         "linux"
       ],
@@ -1323,24 +1323,24 @@
       "optional": true
     },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.29.0.tgz",
-      "integrity": "sha512-/Dc/pSGXfye5Dt2e2syearn95zggx9FiXWKJCiiNDbObBR5klsLYdd/G6evpLjyWGBONZzZ/s2YJrY5z6vl9uA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.30.0.tgz",
+      "integrity": "sha512-3wkN6rRAEGq9uLNc4zNMu23bcDBt9cBPvSR8Cuco8j2FogI3tyI6PqJWEDDmMMicg1pVUGCDjrw15f9ezeRuZg==",
       "dependencies": {
         "@deepkit/type-compiler": "^1.0.19",
         "typescript": "^6.0.3"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.29.0.tgz",
-      "integrity": "sha512-lGQvF2kHefjYUiG2E0XJilXxeHRY+8l+AQwp/Hr8Dz8sgwm6JYXYu9svSquPUIuU0sQiS47aa4PHSu7TxO6hDQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.30.0.tgz",
+      "integrity": "sha512-FNm8jdPgitaXYSHEFxJ+B6D1UqsfV0csLJP/pAtUUIBVVopsIMFNCI9eBZ1PmuvBLf0DSOgZqWvGcS46TD9fEg==",
       "dependencies": {
-        "@gjsify/console": "^0.29.0",
-        "@gjsify/resolve-npm": "^0.29.0",
-        "@gjsify/rolldown-plugin-deepkit": "^0.29.0",
-        "@gjsify/rolldown-plugin-pnp": "^0.29.0",
-        "@gjsify/vite-plugin-blueprint": "^0.29.0",
+        "@gjsify/console": "^0.30.0",
+        "@gjsify/resolve-npm": "^0.30.0",
+        "@gjsify/rolldown-plugin-deepkit": "^0.30.0",
+        "@gjsify/rolldown-plugin-pnp": "^0.30.0",
+        "@gjsify/vite-plugin-blueprint": "^0.30.0",
         "@rollup/pluginutils": "^5.4.0",
         "acorn": "^8.17.0",
         "acorn-walk": "^8.3.5",
@@ -1350,23 +1350,23 @@
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify/node_modules/@gjsify/vite-plugin-blueprint": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.29.0.tgz",
-      "integrity": "sha512-HinytTTWeWOkoLepi2G+REi1dHXR/+vvXkJdE6Wb4FPClOXv5nmFYe2yDo+aVpl4SLj1gfRfs4NBzZlSJcGJeA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.30.0.tgz",
+      "integrity": "sha512-Bs/N7TMArJ0jIzFhSqooteAi8+36qcujTudlthIRJ8ngPc292yUj1VMd9kbM2dF8bVK/2HIzjDIa/F2jLObQGA==",
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.29.0.tgz",
-      "integrity": "sha512-dXX2IH281/8eQmJ+1zM7OUeGjKqcCq/+RPZLmb+TlRncJgIzRhpttWUxBYZb6yqHErkpkTcEmmWX1CEWJYiRyw=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.30.0.tgz",
+      "integrity": "sha512-gbexekd2hT9HSm8q3vqdc9vr2uwlfLU6bto0qgVVzJyFwwxw+Fkm+Pag9JTeqtpcYbQnM3gFWeunQi/AoDQI5w=="
     },
     "node_modules/@gjsify/sab-native": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.29.0.tgz",
-      "integrity": "sha512-jFJBA+BoM2F2gPB1dN1v6vLvUSHRT3LBxV+MmVJRLcF3NOb3AMGPWrmQfoxEhSbuLZM+n1LAADzQzLDQ/8YImA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.30.0.tgz",
+      "integrity": "sha512-7yMCZx6OBq3wa9u9fVY+en/hVuQCpefGHsSheLhgG7qh6/TsQSLyAdCeuPAFJkqU6njyLZjGNoFMMuvpYIxioQ==",
       "dependencies": {
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
@@ -1374,17 +1374,17 @@
         "@girs/gio-2.0": "^4.1.0"
       },
       "optionalDependencies": {
-        "@gjsify/sab-native-linux-arm64": "0.29.0",
-        "@gjsify/sab-native-linux-ppc64": "0.29.0",
-        "@gjsify/sab-native-linux-riscv64": "0.29.0",
-        "@gjsify/sab-native-linux-s390x": "0.29.0",
-        "@gjsify/sab-native-linux-x64": "0.29.0"
+        "@gjsify/sab-native-linux-arm64": "0.30.0",
+        "@gjsify/sab-native-linux-ppc64": "0.30.0",
+        "@gjsify/sab-native-linux-riscv64": "0.30.0",
+        "@gjsify/sab-native-linux-s390x": "0.30.0",
+        "@gjsify/sab-native-linux-x64": "0.30.0"
       }
     },
     "node_modules/@gjsify/sab-native-linux-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-arm64/-/sab-native-linux-arm64-0.29.0.tgz",
-      "integrity": "sha512-C2vcTQunBerrT+ckWM2xRz7ixSnMkMQhTv5eEVTVIWKkfJKnkoKmAuBf6F0/xE/d4ORRpzMFx5bIaFh/9T/rrA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-arm64/-/sab-native-linux-arm64-0.30.0.tgz",
+      "integrity": "sha512-Rm8w0HrOUiPs5/hkY2NkkaxkYTaj5AD6+6TC5HB34c8KnrP/JxwIkYIv/SnmhjNoBZXNz8DDzhN1s28X6J4uNg==",
       "os": [
         "linux"
       ],
@@ -1394,9 +1394,9 @@
       "optional": true
     },
     "node_modules/@gjsify/sab-native-linux-ppc64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-ppc64/-/sab-native-linux-ppc64-0.29.0.tgz",
-      "integrity": "sha512-Vjv8z7B0Ip2lyJB1/IFTclJKiyJph3rfQHTph2FsVvlTANLBWTbKvn/FV4LMnlb+vSY7ect/zPqUPlmorES3Tg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-ppc64/-/sab-native-linux-ppc64-0.30.0.tgz",
+      "integrity": "sha512-0eOuZTOYIr3MThQ46ahRSsdPfc0rsLZIk6OaLuLvlpUQ6luG0AwVpsbpIXaanLt11Cpfs6ogGzXGOl3mNffVHg==",
       "os": [
         "linux"
       ],
@@ -1406,9 +1406,9 @@
       "optional": true
     },
     "node_modules/@gjsify/sab-native-linux-riscv64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-riscv64/-/sab-native-linux-riscv64-0.29.0.tgz",
-      "integrity": "sha512-cnOzg9RwT+5GP/G9Kz5/o5ZFMGB79Kkm+3ps9oNfdivUnZNvuZdKHuwJYW57Ys7+9dSsgWCJrO5QT9a/aCo2xg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-riscv64/-/sab-native-linux-riscv64-0.30.0.tgz",
+      "integrity": "sha512-kRvHM5INyUSEq/ucP+sN/4ryPGgYzsHy1ZPL8EgjQraMkotOJnEuxatb4g4J0GXVqS4gPXc3g+QwIlBVRkJh+g==",
       "os": [
         "linux"
       ],
@@ -1421,9 +1421,9 @@
       "optional": true
     },
     "node_modules/@gjsify/sab-native-linux-s390x": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-s390x/-/sab-native-linux-s390x-0.29.0.tgz",
-      "integrity": "sha512-cc0JV/I/TmFf/wKCtlDOPkuuWzaXQB0gbiheaBw0gyC+d4D1nskQ3m0BtopOviSxnE7sBagAQ1ZSEwttsnuPew==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-s390x/-/sab-native-linux-s390x-0.30.0.tgz",
+      "integrity": "sha512-PLy/r0JCUTbrO+SDoHzPoLzeI/C4dBBB4YlFh9exVKLfU58/ru5uESUpxjPxMc8ylwNnS9ybmRvRyEbeK+7LBQ==",
       "os": [
         "linux"
       ],
@@ -1433,9 +1433,9 @@
       "optional": true
     },
     "node_modules/@gjsify/sab-native-linux-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-x64/-/sab-native-linux-x64-0.29.0.tgz",
-      "integrity": "sha512-AXCKlfUNVnxhMxw69K5huCZhiHpnCvG8f5FcwrgV7F3OWRG/gMKE7/aLJCJDleT9Iuga8QT75FrHliRuVMUAmQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native-linux-x64/-/sab-native-linux-x64-0.30.0.tgz",
+      "integrity": "sha512-azLvMZOR5uWQkCp32tCl/JyLFamepYdyogJNHjHtx4ErNqKMZ3ldNZiidjGI1CUyXc6Xa3wiLzc/T9rWaifdLA==",
       "os": [
         "linux"
       ],
@@ -1445,14 +1445,14 @@
       "optional": true
     },
     "node_modules/@gjsify/semver": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.29.0.tgz",
-      "integrity": "sha512-ypXwc/b8+pNC8PjxORhFeaTG8noy6Jw2TzwZuFMlcx7rS4XEet9ucy1DAegyrVpNdZHsXHavP7YqZmIFNcd3UQ=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.30.0.tgz",
+      "integrity": "sha512-YQgDqsp1LAM06Wx2ETsjZJbQZhmzurwovMB8z+f6G7iicDPeGVR5R+uqGFY3q+hcODcBbP3MhqgaJrJGV9olZw=="
     },
     "node_modules/@gjsify/sqlite": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.29.0.tgz",
-      "integrity": "sha512-vjN0gYd7kW+REc8MEyNdu/93K05GH4SORgezjwQT+fcS6bIUrEaw0ypzC+ivFA6GzDlzgaEgIAIcMNeIkPM2eA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.30.0.tgz",
+      "integrity": "sha512-KmehQb20KXvKiHTYl8QKUqaVFEKAw7oSq1yu1Rbl+wk3LPJT1pDKsRDf/7UivysjSudkXOTY69vktZX/fhQL5w==",
       "dependencies": {
         "@girs/gda-6.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
@@ -1460,58 +1460,58 @@
       }
     },
     "node_modules/@gjsify/stream": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.29.0.tgz",
-      "integrity": "sha512-KdZt1UcGN2lwI4l2PfOjZ9TfmWlqK6R7fyNsN8UdXyFy76JVJrW8PHEZaT6GAYbwMb/uEm3xn9H3+/DVwuUbxw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.30.0.tgz",
+      "integrity": "sha512-qg0mi3NKW+3BGZK8KiQ8SyvfDXQuHk2FJ0/5jJ7mdZn6EMHwjahN9OJmrfYJBKTK3yxkhkoRdncPnz5NbAQv3w==",
       "dependencies": {
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/utils": "^0.29.0",
-        "@gjsify/web-streams": "^0.29.0"
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/utils": "^0.30.0",
+        "@gjsify/web-streams": "^0.30.0"
       }
     },
     "node_modules/@gjsify/string_decoder": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.29.0.tgz",
-      "integrity": "sha512-6sgOZVQYSMU9rR9pnpf403VTOR57ubobMHdDfr/svoJxuMm7yNZgk1/AnMLptSli2FldCTFZ+Rjw9ToCgKbZ+A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.30.0.tgz",
+      "integrity": "sha512-ibQmBSkQzeC1AIpHomx8Sw0VVUW81oU219oMS+GaSbuUAnxCk1uqRscL1NIpyP5X0KjQuVLXjBvDaHWfoefv6A==",
       "dependencies": {
-        "@gjsify/buffer": "^0.29.0"
+        "@gjsify/buffer": "^0.30.0"
       }
     },
     "node_modules/@gjsify/sys": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.29.0.tgz",
-      "integrity": "sha512-jrfrinHcUHGSRvPIiNLaI9uTWlY1iJgou0s0l7y+ZN5dIVpa+diUuHck5XGinU5+v0iNi7uKz5Js9DsaFOy3ug==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.30.0.tgz",
+      "integrity": "sha512-KC/dJbxVNSCmSoNyl1ESSaxjUMN336FMhFSHj/jILEn15hzvq/HfxezWYwnlZYMEuz31pHU6uK2NGf1q6Gc5Mg==",
       "dependencies": {
-        "@gjsify/util": "^0.29.0"
+        "@gjsify/util": "^0.30.0"
       }
     },
     "node_modules/@gjsify/tar": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.29.0.tgz",
-      "integrity": "sha512-jWlleBSQoQWMqvwmMPLfMNGGJpouzzlBITemxGrT/whAKclqrDNpzT9vKuE0n6Yr8p4IvqSROd00/3ZPBJqo+Q=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.30.0.tgz",
+      "integrity": "sha512-qz0i/qPwN3lcn6aw0B2kx/T71P2NnN4v+GJ/go4SjmnKGm+Iy5Xm+NG7UAbLR6qy+9NakHhexzq+K9hL7NNnoQ=="
     },
     "node_modules/@gjsify/terminal-native": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.29.0.tgz",
-      "integrity": "sha512-8ykYmWFWheVuPiVwkIe9wezmoBeYF1ttaBHmWPvjDsM3Uj+NDLdkfBFXxsguGZ3Pzl6C7J/qxHBaDwnm5DivFA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.30.0.tgz",
+      "integrity": "sha512-UFyN6lur3omZSmKx4FvCD73dZdaEDcyBsVzXx3O6hBuWMLmsZARd37cUU3I9DYFiaHi0y891tvyYM3bBYb2A8g==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
       },
       "optionalDependencies": {
-        "@gjsify/terminal-native-darwin-arm64": "0.29.0",
-        "@gjsify/terminal-native-darwin-x64": "0.29.0",
-        "@gjsify/terminal-native-linux-arm64": "0.29.0",
-        "@gjsify/terminal-native-linux-ppc64": "0.29.0",
-        "@gjsify/terminal-native-linux-riscv64": "0.29.0",
-        "@gjsify/terminal-native-linux-s390x": "0.29.0",
-        "@gjsify/terminal-native-linux-x64": "0.29.0"
+        "@gjsify/terminal-native-darwin-arm64": "0.30.0",
+        "@gjsify/terminal-native-darwin-x64": "0.30.0",
+        "@gjsify/terminal-native-linux-arm64": "0.30.0",
+        "@gjsify/terminal-native-linux-ppc64": "0.30.0",
+        "@gjsify/terminal-native-linux-riscv64": "0.30.0",
+        "@gjsify/terminal-native-linux-s390x": "0.30.0",
+        "@gjsify/terminal-native-linux-x64": "0.30.0"
       }
     },
     "node_modules/@gjsify/terminal-native-darwin-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-darwin-arm64/-/terminal-native-darwin-arm64-0.29.0.tgz",
-      "integrity": "sha512-+i6aeBjVjeiY4t5awNkaNz03UtXf4MFItyavJ9YWsbDNB/JllIGN3g4m1Nan6B06SAB/1qmEj2eSuG+vtIdL8A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-darwin-arm64/-/terminal-native-darwin-arm64-0.30.0.tgz",
+      "integrity": "sha512-lZTN26NfCL7Tc9azEsH/PsbhVAHF1haNfOjXZSA96OQw3mjEEg2rvrVz6iD9pT4qaKJpUDEEeqCGam7Ti50xkA==",
       "os": [
         "darwin"
       ],
@@ -1521,9 +1521,9 @@
       "optional": true
     },
     "node_modules/@gjsify/terminal-native-darwin-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-darwin-x64/-/terminal-native-darwin-x64-0.29.0.tgz",
-      "integrity": "sha512-L0yjNFlpGiezpLgS4hpTvlmDyxS4m0lLdZFS6NZ7XEot/gvEPufmy5XS0Nw2FqS+TKnuHTy8szAKvmoMWfHhow==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-darwin-x64/-/terminal-native-darwin-x64-0.30.0.tgz",
+      "integrity": "sha512-zaUk8zBa1KhDk+PnJLd8DFh/zZD2/Ws5J+T4rFgrxaRxM/6hHgJxsjl3dAm0uI7gcIKTIk04WgPPvP1dODBaJw==",
       "os": [
         "darwin"
       ],
@@ -1533,9 +1533,9 @@
       "optional": true
     },
     "node_modules/@gjsify/terminal-native-linux-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-arm64/-/terminal-native-linux-arm64-0.29.0.tgz",
-      "integrity": "sha512-MCbTaGuh1xs0LOWDUjRw7dGRTDqOus7Tk+5ythDZq0poxRoWB39p+AMyzhd2cvCxsqvxpTx+BvfTHKfEBUSF/g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-arm64/-/terminal-native-linux-arm64-0.30.0.tgz",
+      "integrity": "sha512-1QRkjmrqSSG8268vw1p96a73P//PqZiUjzmtT9J6I+e/YPCSNUcQyPTKp+ZfbxXQa45/TsrbMWkFFI309vzKdw==",
       "os": [
         "linux"
       ],
@@ -1545,9 +1545,9 @@
       "optional": true
     },
     "node_modules/@gjsify/terminal-native-linux-ppc64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-ppc64/-/terminal-native-linux-ppc64-0.29.0.tgz",
-      "integrity": "sha512-cBgsdySevc2hnBgoHij0Pqt8V13o0m48TC3bYSPIboWSpHY8PzO4pYY/Orhcj/qp4X9KwzVc1LWv+ovo97vaRQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-ppc64/-/terminal-native-linux-ppc64-0.30.0.tgz",
+      "integrity": "sha512-RE9yS6HisRben2rfqcho54DSZ/ZksBHOgN7Ztmuf7t/+cdskzv0XSDKSDQAMG71C06sBxSSEYV75+Rw4sxzY4g==",
       "os": [
         "linux"
       ],
@@ -1557,9 +1557,9 @@
       "optional": true
     },
     "node_modules/@gjsify/terminal-native-linux-riscv64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-riscv64/-/terminal-native-linux-riscv64-0.29.0.tgz",
-      "integrity": "sha512-ZMtiQA9vJcVFjjRGOkWDtypKkyyS6aTjfQrClGm9A3uoAmgWH38XKsbHR+iOP9ZnL4RWhGNVLt3yDdvhn/uH3w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-riscv64/-/terminal-native-linux-riscv64-0.30.0.tgz",
+      "integrity": "sha512-9Kb/j2G8S7PqCGuMGL65BooME1+yiqYmyRLTtWzr6OFKw0NCX0g3zjV8zEQ6EbPMV+KEcp66T7FhYaHjnfKu3w==",
       "os": [
         "linux"
       ],
@@ -1572,9 +1572,9 @@
       "optional": true
     },
     "node_modules/@gjsify/terminal-native-linux-s390x": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-s390x/-/terminal-native-linux-s390x-0.29.0.tgz",
-      "integrity": "sha512-mGQwlGAnPRIngXcMO1jTfckCCzGRTCOITIzKMW7suvxIUWnzbKOJlkVoLW/ywc5Pr1khEBfM66OGYLBGJFKDaQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-s390x/-/terminal-native-linux-s390x-0.30.0.tgz",
+      "integrity": "sha512-nUc8cLvsym2jwh/Y8BdL3VhcqVga5S3xPnB1t5amnNCeFy7AmGWyWZ52Cu3jcku57WJvqp5BSYuek041cusdiw==",
       "os": [
         "linux"
       ],
@@ -1584,9 +1584,9 @@
       "optional": true
     },
     "node_modules/@gjsify/terminal-native-linux-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-x64/-/terminal-native-linux-x64-0.29.0.tgz",
-      "integrity": "sha512-1P+wuy7KH54sWENLQr+6JQ32PJrzLvhu2TXQId0mvsyp+kDZtUTKkWZQxTswm9inz7YXETgVZzfdisrAvaUzTg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native-linux-x64/-/terminal-native-linux-x64-0.30.0.tgz",
+      "integrity": "sha512-Tq/Ud79V6ESff60scY00gaNDwt91mt0AadIh5rBTaAPmbJ+yqams56xW4mGwXc+13h1bCsmaKhd9aDll8GhHRQ==",
       "os": [
         "linux"
       ],
@@ -1596,44 +1596,44 @@
       "optional": true
     },
     "node_modules/@gjsify/timers": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.29.0.tgz",
-      "integrity": "sha512-tICAxMiTPTeklJ23iyRqwqasPz7QXluRcsEHG7kEYz41ppH0KP6G88T8rrBsGNz6S6j3xahtkbQ70Tdw9x/liA=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.30.0.tgz",
+      "integrity": "sha512-bQXoXFWgj8Y4nsa1+bw3G0XHzw82ZbnEspJ1bCegfzS3sjzgUpAsw8QwhXpKDYlpXLrumI7YJTfL0Rk5SOqFng=="
     },
     "node_modules/@gjsify/tls": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.29.0.tgz",
-      "integrity": "sha512-CDm/rpsKLxHf+M226w/8GhbQvTfueYXqWleonRtHxWcCKTwbECWxBn0kE9wvqn/UivxruBkNnf5byYQmZ6KgOQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.30.0.tgz",
+      "integrity": "sha512-vLG4aGUlzIByXI5RA8TRQhIsqYDEEQd/zNx4Rn/BNtKLIz6/2eneS9Th5p1TGmVo8Z0qZ+JiK/mQ8ntVOFk88w==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/net": "^0.29.0",
-        "@gjsify/tls-native": "^0.29.0",
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/net": "^0.30.0",
+        "@gjsify/tls-native": "^0.30.0",
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/tls-native": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.29.0.tgz",
-      "integrity": "sha512-xcZSiFlfDjHS9gMPBDobTM0UHTlwtIEAMfH/9IpRtRxsmYB4huFjmvm9pmdiZkH+VIZW5pGyjSqkbiDhkphfAQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.30.0.tgz",
+      "integrity": "sha512-MHnMHluQciwMNGPHjBvpoTyi3s9WdbM3pUq4mHRcm58JAu59CIa9Tkkdq0bz1oWD7h7I7X2kVa1C4wI64h4GSA==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gobject-2.0": "^4.1.0"
       },
       "optionalDependencies": {
-        "@gjsify/tls-native-darwin-arm64": "0.29.0",
-        "@gjsify/tls-native-darwin-x64": "0.29.0",
-        "@gjsify/tls-native-linux-arm64": "0.29.0",
-        "@gjsify/tls-native-linux-ppc64": "0.29.0",
-        "@gjsify/tls-native-linux-riscv64": "0.29.0",
-        "@gjsify/tls-native-linux-s390x": "0.29.0",
-        "@gjsify/tls-native-linux-x64": "0.29.0"
+        "@gjsify/tls-native-darwin-arm64": "0.30.0",
+        "@gjsify/tls-native-darwin-x64": "0.30.0",
+        "@gjsify/tls-native-linux-arm64": "0.30.0",
+        "@gjsify/tls-native-linux-ppc64": "0.30.0",
+        "@gjsify/tls-native-linux-riscv64": "0.30.0",
+        "@gjsify/tls-native-linux-s390x": "0.30.0",
+        "@gjsify/tls-native-linux-x64": "0.30.0"
       }
     },
     "node_modules/@gjsify/tls-native-darwin-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-darwin-arm64/-/tls-native-darwin-arm64-0.29.0.tgz",
-      "integrity": "sha512-nKsFnS0KCnFcPN+TLsoEKF1gaXTg/ZbOc5yDLRFraD0cP+3cHnlcOmVQzweCSUUW3K8wHCkU3SFE6pl4Y0ZTIg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-darwin-arm64/-/tls-native-darwin-arm64-0.30.0.tgz",
+      "integrity": "sha512-s+RIUpzSlSCiKpbqN10uHj+trEaFNlLq7Q/PfSqHISx0+GE1KPC7wyPXJj61aHHjSpO9gKJmiEd5plxvhFNYwg==",
       "os": [
         "darwin"
       ],
@@ -1643,9 +1643,9 @@
       "optional": true
     },
     "node_modules/@gjsify/tls-native-darwin-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-darwin-x64/-/tls-native-darwin-x64-0.29.0.tgz",
-      "integrity": "sha512-p/Za5fuv5lbyDIolnQhIJjMiS0kVAuGVE5A8C4zT2RCr97N6DB6J71osdt60ERm/HNdc2bOA+e68FTVoI29C1A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-darwin-x64/-/tls-native-darwin-x64-0.30.0.tgz",
+      "integrity": "sha512-VTk4Bn8ToqSU6gLyCHg1fjv8alxWr/GeLLAJkEONICTOYomzcNTmZDzqMTqM0zkx909QHuyymuQZLVa1xGHmqg==",
       "os": [
         "darwin"
       ],
@@ -1655,9 +1655,9 @@
       "optional": true
     },
     "node_modules/@gjsify/tls-native-linux-arm64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-arm64/-/tls-native-linux-arm64-0.29.0.tgz",
-      "integrity": "sha512-9Cc/wni8WPY+qattUxNWtJpiWnmZBNsSxpE5645/7ilRXzntePHIeyLGatC0Kk7r1NCv+CMaasDNyxgv3UaNOw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-arm64/-/tls-native-linux-arm64-0.30.0.tgz",
+      "integrity": "sha512-5lp8shXvy5OjfUr5I5/SmhBLWHBJSVZxbw6R9NmxQuEax7/0VtsQmrb/B47pmAjuxtecFAJWIcmRcddbB6c3oQ==",
       "os": [
         "linux"
       ],
@@ -1667,9 +1667,9 @@
       "optional": true
     },
     "node_modules/@gjsify/tls-native-linux-ppc64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-ppc64/-/tls-native-linux-ppc64-0.29.0.tgz",
-      "integrity": "sha512-R0eZSBAsX/zSU5W8IHmDgROliTkibS4etpi/DmFKCCBFQA4e6cUEoSGAkiT+3LxYmo30mBPaeQG7JH21YGPW2g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-ppc64/-/tls-native-linux-ppc64-0.30.0.tgz",
+      "integrity": "sha512-jIDZxYhXQCrC7W7/YJe8rdozJeEZ3OEZe9G+MqO+6oQ0CwYjgKA8ui15B4o4BVSdxBI/r+5uCIZTWtLWwEBnFQ==",
       "os": [
         "linux"
       ],
@@ -1679,9 +1679,9 @@
       "optional": true
     },
     "node_modules/@gjsify/tls-native-linux-riscv64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-riscv64/-/tls-native-linux-riscv64-0.29.0.tgz",
-      "integrity": "sha512-lHmYkOkTJMv554amxyDbBW1zzW/4z8sgTrvR2Jrx1ystAZ29QCLL7aQXyda/mrSiKJargyX5wXwnVfh4Zq50Bg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-riscv64/-/tls-native-linux-riscv64-0.30.0.tgz",
+      "integrity": "sha512-ba17KCC8G9d5iwjv4GLuMyNT/urzR9kQBYMD5heL6MInWsvVQVeU0eHXA5GbKrT5onePB4n4IdVbm2+oiWQA3g==",
       "os": [
         "linux"
       ],
@@ -1694,9 +1694,9 @@
       "optional": true
     },
     "node_modules/@gjsify/tls-native-linux-s390x": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-s390x/-/tls-native-linux-s390x-0.29.0.tgz",
-      "integrity": "sha512-hECkbAk4iEJq+7E560HhLZrpaPP77PUjDd12QFJhyMmIj4pAAPh8jXy/KoksDSFhtHaaDndTMpt9AAzlp2byMg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-s390x/-/tls-native-linux-s390x-0.30.0.tgz",
+      "integrity": "sha512-miXPH1tXTXN4Rhdtn9PeytFRqpDebHm7FLryEQtKg/c/P9hV2k7cz/HskpY2GNgGjqbVRBAS0GBeuc5mHzckKg==",
       "os": [
         "linux"
       ],
@@ -1706,9 +1706,9 @@
       "optional": true
     },
     "node_modules/@gjsify/tls-native-linux-x64": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-x64/-/tls-native-linux-x64-0.29.0.tgz",
-      "integrity": "sha512-UD10rSNgSgz77+XedkRQ5QhnIbOML4MUmXUYhnavJfUz/WeMI/07GaQncAaeDypuOuqd2pAVrhixIQmEwyEHEg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native-linux-x64/-/tls-native-linux-x64-0.30.0.tgz",
+      "integrity": "sha512-jQxWMhA23giNMKZwWM8JJ+opEKOVGYjAgrFd6LnTPQcs+zPE/fdI58q5OVjrLgoQM2di8osYOVFNXEw/1qIGaw==",
       "os": [
         "linux"
       ],
@@ -1718,45 +1718,45 @@
       "optional": true
     },
     "node_modules/@gjsify/tsc": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.29.0.tgz",
-      "integrity": "sha512-uPgI3TBqxF4HPm98k8M692aYQZNEAlmbINZbO/0ehwQwfYljewm7zSlk8FS97WwsYHsFw40hBM5zJPNJWAzAWA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.30.0.tgz",
+      "integrity": "sha512-ST+zJShgvwaM0UvlyqK/kSyDMtm6s+ouDqzhLHneIojDs/S/wnZcJodth9TooVEPlVQKMT3/dOi4fSz6rO8r8w==",
       "dependencies": {
-        "@gjsify/console": "^0.29.0",
-        "@gjsify/node-globals": "^0.29.0",
-        "@gjsify/web-globals": "^0.29.0"
+        "@gjsify/console": "^0.30.0",
+        "@gjsify/node-globals": "^0.30.0",
+        "@gjsify/web-globals": "^0.30.0"
       },
       "bin": {
         "gjsify-tsc": "./dist/tsc.gjs.mjs"
       }
     },
     "node_modules/@gjsify/tty": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.29.0.tgz",
-      "integrity": "sha512-WS9n0c7XFUBF8iX61UZkM9d3+1pc7XtFpPE/E+//rMv6Xpn4eiabtPANIgl7o1zefbdqwotley6vjYFPyoW6mA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.30.0.tgz",
+      "integrity": "sha512-iFnbhNDriZO7+fDmooi2SVjUFLjZCwogKDTLEFbLcjNBrVnq+/7UiNeqHG5uyI70s1T33Uu3JRdB5h3K/Z+0cg==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/stream": "^0.29.0",
-        "@gjsify/terminal-native": "^0.29.0"
+        "@gjsify/stream": "^0.30.0",
+        "@gjsify/terminal-native": "^0.30.0"
       }
     },
     "node_modules/@gjsify/url": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.29.0.tgz",
-      "integrity": "sha512-5YRTnCNJyol2RS+2ad8sGsp/y2olIrXUr/dZ57Yj56tmKe68Me0akBZLz0J7D+jh6wxVIgIGKI03I3sqiWNt/w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.30.0.tgz",
+      "integrity": "sha512-egBXEgfTdtEAILZR5DuEQFM3iF7kblYGkM+yXw/dkJCwUXNamCu+ixKkj14/xm4L9KT2MtSJsTLZBm76dzRs6A==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
     },
     "node_modules/@gjsify/util": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.29.0.tgz",
-      "integrity": "sha512-t/X8c0NjT/ji/QlixeYDmZcvEBzzG/muMEojXjuHFVb7/wYoV2IP+wjs44RtcGvqH2KLdmx29R9PR5ycFGAWqw=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.30.0.tgz",
+      "integrity": "sha512-FmyEUSg6yQIkRi8NE0dvXRLkJLpndNJn/MWq9CJvPhUA9zD++P1tP0oCnAGg9v3RWyRDawKNOSdFFj1+0tUBbA=="
     },
     "node_modules/@gjsify/utils": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.29.0.tgz",
-      "integrity": "sha512-dVBdlvkp33W4C1MGc8LAL6tXEA2Ml8TZMqVmycd6JFCrNlgTrJe8FwB4Od0Qd0bOC38MqjplxgbsRKUx0Kqnbw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.30.0.tgz",
+      "integrity": "sha512-+RTwBuJfBE7rr4MadJv4bWjJx350bEDOKb68hW6xMrj3tVooXsK1Khk56IZXl+jtJ/Bdo51LNGZ00X+eJoFudA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/giounix-2.0": "^4.1.0",
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/@gjsify/v8": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.29.0.tgz",
-      "integrity": "sha512-9Pa+R6cX9skYocrezr7tCgMEiWffR1FGRHM9N6anfaGjZ/5Vcz513eoX7E2weO+kNs0AaFb3nPfmXnwVMt4rmw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.30.0.tgz",
+      "integrity": "sha512-5IEr+2zEkYcBrzQP3kRbyV21xDBv2uc3vT5ohZTeKy16xSuZh83urojIJtWWAad9Sm99W6J1TAmzQWi5BsfRMQ==",
       "dependencies": {
         "@girs/glib-2.0": "^4.1.0"
       }
@@ -1782,136 +1782,136 @@
       }
     },
     "node_modules/@gjsify/vm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.29.0.tgz",
-      "integrity": "sha512-odxFhh6pJdmqnt12d4dqphkezlOexUqU7ny7MYOIBAUaS2GfTXG/Yttb5yyo0oZTHdZA8ElmqupQUqHtok6iNA=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.30.0.tgz",
+      "integrity": "sha512-+x7uHiRczmLRkWZnJ3ArBjpG+jViKDLVFgc1s0AX+uJ0Rkcvzz79x9uABGWRk/Dc/1cCOHY3May/NKp8FULDFQ=="
     },
     "node_modules/@gjsify/web-globals": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.29.0.tgz",
-      "integrity": "sha512-4QnMfTPe24Kvh9sAoqUyY1Vxu9f+kq6PUYtewtzuz5X6qgR2DTQznLvD5aO53dj2yBx1AGyz3lpLZ3QQe/b/Mw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.30.0.tgz",
+      "integrity": "sha512-ocmo0iPCiKFaJ3t2cNeWTvpRxOVacKhyvWw7lOXfjaFz2YHQOX+F8q75acg/0RIS+mfGD5sF11ZM39DOXIT2cA==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.29.0",
-        "@gjsify/buffer": "^0.29.0",
-        "@gjsify/compression-streams": "^0.29.0",
-        "@gjsify/dom-events": "^0.29.0",
-        "@gjsify/dom-exception": "^0.29.0",
-        "@gjsify/eventsource": "^0.29.0",
-        "@gjsify/formdata": "^0.29.0",
-        "@gjsify/gamepad": "^0.29.0",
-        "@gjsify/perf_hooks": "^0.29.0",
-        "@gjsify/url": "^0.29.0",
-        "@gjsify/web-streams": "^0.29.0",
-        "@gjsify/webcrypto": "^0.29.0"
+        "@gjsify/abort-controller": "^0.30.0",
+        "@gjsify/buffer": "^0.30.0",
+        "@gjsify/compression-streams": "^0.30.0",
+        "@gjsify/dom-events": "^0.30.0",
+        "@gjsify/dom-exception": "^0.30.0",
+        "@gjsify/eventsource": "^0.30.0",
+        "@gjsify/formdata": "^0.30.0",
+        "@gjsify/gamepad": "^0.30.0",
+        "@gjsify/perf_hooks": "^0.30.0",
+        "@gjsify/url": "^0.30.0",
+        "@gjsify/web-streams": "^0.30.0",
+        "@gjsify/webcrypto": "^0.30.0"
       }
     },
     "node_modules/@gjsify/web-polyfills": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.29.0.tgz",
-      "integrity": "sha512-JPJBBRC1lRbMrS6dJOrIaibD2G0M5CM3RWu/UBW/isYUbXWAe1V0cZwL3hruZMSyy6Y2FFDskkTQKw1LD/8Z5Q==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.30.0.tgz",
+      "integrity": "sha512-gY/BNOwj6fee8QDCuTHNazx4ZkajUpV3B6G3v33PS94QruAxxF704WRJFmUa+cxNVt0N0AIFJnsuuYdowQ2yhw==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.29.0",
-        "@gjsify/compression-streams": "^0.29.0",
-        "@gjsify/dom-events": "^0.29.0",
-        "@gjsify/dom-exception": "^0.29.0",
-        "@gjsify/domparser": "^0.29.0",
-        "@gjsify/eventsource": "^0.29.0",
-        "@gjsify/fetch": "^0.29.0",
-        "@gjsify/formdata": "^0.29.0",
-        "@gjsify/gamepad": "^0.29.0",
-        "@gjsify/message-channel": "^0.29.0",
-        "@gjsify/web-globals": "^0.29.0",
-        "@gjsify/web-streams": "^0.29.0",
-        "@gjsify/webassembly": "^0.29.0",
-        "@gjsify/webaudio": "^0.29.0",
-        "@gjsify/webcrypto": "^0.29.0",
-        "@gjsify/websocket": "^0.29.0",
-        "@gjsify/webstorage": "^0.29.0",
-        "@gjsify/xmlhttprequest": "^0.29.0"
+        "@gjsify/abort-controller": "^0.30.0",
+        "@gjsify/compression-streams": "^0.30.0",
+        "@gjsify/dom-events": "^0.30.0",
+        "@gjsify/dom-exception": "^0.30.0",
+        "@gjsify/domparser": "^0.30.0",
+        "@gjsify/eventsource": "^0.30.0",
+        "@gjsify/fetch": "^0.30.0",
+        "@gjsify/formdata": "^0.30.0",
+        "@gjsify/gamepad": "^0.30.0",
+        "@gjsify/message-channel": "^0.30.0",
+        "@gjsify/web-globals": "^0.30.0",
+        "@gjsify/web-streams": "^0.30.0",
+        "@gjsify/webassembly": "^0.30.0",
+        "@gjsify/webaudio": "^0.30.0",
+        "@gjsify/webcrypto": "^0.30.0",
+        "@gjsify/websocket": "^0.30.0",
+        "@gjsify/webstorage": "^0.30.0",
+        "@gjsify/xmlhttprequest": "^0.30.0"
       }
     },
     "node_modules/@gjsify/web-streams": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.29.0.tgz",
-      "integrity": "sha512-CohqBvkwNcTyd4BI5+uh5PdcLGbDI4M5YIa5DFUS/axbavGhhhgvvgXvPuAgiIg4JpIB27y5OZLeNX/5iZuxGQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.30.0.tgz",
+      "integrity": "sha512-KKVLopuWDD8iKQMDfzJaBYxTrNPZydEJbbU/fwI6KjO6l84SVgSgC5sqXeqo08ZyU+QkX0BYAo8BihUqCHxdcA==",
       "dependencies": {
-        "@gjsify/utils": "^0.29.0"
+        "@gjsify/utils": "^0.30.0"
       }
     },
     "node_modules/@gjsify/webassembly": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.29.0.tgz",
-      "integrity": "sha512-xnF8gSlXRt/1xZnWN6wPKlFprExe4mdxPFN791QKH3D/5zHZ1yYAOuz3FM5w6djWdHF4JpBXI8pQHLWK5+i6cg=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.30.0.tgz",
+      "integrity": "sha512-1Hf/qNpHbMfPmFKnDZb5qHuzR9IQjeQ3eYWDMROuqKPM0q0P9W7TRPKLW6cU3/FEj0WhP70ugyZBtQUEIC8a6g=="
     },
     "node_modules/@gjsify/webaudio": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.29.0.tgz",
-      "integrity": "sha512-zEc+8IWQsPcN3Q45liqSYV5YajYCbcPBIeCWbEwWoZrWSDhW7u/oRFuDG+JjS8rrAUVdMEuG5zHAzmqv0Ehorg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.30.0.tgz",
+      "integrity": "sha512-ggB3xmS83t7eAbuyCD/OUTxH37fCnBdyEp5da+94d0+SnEhwaPK0g9p+K0AoU17uhQwoc5Sy7DJZ4c1eSZ3zmg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.29.0"
+        "@gjsify/dom-events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/webcrypto": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.29.0.tgz",
-      "integrity": "sha512-vZw2XJBZZ7qMbvfxYbOznmLTuEwb3SmTz5zjAymRbgMBVveNrZ0HeG+ziEAPEhW+O62sY+V18ar574vUSFccIg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.30.0.tgz",
+      "integrity": "sha512-U9+9lBDFotBAsbH9Glk1u2xKWi8ItBuukGmP/zXhMVi0FzXUxjuWfyzR1g+C1hkoMSoREiERvSbWPw8ODiCGsg==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.29.0"
+        "@gjsify/dom-exception": "^0.30.0"
       }
     },
     "node_modules/@gjsify/websocket": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.29.0.tgz",
-      "integrity": "sha512-9tEvdSjoQExckAOi4PRE6r4RpgPczGrrLv2pgtTXBjmsLoCXupuxPINPVk6MWBn0KoWQkPV4YpxW5YnFHXmSkA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.30.0.tgz",
+      "integrity": "sha512-iW3+fWCPt7k0Qt0E2qknYoTwsoWxZRo1QXJ4mmmXpNHKY3QH0ybQeQ3xR6AleRhAlRr7mn2y4gaABrsxeoARTg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/soup-3.0": "^4.1.0",
-        "@gjsify/dom-events": "^0.29.0"
+        "@gjsify/dom-events": "^0.30.0"
       }
     },
     "node_modules/@gjsify/webstorage": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.29.0.tgz",
-      "integrity": "sha512-EdspmWzRf9FaZyEx1wMshTyWe5GZqGv4lZHDWNuuuYF6ft1SXCNF3UUqPgCg1iGokvQfgd7FWdmbomL4EoNLnA=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.30.0.tgz",
+      "integrity": "sha512-kBYBvlwbrKyb3htcruO+kV/bX0Aaf2TEvv8nu89+c8TevsmGREgSKbRrPt9ZHKjrgsJKGzxwqhr9FNSB4Tf47A=="
     },
     "node_modules/@gjsify/worker_threads": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.29.0.tgz",
-      "integrity": "sha512-biC3jeMkdsdTBpSSL79cs5W6DtMtLrq2/RFDME05W14xMl3ufDj0VZnQeqUHZupd33mwdQuOzE9ICGIwU+J19A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.30.0.tgz",
+      "integrity": "sha512-tUmgWhAbWs6wy8bgHPUZ4f5dNyI2w8qKEg1j4MuJdjoLzvoAJdl9Iqs2I8V1S0jjkFuH6xBEcSrftUvB4PO2cQ==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/events": "^0.29.0",
-        "@gjsify/message-channel": "^0.29.0",
-        "@gjsify/sab-native": "^0.29.0"
+        "@gjsify/events": "^0.30.0",
+        "@gjsify/message-channel": "^0.30.0",
+        "@gjsify/sab-native": "^0.30.0"
       }
     },
     "node_modules/@gjsify/workspace": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.29.0.tgz",
-      "integrity": "sha512-Uil8hMx+2hZgAHeoouspajlvjyGkzntxMw2dAZwgAQOi+bV4ZDrVF/G5QE0vAgYtanwxpGhbvla0MNrCgzFv1A=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.30.0.tgz",
+      "integrity": "sha512-E+2ukiH4M78lHo904//1btL9lBx8WVftoX2WYPNqP6img1+qiVhvnRf1NLEELt9WrcPlwaUglrTchbyLrdI/uw=="
     },
     "node_modules/@gjsify/xmlhttprequest": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.29.0.tgz",
-      "integrity": "sha512-/5HzY9C2NZcqBAYMrTEbA98rBN6y4qoIQJg0mBYptIskG/hRxDe86XTQrCw8Jr4Opr4JCOObCaqM8WnCVGIdZw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.30.0.tgz",
+      "integrity": "sha512-/xse6L0EyFwK1hOtRCvjywsdYpv1USClMurTOeWHJqPdCbZ61SiHvSVwSKuew58UEXzTJNm5q6EK1Pn8mWNKdA==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/gjs": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/fetch": "^0.29.0"
+        "@gjsify/fetch": "^0.30.0"
       }
     },
     "node_modules/@gjsify/zlib": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.29.0.tgz",
-      "integrity": "sha512-f9sVbCz7DLmrfiDJXlLV/HQHgMil7gOSZzNPn1RtMq/6yA4sH8wb2yJu8dcSONxDv6JZvMXw6dF+7GiL+Jb9gw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.30.0.tgz",
+      "integrity": "sha512-21zBpJVtyiypc48qQVsUSknHkY7lwI7uko2IahGXrvSqi9OYYpKGupG1KkmSIi1rmQGiFzm5PkG7KmeSJ9iFUg==",
       "dependencies": {
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
-        "@gjsify/stream": "^0.29.0"
+        "@gjsify/stream": "^0.30.0"
       }
     },
     "node_modules/@iarna/toml": {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
-    "@gjsify/cli": "^0.29.0",
-    "@gjsify/rolldown-native": "^0.29.0",
+    "@gjsify/cli": "^0.30.0",
+    "@gjsify/rolldown-native": "^0.30.0",
     "@release-it/bumper": "^7.0.6",
     "@release-it/conventional-changelog": "^11.0.1",
     "@ts-for-gir/cli": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "@gjsify/cli": "^0.29.0",
+    "@gjsify/rolldown-native": "^0.29.0",
     "@release-it/bumper": "^7.0.6",
     "@release-it/conventional-changelog": "^11.0.1",
     "@ts-for-gir/cli": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
-    "@gjsify/cli": "^0.14.0",
+    "@gjsify/cli": "^0.29.0",
     "@release-it/bumper": "^7.0.6",
     "@release-it/conventional-changelog": "^11.0.1",
     "@ts-for-gir/cli": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -157,7 +157,7 @@
   },
   "devDependencies": {
     "@gi.ts/parser": "workspace:^",
-    "@gjsify/cli": "^0.29.0",
+    "@gjsify/cli": "^0.30.0",
     "@ts-for-gir/generator-base": "workspace:^",
     "@ts-for-gir/generator-html-doc": "workspace:^",
     "@ts-for-gir/generator-json": "workspace:^",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -157,7 +157,7 @@
   },
   "devDependencies": {
     "@gi.ts/parser": "workspace:^",
-    "@gjsify/cli": "^0.14.0",
+    "@gjsify/cli": "^0.29.0",
     "@ts-for-gir/generator-base": "workspace:^",
     "@ts-for-gir/generator-html-doc": "workspace:^",
     "@ts-for-gir/generator-json": "workspace:^",

--- a/packages/cli/templates/types-gjsify/package.json
+++ b/packages/cli/templates/types-gjsify/package.json
@@ -13,7 +13,7 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.13",
-		"@gjsify/cli": "^0.4.23",
+		"@gjsify/cli": "^0.30.0",
 		"typescript": "^6.0.2"
 	},
 	"dependencies": {


### PR DESCRIPTION
`check` and `test-e2e` have been red. There are **two independent causes**, both fixed here, both measured.

## 1. The CLI that ran was 0.14.0, not the one we bootstrap

`ci.yml` bootstraps `@gjsify/cli` from `releases/latest`, then runs:

```yaml
- run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run check
```

`node_modules/.bin` comes **first**, and `gjsify-lock.json` pinned `@gjsify/cli: 0.14.0` — so the bootstrapped CLI lost the PATH lookup to a 14-versions-stale one. Verified in a local checkout: `node_modules/.bin/gjsify -> node_modules/@gjsify/cli/lib/index.js`, version `0.14.0`.

0.14.0 predates the fix for spawning oxlint via `process.execPath` (gjsify `78ae67790`, 2026-07-03, an ancestor of **both** v0.27.1 and v0.28.0). Under GJS that path is the CLI bundle itself — which carries `#!/usr/bin/env -S gjs -m` and is executable — so the CLI re-executed **itself** with oxlint's argv. That is the failing run's output verbatim:

```
Running on GJS 1.86.0 (SpiderMonkey)
Unknown arguments: config, /__w/ts-for-gir/ts-for-gir/node_modules/oxlint/bin/oxlint, .
script "check" exited with code 1
```

0.14.0's own source says so, unminified — `lib/utils/oxc-resolve.js:263`: *"oxlint: always spawned via its Node ESM launcher with the current Node executable (`process.execPath`)"*.

## 2. `json-glib` was missing from the container

`test-e2e` failed with `gjsify build: no usable bundler engine under GJS — @gjsify/rolldown-native is not loadable`, and its log lists five detected native prebuilds with **rolldown-native absent from them**.

Measured on `fedora:43` with this workflow's exact package list: the engine's prebuild needs `libjson-glib-1.0.so.0`, which nothing here installed, so GIRepository cannot open its backing library. Adding `json-glib` alone makes `gjsify build --app gjs` succeed on **gjs 1.86.0**.

Declared upstream too (gjsify#994), so the installer names the missing library instead of failing with `Unsupported type void, deriving from fundamental void` — which is what it does today, and which names nothing.

## `fedora:43` stays

GJS 1.86 was suspected and **cleared by measurement**: with json-glib present it installs, constructs `BundlerSession` and builds. It is also the Fedora 43 / GNOME 49 / `org.gnome.Platform//49` baseline, so dropping it would cost more than it buys.

## About the lockfile

This is a **real upgrade**, not a format migration: 94 packages move `0.14.0 -> 0.29.0`, and the tree grows 878 → 931 entries.

Regenerated with the **published 0.29.0** — the version this CI bootstraps — for two reasons:

- gjsify writes `lockfileVersion 4` as of that release; 0.28.0 cannot read it, so a v4 file regenerated with a newer CLI would break the bootstrapped one.
- With 0.28.0 the regeneration is not even possible: it dies on `EBADPLATFORM` for `@parcel/rust-darwin-x64`, the both-block optional-dependency bug fixed in gjsify#988 and released in 0.29.0.

## What proves it

CI. It has been red on both jobs, so a green run here is the first evidence either way — and it is the only thing that can vouch for a 15-minor-version jump across 94 packages.