### PR TITLE
feat: emit the GIR-derived widget vocabulary on `@girs/<ns>/surface`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ tests/**/dist/
 
 # Generator output of test workspaces
 tests/**/generated/
+tests/**/generated-off/
+tests/**/generated-inline/
+tests/**/generated-cross/
+tests/**/generated-broken/
 
 # Local Claude Code state (plans, settings)
 .claude/

--- a/.ts-for-gir.packages-all.rc.js
+++ b/.ts-for-gir.packages-all.rc.js
@@ -18,6 +18,10 @@ export default {
   ],
   ignoreVersionConflicts: true,
   promisify: true,
+  // The GIR-derived widget vocabulary on `@girs/<ns>/surface`. Namespaces that declare no
+  // GtkWidget descendant emit nothing regardless, so this turns it on for the handful that
+  // do (Gtk-4.0, Gtk-3.0, Adw-1, GtkSource, WebKit, …) and leaves the rest untouched.
+  widgetSurface: true,
   onlyVersionPrefix: false,
   package: true,
   reporter: true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ TS type definition generator for GObject Introspection (GIR) → GJS. Prefer ret
 
 ## General
 
-- `./types`, `./gjs`, `./vala-girs` are git submodules — **never delete**
+- `./types-release`, `./types-dev`, `./refs/*` are git submodules — **never delete**
 - Always use `.ts` import extensions — TS runs directly, no build step
 - Config files: `.ts-for-gir.*.rc.js` in project root
 
@@ -15,7 +15,7 @@ Yarn v4 workspaces | Node >= 22 | all ESM (`"type": "module"`)
 Category | Path | Namespace | Notes
 ---|---|---|---
 Core | `/packages/*` | `@ts-for-gir/*`, `@gi.ts/*` | No build, runs TS directly
-Types | `/types/*` | `@girs/*` | Generated — **never edit manually**
+Types | `/types-release/*`, `/types-dev/*` | `@girs/*` | Generated — **never edit manually**
 Examples | `/examples/*` | `@ts-for-gir-example/*` | Req build (GJS can't run TS)
 Tests | `/tests/*` | `@ts-for-gir-test/*` | Generator tests
 
@@ -39,7 +39,7 @@ gjsify run ts-for-gir-dev list
 
 ## Generation Flow
 
-GIR XML (`/girs/`) → `@gi.ts/parser` → `@ts-for-gir/lib` → `@ts-for-gir/generator-typescript` → `/types/@girs/*`
+GIR XML (`/girs/`) → `@gi.ts/parser` → `@ts-for-gir/lib` → `@ts-for-gir/generator-typescript` → `/types-dev/@girs/*`
 
 ### Key Files
 
@@ -61,7 +61,7 @@ Use `node.assertClass("ClassName").noEmit()` to disable auto-generation; templat
 
 ### Output Dirs
 
-`/types/*` (submodule, branch `main`): official published types, may be cached
+`/types-release/*` (submodule, branch `main`): official published types, may be cached
 `/types-dev/*` (submodule, branch `dev`): development types, used by examples and workspace `@girs/*` packages
 Custom `--outdir=./test-types-*`: fresh generation for dev/testing
 
@@ -77,6 +77,34 @@ When modifying generators, templates, injections, or lib code that affects gener
 `gjsify run build` chains all steps: `build:app → build:types → build:examples → build:json → build:doc`
 
 **Important:** Examples import from `@girs/*` packages which resolve to `/types-dev/`. Generator changes will NOT be reflected in examples or `gjsify run check` until `gjsify run build:types` has been run.
+
+### Widget surface (`@girs/<ns>/surface`)
+
+Opt-in subpath (`widgetSurface`, on in `.ts-for-gir.packages-all.rc.js`) carrying the
+GIR-derived widget VOCABULARY: a writable-only, optional, GObject-keyed props interface per
+declaration, the construct-only name union, enum nick unions from `glib:nick`, a GType-keyed
+`Widgets` map, and the same facts again as runtime data in the sibling `.js` — because types
+are erased and the only check that can go red for a real reason is a consumer asking the
+INSTALLED library whether every name is real. Code: `packages/generator-typescript/src/surface/`.
+Decided in gjsify's ADR 0029.
+
+Three rules bind work here. **The vocabulary ships, the dialect does not** — no tag spelling,
+no `on<Signal>` prop, no `JSX.IntrinsicElements`, no Vue `GlobalComponents`, no camelCase
+property key. A JSX namespace is a GLOBAL declaration, so a second library declaring one
+collides on every shared tag, and `@girs/*` is the package that must not do that.
+**Only namespaces that DECLARE a concrete `GtkWidget` descendant emit one** — a handful of the
+705 GIRs; a cross-namespace base is imported from its owner's `./surface`, and a base owned by
+a namespace with no surface is dropped only if it contributes no settable property (otherwise
+the generator refuses and names it). **Nothing is derived that GIR carries**: the nick comes
+from `glib:nick` (889 of 40 940 members disagree with the underscore substitution, none of them
+in Gtk-4.0 or Adw-1 — which is how a derived nick passes review), the dashed property name from
+`IntrospectedProperty.girName`, the GType from `glibTypeName`.
+
+Gate: `tests/widget-surface` — positives plus three controls that must go the other way (flag
+off emits nothing, a broken fixture exits non-zero naming the declaration, and the `.d.ts` and
+`.js` halves are read separately and compared). The emitted surface is also in each package's
+own `tsconfig.json#include`, so `gjsify run check:types` compiles it — the only thing that
+catches a surface referencing a name the main emitter did not emit.
 
 ### GIR → TS Mapping
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,10 @@ property key. A JSX namespace is a GLOBAL declaration, so a second library decla
 collides on every shared tag, and `@girs/*` is the package that must not do that.
 **Only namespaces that DECLARE a concrete `GtkWidget` descendant emit one** — a handful of the
 705 GIRs; a cross-namespace base is imported from its owner's `./surface`, and a base owned by
-a namespace with no surface is dropped only if it contributes no settable property (otherwise
-the generator refuses and names it). **Nothing is derived that GIR carries**: the nick comes
+a namespace with no surface is dropped when it contributes no settable property and INLINED
+when it does, named in that file's provenance line. (Refusing it was the first version, and it
+took a 705-namespace run down at namespace 265 on `Gcr.Prompt` — the only such base in the
+corpus.) **Nothing is derived that GIR carries**: the nick comes
 from `glib:nick` (889 of 40 940 members disagree with the underscore substitution, none of them
 in Gtk-4.0 or Adw-1 — which is how a derived nick passes review), the dashed property name from
 `IntrospectedProperty.girName`, the GType from `glibTypeName`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -136,6 +136,9 @@ Options:
                                                       [boolean] [default: false]
       --promisify               Generate promisified functions for async/finish
                                 calls                  [boolean] [default: true]
+      --widgetSurface           Emit the GIR-derived widget vocabulary on a
+                                `./surface` subpath for namespaces that declare
+                                GtkWidget descendants [boolean] [default: false]
       --npmScope                Scope of the generated NPM packages
                                                      [string] [default: "@girs"]
       --workspace               Uses the workspace protocol for the generated
@@ -524,6 +527,43 @@ The `noAdvancedVariants` option disables the advanced GLib.Variant class with st
 ```bash
 ts-for-gir generate * --noAdvancedVariants=false
 ```
+
+### widgetSurface
+
+Emits the GIR-derived widget **vocabulary** on an opt-in `@girs/<ns>/surface` subpath, for the
+namespaces that declare concrete descendants of `GtkWidget` — `Gtk-4.0`, `Adw-1`, `Gtk-3.0`,
+`GtkSource`, `WebKit` and so on. Every other namespace emits nothing regardless of the flag, so
+this is not something a Gio-only project pays for. Requires `--package`.
+
+What the subpath exports, all module-scoped:
+
+```ts
+import type { Widgets, GtkBoxProps, GtkOrientationNick } from '@girs/gtk-4.0/surface';
+import { OWN_PROPS, ENUM_NICKS, SINCE } from '@girs/gtk-4.0/surface';
+
+// One props interface per GIR DECLARATION, mirroring GIR's own inheritance:
+// writable-only, optional, keyed by the name GObject registered.
+declare const box: GtkBoxProps;   // { 'css-classes'?: string[]; orientation?: …; spacing?: number }
+
+// A GType-keyed map, pointing at the `SignalSignatures` @girs already emits.
+type BoxSignals = Widgets['GtkBox']['signals'];
+```
+
+Three things this is and `X.ConstructorProps` is not: **writable-only** (measured on Gtk-4.0,
+`ConstructorProps` offers 150 read-only properties across 68 classes as settable, and GTK's
+failure mode for writing one is exit 0), **optional**, and **keyed by the registered name** —
+the dashed spelling `g_object_set()`, GtkBuilder XML and Blueprint all use.
+
+What it deliberately does **not** contain: tag spellings, `on<Signal>` handler prop names,
+`JSX.IntrinsicElements`, a Vue `GlobalComponents` interface, camelCase property keys. Those are
+framework dialect, every framework answers them differently, and a JSX namespace is a global
+declaration — a second library declaring one collides on every shared tag. Build your dialect on
+these names instead.
+
+Beside the `.d.ts`, the same subpath exports the facts as runtime **data** (`OWN_PROPS`,
+`OWN_SIGNALS`, `DECLS`, `ENUM_NICKS`, `SLOT_CANDIDATES`, `SINCE`), because types are erased and
+the check worth having is a consumer asking the *installed* library whether every name is real.
+`SINCE` is what lets that check tell a version gap from a defect without an allowlist.
 
 ### package
 

--- a/packages/cli/src/config/config-loader.ts
+++ b/packages/cli/src/config/config-loader.ts
@@ -168,6 +168,7 @@ export async function load(cliOptions: ConfigFlags): Promise<UserConfig> {
       ["noNamespace", options.noNamespace.default],
       ["noComments", options.noComments.default],
       ["promisify", options.promisify.default],
+      ["widgetSurface", options.widgetSurface.default],
       ["workspace", options.workspace.default],
       ["onlyVersionPrefix", options.onlyVersionPrefix.default],
       ["noPrettyPrint", options.noPrettyPrint.default],

--- a/packages/cli/src/config/defaults.ts
+++ b/packages/cli/src/config/defaults.ts
@@ -23,6 +23,7 @@ export const defaults = {
   noNamespace: false,
   noComments: false,
   promisify: true,
+  widgetSurface: false,
   npmScope: "@girs",
   workspace: false,
   onlyVersionPrefix: false,

--- a/packages/cli/src/config/options.ts
+++ b/packages/cli/src/config/options.ts
@@ -90,6 +90,13 @@ export const options: { [name: string]: Options } = {
     default: defaults.promisify,
     normalize: true,
   },
+  widgetSurface: {
+    type: "boolean",
+    description:
+      "Emit the GIR-derived widget vocabulary on a `./surface` subpath for namespaces that declare GtkWidget descendants",
+    default: defaults.widgetSurface,
+    normalize: true,
+  },
   npmScope: {
     type: "string",
     description: "Scope of the generated NPM packages",
@@ -184,6 +191,7 @@ export const generateOptions = {
   noNamespace: options.noNamespace,
   noComments: options.noComments,
   promisify: options.promisify,
+  widgetSurface: options.widgetSurface,
   npmScope: options.npmScope,
   workspace: options.workspace,
   depVersionFormat: options.depVersionFormat,

--- a/packages/cli/src/types/command-args.ts
+++ b/packages/cli/src/types/command-args.ts
@@ -32,6 +32,7 @@ export interface GenerateCommandArgs extends BaseCommandArgs {
   noComments: boolean;
   /** Generate promisified functions for async/finish calls */
   promisify: boolean;
+  widgetSurface: boolean;
   /** Scope of the generated NPM packages */
   npmScope: string;
   /** Uses the workspace protocol for the generated packages which can be used with package managers like Yarn and PNPM */

--- a/packages/generator-typescript/src/generators/module-exporter.ts
+++ b/packages/generator-typescript/src/generators/module-exporter.ts
@@ -7,6 +7,7 @@ import type {
 } from "@ts-for-gir/lib";
 import type { ModuleGenerator } from "../module-generator.ts";
 import { NpmPackage } from "../npm-package.ts";
+import { buildWidgetSurface, emitSurfaceData, emitSurfaceTypes } from "../surface/index.ts";
 import type { TemplateProcessor } from "../template-processor.ts";
 
 /** Handles exporting generated modules to files. */
@@ -72,6 +73,46 @@ export class ModuleExporter {
     }
   }
 
+  /**
+   * Emit the opt-in `@girs/<ns>/surface` subpath, if this namespace declares widgets.
+   *
+   * Two gates, and the second is the one that keeps the count honest: the config flag
+   * has to be on, and the namespace has to declare at least one concrete descendant of
+   * `GtkWidget`. Of the 705 GIRs in this repository a handful do; emitting an empty
+   * surface for the rest would put a `./surface` entry in every package that resolves
+   * to a file with no widgets in it.
+   *
+   * `package` mode only: the subpath needs an `exports` entry to be reachable at all,
+   * and `externalDeps` mode deliberately emits one flat ambient `.d.ts` with no package
+   * around it.
+   */
+  private async exportWidgetSurface(girModule: GirModule): Promise<void> {
+    if (!this.config.widgetSurface || !this.config.package || this.config.externalDeps) return;
+    if (!this.config.outdir) return;
+
+    const surface = buildWidgetSurface(girModule, this.config);
+    if (!surface) return;
+
+    const name = girModule.importName;
+    await this.moduleTemplateProcessor.write(
+      emitSurfaceTypes(surface),
+      this.config.outdir,
+      `${name}-surface.d.ts`,
+    );
+    await this.moduleTemplateProcessor.write(
+      emitSurfaceData(surface),
+      this.config.outdir,
+      `${name}-surface.js`,
+    );
+    // Read by the package.json and tsconfig.json templates, which run after this.
+    girModule.hasWidgetSurface = true;
+    this.log.log(
+      `${girModule.packageName}: widget surface — ${surface.widgets.length} widgets, ` +
+        `${[...surface.declarations.values()].filter((d) => d.emitted).length} declarations, ` +
+        `${surface.enums.size} enum nick unions`,
+    );
+  }
+
   async exportModule(registry: NSRegistry, girModule: GirModule): Promise<void> {
     await this.exportModuleTS();
 
@@ -84,6 +125,9 @@ export class ModuleExporter {
       await this.exportTemplate("module-ambient.js", `${name}-ambient.js`);
       await this.exportTemplate("module-import.d.ts", `${name}-import.d.ts`);
       await this.exportTemplate("module-import.js", `${name}-import.js`);
+
+      // Before the package.json, which needs to know whether the subpath exists.
+      await this.exportWidgetSurface(girModule);
 
       const pkg = new NpmPackage(
         this.config,

--- a/packages/generator-typescript/src/surface/emit-data.ts
+++ b/packages/generator-typescript/src/surface/emit-data.ts
@@ -1,0 +1,75 @@
+/**
+ * Render the `./surface` runtime data module.
+ *
+ * Why data and not only types: the one check that can go red for a real reason is
+ * "does the INSTALLED library actually have this". Asking it needs a running GJS
+ * with a GTK present, which this generator does not have — it emits 705 namespaces
+ * headlessly. So the facts ship as values a consumer's test can read, and the
+ * checking stays where a GTK is installed.
+ *
+ * Kept deliberately narrow: names, the declaration chain, nicks, slot candidates and
+ * since-versions. No default values — GIR's `default-value` and a probed instance
+ * disagree in 104 of 953 measured cases, so a default that is worth having has to
+ * come from constructing the object, which again is not something this generator can
+ * do.
+ */
+
+import type { WidgetSurface } from "./model.ts";
+
+const record = (rows: readonly string[]): string => (rows.length === 0 ? "{}" : `{\n${rows.join("\n")}\n}`);
+
+const list = (items: readonly string[]): string => `[${items.map((item) => `'${item}'`).join(", ")}]`;
+
+export function emitSurfaceData(surface: WidgetSurface): string {
+  const ownProps: string[] = [];
+  for (const decl of [...surface.declarations.values()].sort((a, b) => (a.gtype < b.gtype ? -1 : 1))) {
+    if (!decl.emitted || decl.props.length === 0) continue;
+    ownProps.push(`    ${decl.gtype}: ${list(decl.props.map((prop) => prop.girName))},`);
+  }
+
+  const ownSignals = surface.widgets
+    .filter((widget) => widget.signals.length > 0)
+    .map((widget) => `    ${widget.gtype}: ${list(widget.signals)},`);
+
+  const decls = surface.widgets.map((widget) => `    ${widget.gtype}: ${list(widget.chain)},`);
+
+  const nicks = [...surface.enums.values()]
+    .sort((a, b) => (a.gtype < b.gtype ? -1 : 1))
+    .map((entry) => `    ${entry.gtype}: ${list(entry.nicks)},`);
+
+  const slots = surface.widgets
+    .filter((widget) => widget.slotCandidates.size > 0)
+    .map((widget) => {
+      const rows = [...widget.slotCandidates]
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([slot, method]) => `        '${slot}': '${method}',`);
+      return `    ${widget.gtype}: {\n${rows.join("\n")}\n    },`;
+    });
+
+  const since = [...surface.since]
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([member, version]) => `    '${member}': '${version}',`);
+
+  return `// The widget vocabulary of ${surface.namespace}-${surface.version} as runtime data.
+//
+// GENERATED — do not edit. Provenance: ${surface.provenance}
+//
+// The type half of this subpath is the sibling \`.d.ts\`. This file exists because
+// types are erased: a consumer that wants to ask the installed library whether every
+// name here is real needs values, not declarations.
+
+export const SURFACE_PROVENANCE = '${surface.provenance.replace(/'/g, "\\'")}';
+
+export const OWN_PROPS = ${record(ownProps)};
+
+export const OWN_SIGNALS = ${record(ownSignals)};
+
+export const DECLS = ${record(decls)};
+
+export const ENUM_NICKS = ${record(nicks)};
+
+export const SLOT_CANDIDATES = ${record(slots)};
+
+export const SINCE = ${record(since)};
+`;
+}

--- a/packages/generator-typescript/src/surface/emit-types.ts
+++ b/packages/generator-typescript/src/surface/emit-types.ts
@@ -1,0 +1,237 @@
+/**
+ * Render the `./surface` type module.
+ *
+ * Module-scoped exports ONLY: named interfaces and type aliases a consumer imports.
+ * No `declare global`, no `JSX` namespace, no `IntrinsicElements`, no augmentation
+ * of anyone else's module. That is the whole design constraint, and it is observed
+ * rather than feared — a JSX namespace is a global declaration, so a second library
+ * declaring one collides on every shared tag, and `@girs/*` is used by projects that
+ * want nothing to do with JSX.
+ *
+ * The runtime data is DECLARED here and defined in the sibling `.js`, so one subpath
+ * serves both. Types are erased, and a test that asks the installed GTK whether
+ * every emitted name is real cannot read a type.
+ */
+
+import {
+  constructOnlyAliasOf,
+  nickAliasOf,
+  propsInterfaceOf,
+  type SurfaceDecl,
+  type WidgetSurface,
+} from "./model.ts";
+
+const RUNTIME_DATA_DOC = `/**
+ * The same facts as runtime data, for a consumer that CHECKS them.
+ *
+ * Types are erased, so a spec that asks the installed GTK whether every property
+ * here is a writable ParamSpec, every signal resolvable by \`GObject.signal_lookup\`
+ * and every nick resolvable through an enum lookup cannot read the interfaces
+ * above. Emitted headlessly with no GTK present, which is exactly why the checking
+ * belongs to the consumer and the DATA belongs here.
+ */`;
+
+const jsdoc = (indent: string, doc: string | undefined, deprecated: boolean, since?: string): string => {
+  const lines: string[] = [];
+  if (doc) lines.push(doc);
+  if (since) lines.push(`@since ${since}`);
+  if (deprecated) lines.push("@deprecated");
+  if (lines.length === 0) return "";
+  if (lines.length === 1) return `${indent}/** ${lines[0]} */\n`;
+  return `${indent}/**\n${lines.map((l) => `${indent} * ${l}`).join("\n")}\n${indent} */\n`;
+};
+
+/** A GObject property name is dashed, so every key needs quoting; be exact anyway. */
+const key = (name: string): string => (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : `'${name}'`);
+
+function renderBases(decl: SurfaceDecl, surface: WidgetSurface): string {
+  if (decl.bases.length === 0) return "";
+  const omissions = surface.omissions.get(decl.key);
+  const rendered = decl.bases.map((base) => {
+    const target = surface.declarations.get(base);
+    const name = target ? propsInterfaceOf(target.gtype) : base;
+    const drop = omissions?.get(base);
+    if (!drop || drop.length === 0) return name;
+    return `Omit<${name}, ${drop.map((d) => `'${d}'`).join(" | ")}>`;
+  });
+  return ` extends ${rendered.join(", ")}`;
+}
+
+function renderDeclaration(decl: SurfaceDecl, surface: WidgetSurface): string {
+  const body = decl.props
+    .map(
+      (prop) =>
+        jsdoc("    ", prop.doc, prop.deprecated, prop.since) + `    ${key(prop.girName)}?: ${prop.ts};\n`,
+    )
+    .join("");
+  const constructOnly = decl.props.filter((prop) => prop.constructOnly).map((prop) => `'${prop.girName}'`);
+  const baseAliases = decl.bases
+    .map((base) => surface.declarations.get(base))
+    .filter((base): base is SurfaceDecl => base !== undefined)
+    .map((base) => constructOnlyAliasOf(base.gtype));
+  const parts = [...baseAliases, ...constructOnly];
+  return (
+    jsdoc("", decl.doc, false) +
+    `export interface ${propsInterfaceOf(decl.gtype)}${renderBases(decl, surface)} {\n${body}}\n` +
+    `/** Settable only at construction — a renderer must REBUILD, not patch. */\n` +
+    `export type ${constructOnlyAliasOf(decl.gtype)} = ${parts.length > 0 ? parts.join(" | ") : "never"};\n`
+  );
+}
+
+function renderImports(surface: WidgetSurface): string[] {
+  const lines: string[] = [];
+  for (const [ns, importPath] of [...surface.namespaceImports].sort(([a], [b]) => (a < b ? -1 : 1))) {
+    // The own namespace is a SIBLING file, not a package self-reference: the
+    // surface ships inside the package it describes.
+    const from = ns === surface.namespace ? `./${surface.importName}.js` : importPath;
+    lines.push(`import type ${ns} from '${from}';`);
+  }
+  for (const [subpath, names] of [...surface.surfaceImports].sort(([a], [b]) => (a < b ? -1 : 1))) {
+    lines.push(`import type { ${names.join(", ")} } from '${subpath}';`);
+  }
+  return lines;
+}
+
+export function emitSurfaceTypes(surface: WidgetSurface): string {
+  const emitted = [...surface.declarations.values()]
+    .filter((decl) => decl.emitted)
+    .sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
+  const inlined = emitted.filter((decl) => decl.inlined);
+
+  const nicks = [...surface.enums.values()]
+    .sort((a, b) => (a.gtype < b.gtype ? -1 : 1))
+    .map((entry) => {
+      const union = entry.nicks.length === 0 ? "never" : entry.nicks.map((nick) => `'${nick}'`).join(" | ");
+      return `export type ${nickAliasOf(entry.gtype)} = ${union};`;
+    });
+
+  const rows = surface.widgets.map((widget) => {
+    const slots = [...widget.slotCandidates]
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([slot, method]) => `        '${slot}': '${method}';`);
+    return (
+      `    ${widget.gtype}: {\n` +
+      `        class: ${widget.namespace}.${widget.local};\n` +
+      `        props: ${propsInterfaceOf(widget.gtype)};\n` +
+      `        signals: ${widget.namespace}.${widget.local}.SignalSignatures;\n` +
+      `        constructOnly: ${constructOnlyAliasOf(widget.gtype)};\n` +
+      `        slotCandidates: ${slots.length > 0 ? `{\n${slots.join("\n")}\n        }` : "{}"};\n` +
+      `    };`
+    );
+  });
+
+  const slotTotal = surface.widgets.reduce((n, widget) => n + widget.slotCandidates.size, 0);
+
+  return `/**
+ * The GIR-derived widget VOCABULARY for ${surface.namespace}-${surface.version}.
+ *
+ * GENERATED — do not edit. Provenance: ${surface.provenance}
+ *
+ * ${surface.widgets.length} concrete widgets, ${emitted.length} declarations${inlined.length > 0 ? ` (${inlined.length} inlined from a namespace with no surface)` : ""}, ${surface.enums.size} enum nick unions, ${slotTotal} slot candidates.
+ *
+ * Module-scoped exports only. There is no \`JSX\` namespace here, no tag spelling and
+ * no \`on<Signal>\` prop name: those are DIALECT, every framework answers them
+ * differently, and a JSX namespace is a global declaration that a second library
+ * cannot declare without colliding. Each consumer builds its own dialect on these
+ * names.
+ *
+ * Three things this is and \`ConstructorProps\` is not: WRITABLE-only (measured on
+ * Gtk-4.0, \`ConstructorProps\` offers 150 read-only properties across 68 classes as
+ * settable, and GTK's failure mode for writing one is exit 0), OPTIONAL, and keyed
+ * by the name GObject actually REGISTERED — the dashed spelling \`g_object_set\`,
+ * GtkBuilder XML and Blueprint all use.
+ *
+ * Signal handler types are not re-derived: \`X.SignalSignatures\`, which this package
+ * already emits for every class with the parent chain, every implemented interface
+ * and the \`notify::\` keys folded in, is what \`Widgets[G]['signals']\` points at.
+ */
+
+${renderImports(surface).join("\n")}
+
+// ---------------------------------------------------------------------------
+// Enum nicks — the string vocabulary GObject registered, from GIR's \`glib:nick\`.
+//
+// Not derived from the member name: measured across the 705 GIR files in this
+// repository, 889 of the 40 940 members carrying the attribute disagree with the
+// underscore substitution. Gtk-4.0 and Adw-1 happen not to be among them, which is
+// how a derived nick passes review and breaks elsewhere.
+// ---------------------------------------------------------------------------
+
+${nicks.join("\n")}
+
+// ---------------------------------------------------------------------------
+// Property surfaces — one interface per GIR DECLARATION, mirroring GIR's own
+// inheritance rather than flattening per widget.
+//
+// The interfaces are load-bearing, not tidiness: \`GtkBox\` declares four properties
+// of its own and \`orientation\` is not among them — it lives on \`Gtk.Orientable\`,
+// because GObject installs interface properties on the implementor at runtime while
+// GIR keeps them once, on the interface.
+// ---------------------------------------------------------------------------
+
+${emitted.map((decl) => renderDeclaration(decl, surface)).join("\n")}
+// ---------------------------------------------------------------------------
+// The GType-keyed widget map.
+//
+// Keyed by GType because that is also the GtkBuilder XML key and the typelib key. A
+// consumer maps GTypes to tags in ITS convention — kebab for JSX intrinsics, Pascal
+// for a Vue \`GlobalComponents\`, the class itself for a renderer whose element type
+// is the class. None of those is baked in here.
+//
+// \`slotCandidates\` is a candidate list and never an answer: derived from methods
+// taking exactly one widget argument. The GIR cannot tell adoption from reference —
+// \`set_title_widget\` parents its argument and \`set_activatable_widget\` does not, and
+// both are \`void f(GtkWidget*)\` at \`transfer-ownership="none"\`. Curation decides;
+// this is what notices when a release adds a candidate.
+// ---------------------------------------------------------------------------
+
+export interface Widgets {
+${rows.join("\n")}
+}
+
+/** Every GType this namespace can create. A consumer derives its own tag map. */
+export type WidgetGType = keyof Widgets;
+
+/** The writable, optional, GObject-keyed property surface of one GType. */
+export type PropsOf<G extends WidgetGType> = Widgets[G]['props'];
+
+/** The signal table this package already emits, reached by GType. */
+export type SignalsOf<G extends WidgetGType> = Widgets[G]['signals'];
+
+/** The instance type — what a \`ref\`-shaped prop should infer. */
+export type InstanceOf<G extends WidgetGType> = Widgets[G]['class'];
+
+/** Property names that can only be set at construction. */
+export type ConstructOnlyOf<G extends WidgetGType> = Widgets[G]['constructOnly'];
+
+/** Candidate child slots — see the note above; curation decides. */
+export type SlotCandidatesOf<G extends WidgetGType> = keyof Widgets[G]['slotCandidates'];
+
+${RUNTIME_DATA_DOC}
+export const SURFACE_PROVENANCE: string;
+
+/** Declaration GType -> its own settable properties, as GObject registered them. */
+export const OWN_PROPS: Readonly<Record<string, readonly string[]>>;
+
+/** Widget GType -> its own signals. */
+export const OWN_SIGNALS: Readonly<Record<string, readonly string[]>>;
+
+/** Widget GType -> every declaration its members come from, self first. */
+export const DECLS: Readonly<Record<string, readonly string[]>>;
+
+/** Enum GType -> the nicks this surface offers. */
+export const ENUM_NICKS: Readonly<Record<string, readonly string[]>>;
+
+/** Widget GType -> slot name -> the method that may adopt a child there. */
+export const SLOT_CANDIDATES: Readonly<Record<string, Readonly<Record<string, string>>>>;
+
+/**
+ * \`Type.property\` -> the release that introduced it.
+ *
+ * What keeps a runtime cross-check honest across a version gap without an
+ * allowlist: a member the installed library lacks is a defect UNLESS the version
+ * here is newer than the one running.
+ */
+export const SINCE: Readonly<Record<string, string>>;
+`;
+}

--- a/packages/generator-typescript/src/surface/index.ts
+++ b/packages/generator-typescript/src/surface/index.ts
@@ -1,0 +1,3 @@
+export * from "./emit-data.ts";
+export * from "./emit-types.ts";
+export * from "./model.ts";

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -1,0 +1,669 @@
+/**
+ * Build the GIR-derived widget VOCABULARY for one namespace.
+ *
+ * What this is for, in one line: a renderer that builds GTK trees needs to know,
+ * per widget, which properties are settable, which of them can only be set at
+ * construction, what strings an enum property accepts, and which methods might
+ * adopt a child. None of that is about any particular UI framework, and all of it
+ * is in the GIR — so it belongs here, next to the types, and not in each renderer.
+ *
+ * WHY NOT `X.ConstructorProps`, which already exists. It is the wrong shape on
+ * three axes and the first is a correctness bug:
+ *
+ *  - It offers READ-ONLY properties as settable. Measured on Gtk-4.0: 150 read-only
+ *    property declarations across 68 classes, all present in `ConstructorProps` —
+ *    `Gtk.Widget` alone contributes `has_default`, `has_focus`, `parent`, `root`
+ *    and `scale_factor`. GTK's failure mode for writing one is exit 0: no throw, no
+ *    warning, the value silently discarded.
+ *  - Its members are REQUIRED, so every consumer wraps it in `Partial<>`.
+ *  - It spells snake_case and camelCase and never the name GObject actually
+ *    registered. `g_object_set(o, "top-bar-style", …)`, GtkBuilder XML and
+ *    Blueprint all want the dashed spelling, and nothing in `@girs/*` had it.
+ *
+ * WHAT IS DELIBERATELY NOT HERE: tag spellings, `on<Signal>` handler prop names,
+ * `JSX.IntrinsicElements`, a Vue `GlobalComponents` interface, camelCase property
+ * keys. Each of those is a DIALECT — every framework answers it differently, and a
+ * JSX namespace in particular is a GLOBAL declaration, so two consumers declaring
+ * one is a merge rather than two dialects. The vocabulary ships; the dialect stays
+ * with the consumer.
+ *
+ * Signal handler types are not re-derived either: `X.SignalSignatures` is already
+ * emitted for every class, inheriting the parent chain and every implemented
+ * interface with `notify::<prop>` keys included, so the widget map POINTS AT it.
+ */
+
+import {
+  ArrayType,
+  type GirModule,
+  IntrospectedClass,
+  IntrospectedEnum,
+  IntrospectedInterface,
+  type IntrospectedBaseClass,
+  type IntrospectedProperty,
+  NativeType,
+  NullType,
+  type OptionsGeneration,
+  OrType,
+  TypeIdentifier,
+  type TypeExpression,
+} from "@ts-for-gir/lib";
+
+/** The GType every widget descends from. Matched by GType, so Gtk-3.0 qualifies too. */
+const WIDGET_ROOT_GTYPE = "GtkWidget";
+
+/** Thrown with the offending member named — never swallowed into a fallback type. */
+export class SurfaceError extends Error {}
+
+export interface SurfaceProp {
+  /** The name GObject registered — `icon-name`, dashed. */
+  readonly girName: string;
+  readonly ts: string;
+  readonly constructOnly: boolean;
+  readonly since?: string;
+  readonly doc?: string;
+  readonly deprecated: boolean;
+}
+
+export interface SurfaceDecl {
+  /** `Gtk.Box` — the key the graph is walked on, the way GIR references. */
+  readonly key: string;
+  readonly namespace: string;
+  readonly local: string;
+  readonly gtype: string;
+  /** This surface emits the interface — its own declaration, or an inlined foreign one. */
+  readonly emitted: boolean;
+  /**
+   * Emitted here despite belonging to another namespace, because that namespace has no
+   * surface of its own to import it from. See {@link buildWidgetSurface}.
+   */
+  readonly inlined: boolean;
+  readonly bases: readonly string[];
+  readonly props: readonly SurfaceProp[];
+  readonly doc?: string;
+}
+
+export interface SurfaceWidget {
+  readonly key: string;
+  readonly namespace: string;
+  readonly local: string;
+  readonly gtype: string;
+  /** Slot name -> the method that might adopt a child there. Candidates only. */
+  readonly slotCandidates: ReadonlyMap<string, string>;
+  /** Every declaration this widget draws members from, self first, by GType. */
+  readonly chain: readonly string[];
+  /** Own signals, for the runtime data module. */
+  readonly signals: readonly string[];
+}
+
+export interface SurfaceEnum {
+  readonly gtype: string;
+  /** `Gtk.Orientation` as the surface spells it. */
+  readonly reference: string;
+  readonly nicks: readonly string[];
+}
+
+export interface WidgetSurface {
+  readonly namespace: string;
+  readonly version: string;
+  readonly importName: string;
+  readonly provenance: string;
+  readonly widgets: readonly SurfaceWidget[];
+  /** Key -> declaration, own and foreign, in emit order. */
+  readonly declarations: ReadonlyMap<string, SurfaceDecl>;
+  /** Nick unions this surface must emit itself, by enum GType. */
+  readonly enums: ReadonlyMap<string, SurfaceEnum>;
+  /** GIR namespace -> the import this surface needs for its VALUE types. */
+  readonly namespaceImports: ReadonlyMap<string, string>;
+  /** `@girs/<pkg>/surface` -> the names imported from another namespace's surface. */
+  readonly surfaceImports: ReadonlyMap<string, readonly string[]>;
+  /** Base -> members it must not contribute, because a nearer declaration disagrees. */
+  readonly omissions: ReadonlyMap<string, ReadonlyMap<string, readonly string[]>>;
+  /** Declaration GType -> its own properties' since versions, for the skew rule. */
+  readonly since: ReadonlyMap<string, string>;
+}
+
+export const propsInterfaceOf = (gtype: string): string => `${gtype}Props`;
+export const constructOnlyAliasOf = (gtype: string): string => `${gtype}ConstructOnly`;
+export const nickAliasOf = (gtype: string): string => `${gtype}Nick`;
+
+const isClassLike = (member: unknown): member is IntrospectedBaseClass =>
+  member instanceof IntrospectedClass || member instanceof IntrospectedInterface;
+
+/** Every class and interface the module declares, deterministically ordered. */
+function classLikeMembers(module: GirModule): IntrospectedBaseClass[] {
+  const out: IntrospectedBaseClass[] = [];
+  for (const member of module.members.values()) {
+    const candidates = Array.isArray(member) ? member : [member];
+    for (const candidate of candidates) if (isClassLike(candidate)) out.push(candidate);
+  }
+  return out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+/**
+ * Resolve one type identifier to the class or interface it names, or null.
+ *
+ * Deliberately NOT `resolveParents()`: its `implements()` THROWS on an interface it
+ * cannot resolve, which would take down a whole 705-namespace run for one namespace
+ * with a missing dependency. Here an unresolvable base is a base that contributes
+ * nothing, and the gate below reports it if it would have contributed a property.
+ */
+function resolveClassLike(module: GirModule, id: TypeIdentifier): IntrospectedBaseClass | null {
+  const target = module.getInstalledImport(id.namespace);
+  if (!target) return null;
+  const found = target.getClass(id.name);
+  return found && isClassLike(found) ? found : null;
+}
+
+const keyOf = (cls: IntrospectedBaseClass): string => `${cls.namespace.namespace}.${cls.name}`;
+
+function ancestorsOf(module: GirModule, cls: IntrospectedBaseClass): IntrospectedBaseClass[] {
+  const out: IntrospectedBaseClass[] = [];
+  const seen = new Set<string>([keyOf(cls)]);
+  let current = cls;
+  while (current.superType) {
+    const parent = resolveClassLike(module, current.superType);
+    if (!parent) break;
+    const key = keyOf(parent);
+    if (seen.has(key)) break;
+    seen.add(key);
+    out.push(parent);
+    current = parent;
+  }
+  return out;
+}
+
+const implementedBy = (cls: IntrospectedBaseClass): readonly TypeIdentifier[] =>
+  cls instanceof IntrospectedClass || cls instanceof IntrospectedInterface ? cls.interfaces : [];
+
+/**
+ * Self, then the parent chain, then every interface reached from either.
+ *
+ * The interfaces are not optional. `GtkBox` declares four properties of its own and
+ * `orientation` is not among them — it lives on `Gtk.Orientable`, an `<implements>`
+ * of GtkBox, because GObject installs interface properties on the implementor at
+ * runtime while GIR keeps them once, on the interface. A class-only walk emits a
+ * vocabulary in which the most-written GtkBox property does not exist.
+ */
+function declarationChain(module: GirModule, cls: IntrospectedBaseClass): IntrospectedBaseClass[] {
+  const out: IntrospectedBaseClass[] = [];
+  const seen = new Set<string>();
+  const push = (candidate: IntrospectedBaseClass) => {
+    const key = keyOf(candidate);
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(candidate);
+  };
+  push(cls);
+  for (const ancestor of ancestorsOf(module, cls)) push(ancestor);
+  for (let i = 0; i < out.length; i++) {
+    for (const id of implementedBy(out[i]!)) {
+      const resolved = resolveClassLike(module, id);
+      if (resolved) push(resolved);
+    }
+  }
+  return out;
+}
+
+const isWidgetClass = (module: GirModule, cls: IntrospectedBaseClass): boolean =>
+  cls.glibTypeName === WIDGET_ROOT_GTYPE ||
+  ancestorsOf(module, cls).some((a) => a.glibTypeName === WIDGET_ROOT_GTYPE);
+
+/** The concrete widgets of one namespace — the set a renderer can actually create. */
+function concreteWidgetsOf(module: GirModule): IntrospectedClass[] {
+  return classLikeMembers(module).filter(
+    (cls): cls is IntrospectedClass =>
+      cls instanceof IntrospectedClass &&
+      !cls.isAbstract &&
+      cls.isIntrospectable &&
+      typeof cls.glibTypeName === "string" &&
+      isWidgetClass(module, cls),
+  );
+}
+
+/**
+ * Does this namespace get a `./surface` at all?
+ *
+ * Only namespaces that DECLARE widgets, not the 700-odd that merely appear in a
+ * widget's property types. Answered per namespace and cached, because a widget's
+ * base chain asks it once per foreign declaration.
+ */
+const qualifies = new WeakMap<GirModule, boolean>();
+export function declaresWidgets(module: GirModule): boolean {
+  const cached = qualifies.get(module);
+  if (cached !== undefined) return cached;
+  // Set before recursing: `isWidgetClass` walks parents, which can re-enter here
+  // through a namespace that depends on this one.
+  qualifies.set(module, false);
+  const answer = concreteWidgetsOf(module).length > 0;
+  qualifies.set(module, answer);
+  return answer;
+}
+
+interface PrintedType {
+  readonly text: string;
+  /** GIR namespaces whose value import the text needs. */
+  readonly namespaces: readonly string[];
+  /** Enums whose nick alias the text references. */
+  readonly enums: readonly SurfaceEnum[];
+}
+
+/**
+ * Print one property type, fully qualified, with enum nicks widened in.
+ *
+ * A separate printer rather than `TypeExpression.print()` for two reasons. The
+ * built-in printer omits the namespace prefix for the CURRENT namespace, because it
+ * emits inside `export namespace Gtk { … }` — this surface is a sibling module, so
+ * every reference must be qualified or it does not resolve. And an enum property
+ * has to accept the NICK as well as the constant, which no general-purpose printer
+ * would do.
+ *
+ * The identifiers themselves still come from the model's own resolution, so a name
+ * this surface references is a name the main emitter emitted.
+ */
+function printPropType(
+  module: GirModule,
+  config: OptionsGeneration,
+  type: TypeExpression,
+  where: string,
+): PrintedType {
+  const namespaces = new Set<string>();
+  const enums = new Map<string, SurfaceEnum>();
+
+  const walk = (node: TypeExpression, depth: number): string => {
+    if (depth > 8) throw new SurfaceError(`${where}: type nests deeper than 8 levels`);
+    if (node instanceof ArrayType) {
+      const inner = walk(node.type, depth + 1);
+      const element = /[|&]/.test(inner) ? `(${inner})` : inner;
+      return `${element}${"[]".repeat(Math.max(node.arrayDepth, 1))}`;
+    }
+    if (node instanceof OrType) {
+      const parts = node.types.map((t) => walk(t, depth + 1));
+      // `null` last, so `Gdk.Cursor | null` reads the way a human writes it.
+      const ordered = [...parts.filter((p) => p !== "null"), ...parts.filter((p) => p === "null")];
+      return [...new Set(ordered)].join(" | ");
+    }
+    if (node instanceof TypeIdentifier) {
+      const resolved = node.resolveIdentifier(module, config);
+      if (!resolved) throw new SurfaceError(`${where}: cannot resolve ${node.namespace}.${node.name}`);
+      const owner = module.getInstalledImport(resolved.namespace);
+      if (!owner) throw new SurfaceError(`${where}: namespace ${resolved.namespace} is not installed`);
+      const enumeration = owner.getEnum(resolved.name);
+      if (enumeration) {
+        // Flags stay `number` in both positions, mirroring the runtime: GObject
+        // exposes no way to resolve a nick SET ("horizontal|vertical"), so a union
+        // of nicks would type something every host has to reject.
+        if (enumeration.flags) return "number";
+        const gtype = enumeration.glibTypeName;
+        // An unregistered enum has no GType, therefore no nicks GObject knows,
+        // therefore nothing a string could be checked against.
+        if (!gtype) return `${resolved.namespace}.${resolved.name}`;
+        namespaces.add(resolved.namespace);
+        const reference = `${resolved.namespace}.${resolved.name}`;
+        const nicks = [...enumeration.members.values()].map((m) => m.nick);
+        enums.set(gtype, { gtype, reference, nicks });
+        return `${nickAliasOf(gtype)} | ${reference}`;
+      }
+      namespaces.add(resolved.namespace);
+      return `${resolved.namespace}.${resolved.name}`;
+    }
+    if (node instanceof NativeType) {
+      if (node === NullType) return "null";
+      return node.print(module, config);
+    }
+    throw new SurfaceError(`${where}: unsupported type expression ${node.constructor.name}`);
+  };
+
+  return { text: walk(type, 0), namespaces: [...namespaces], enums: [...enums.values()] };
+}
+
+/** First sentence, one line, `*​/`-safe — a hover blurb, not the manual. */
+function blurb(doc: string | null | undefined, limit = 200): string | undefined {
+  if (!doc) return undefined;
+  const flat = doc.replace(/\s+/g, " ").trim();
+  if (flat === "") return undefined;
+  const stop = flat.search(/\.\s|\.$/);
+  const text = stop > 0 ? flat.slice(0, stop + 1) : flat;
+  const cut = text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+  return cut.replace(/\*\//g, "*​/");
+}
+
+/**
+ * The settable properties of one declaration, deduplicated by registered name.
+ *
+ * `propertyCase: "both"` puts every property in `props` TWICE — once underscored
+ * and once camelCased — and neither spelling is the one GObject registered. The
+ * dashed `girName` is carried on both copies, so it is both the emitted key and the
+ * key that pairs them back up.
+ */
+function ownProps(
+  module: GirModule,
+  config: OptionsGeneration,
+  cls: IntrospectedBaseClass,
+  collect: (printed: PrintedType) => void,
+): SurfaceProp[] {
+  const byName = new Map<string, SurfaceProp>();
+  for (const prop of cls.props as IntrospectedProperty[]) {
+    // WRITABLE ONLY — the axis `ConstructorProps` gets wrong. GObject spells
+    // CONSTRUCT_ONLY out as `writable` too, so `writable` alone is the settable set.
+    if (!prop.writable) continue;
+    const girName = prop.girName;
+    if (!girName) continue;
+    if (byName.has(girName)) continue;
+    const printed = printPropType(module, config, prop.type, `${keyOf(cls)}.${girName}`);
+    collect(printed);
+    byName.set(girName, {
+      girName,
+      ts: printed.text,
+      constructOnly: prop.constructOnly,
+      since: prop.metadata?.introducedVersion,
+      doc: blurb(prop.doc),
+      deprecated: prop.deprecated === true,
+    });
+  }
+  return [...byName.values()].sort((a, b) => (a.girName < b.girName ? -1 : 1));
+}
+
+/**
+ * A method taking exactly one widget argument names a CANDIDATE slot.
+ *
+ * `pack_start` -> start, `set_title_widget` -> title, `add_top_bar` -> top. It is a
+ * candidate list and never an answer: the GIR cannot tell adoption from reference.
+ * `Adw.HeaderBar.set_title_widget` parents its argument and
+ * `Adw.ActionRow.set_activatable_widget` does not, and both are `void f(GtkWidget*)`
+ * at `transfer-ownership="none"` — nothing in the GIR separates them. Which
+ * candidate is a real slot is runtime behaviour, so it stays curated in the consumer;
+ * this list is what makes a GTK release that adds one show up as a diff.
+ */
+function slotNameOf(method: string): string | null {
+  for (const pattern of [/^pack_(\w+)$/, /^set_(\w+?)(?:_widget)?$/, /^add_(\w+?)(?:_bar)?$/]) {
+    const match = pattern.exec(method);
+    if (match) return match[1]!.replace(/_/g, "-");
+  }
+  return null;
+}
+
+function slotCandidatesOf(module: GirModule, config: OptionsGeneration, cls: IntrospectedClass): Map<string, string> {
+  const out = new Map<string, string>();
+  const methods = [...cls.members].sort((a, b) => (a.name < b.name ? -1 : 1));
+  for (const method of methods) {
+    const slot = slotNameOf(method.name);
+    if (!slot) continue;
+    const params = method.parameters.filter((p) => p.direction === "in");
+    if (params.length !== 1) continue;
+    const type = params[0]!.type.unwrap();
+    if (!(type instanceof TypeIdentifier)) continue;
+    const resolved = type.resolveIdentifier(module, config);
+    if (!resolved) continue;
+    const owner = module.getInstalledImport(resolved.namespace);
+    const target = owner?.getClass(resolved.name);
+    if (!target || !isClassLike(target) || !isWidgetClass(module, target)) continue;
+    // First wins in sorted method order: two methods can derive the same slot name
+    // (`set_child` and `add_child` both yield `child`) and a duplicate key in an
+    // emitted type literal is TS1117 rather than a warning.
+    if (!out.has(slot)) out.set(slot, method.name);
+  }
+  return out;
+}
+
+/**
+ * Which member each base must be stripped of.
+ *
+ * Two conflicts, one repair. TypeScript requires a multiply inherited member to be
+ * IDENTICAL in every base — `string` and `string | null` are not — and GTK's interfaces
+ * do redeclare class properties. It also requires a declaration's OWN member to be
+ * assignable to the base's, which `GimpDialog` breaks: it redeclares `parent` as
+ * `Gtk.Widget` where GTK 3's writable `GtkWidget:parent` is a `Gtk.Container` (TS2430,
+ * "Type 'Widget' is missing 39 properties from type 'Container'"). Neither is repaired by
+ * declaring the member locally — that turns one error into another — so the only repair is
+ * to stop the base from contributing it.
+ *
+ * This is why props are computed for FOREIGN declarations too, even though their
+ * interfaces are emitted by their owner: without their members here the analysis cannot
+ * see a conflict with an imported base, and `GimpDialogProps extends GtkDialogProps` was
+ * emitted with no `Omit` at all. The printed text is comparable across surfaces because
+ * this printer always fully qualifies, so a foreign member renders identically to the way
+ * its owner rendered it.
+ */
+function computeOmissions(decls: ReadonlyMap<string, SurfaceDecl>): Map<string, Map<string, string[]>> {
+  const resolved = new Map<string, Map<string, string>>();
+  const resolving = new Set<string>();
+
+  const membersOf = (key: string): Map<string, string> => {
+    const cached = resolved.get(key);
+    if (cached) return cached;
+    const decl = decls.get(key);
+    if (!decl || resolving.has(key)) return new Map();
+    resolving.add(key);
+    const members = new Map<string, string>();
+    for (const prop of decl.props) members.set(prop.girName, prop.ts);
+    for (const base of decl.bases) {
+      for (const [name, ts] of membersOf(base)) if (!members.has(name)) members.set(name, ts);
+    }
+    resolving.delete(key);
+    resolved.set(key, members);
+    return members;
+  };
+
+  const out = new Map<string, Map<string, string[]>>();
+  for (const [key, decl] of decls) {
+    const claimed = new Map<string, string>();
+    for (const prop of decl.props) claimed.set(prop.girName, prop.ts);
+    const perBase = new Map<string, string[]>();
+    for (const base of decl.bases) {
+      const drop: string[] = [];
+      for (const [name, ts] of membersOf(base)) {
+        const held = claimed.get(name);
+        if (held === undefined) claimed.set(name, ts);
+        else if (held !== ts) drop.push(name);
+      }
+      if (drop.length > 0) perBase.set(base, drop.sort());
+    }
+    if (perBase.size > 0) out.set(key, perBase);
+  }
+  return out;
+}
+
+/**
+ * Build the surface for one namespace, or null if it declares no widgets.
+ *
+ * Cross-namespace bases are IMPORTED, not copied: `AdwToolbarViewProps extends
+ * GtkWidgetProps` reads `GtkWidgetProps` from `@girs/gtk-4.0/surface`. Inlining
+ * them wholesale would put a second, nominally distinct `GtkWidgetProps` in every
+ * widget namespace — a copy per namespace of the same interface, and confusing errors
+ * the first time a consumer mixes two of them.
+ *
+ * A base whose namespace declares NO widgets has no surface to import from, and the
+ * answer depends on whether it carries anything:
+ *
+ *  - nothing settable — DROPPED. There is no vocabulary to lose, and inlining an empty
+ *    interface into every widget namespace buys a name and no members.
+ *  - settable properties — INLINED here, because dropping it would silently shrink the
+ *    vocabulary by properties nobody would notice were missing.
+ *
+ * Both halves are measured over the 475 namespaces in `girs/`, of which 102 declare
+ * widgets. The drop case is ordinary: Gtk-4.0 and Adw-1 each reach exactly four such
+ * declarations (`GObject.Object`, `GObject.InitiallyUnowned`, `Gio.ActionGroup`,
+ * `Gio.ActionMap`), all empty. The inline case happens EXACTLY ONCE in the whole
+ * corpus — `Gcr.Prompt`, a GObject interface with ten writable properties, in a
+ * namespace whose widgets live in a different one — and it is the reason the rule is not
+ * simply "drop it": the first version of this generator refused the input outright and
+ * took the 705-namespace run down with it. One counterexample is a bounded bill, not an
+ * argument for a surface per namespace: `@girs/gcr-3/surface` would be a widget surface
+ * with no widgets in it.
+ */
+export function buildWidgetSurface(module: GirModule, config: OptionsGeneration): WidgetSurface | null {
+  const widgetClasses = concreteWidgetsOf(module);
+  if (widgetClasses.length === 0) return null;
+
+  const namespaceImports = new Map<string, string>();
+  const enums = new Map<string, SurfaceEnum>();
+  const surfaceImports = new Map<string, Set<string>>();
+  const importFromSurface = (owner: GirModule, name: string) => {
+    const subpath = `${owner.importPath}/surface`;
+    const names = surfaceImports.get(subpath) ?? new Set<string>();
+    names.add(name);
+    surfaceImports.set(subpath, names);
+  };
+  const collect = (printed: PrintedType) => {
+    for (const ns of printed.namespaces) {
+      const owner = module.getInstalledImport(ns);
+      if (!owner) throw new SurfaceError(`namespace ${ns} is referenced but not installed`);
+      namespaceImports.set(ns, owner.importPath);
+    }
+    for (const enumeration of printed.enums) {
+      const owner = module.getInstalledImport(enumeration.reference.slice(0, enumeration.reference.indexOf(".")));
+      // A nick union is emitted ONCE, by the surface that owns the enum, and imported
+      // from there — `AdwHeaderBarProps` reads `GtkPackTypeNick` out of
+      // `@girs/gtk-4.0/surface`. Enums from namespaces with no widgets (Pango, Gdk)
+      // have no surface to live in, so each consumer emits its own alias for those.
+      // Skipping the emission without adding the IMPORT is the shape the per-package
+      // `tsc --project` caught first: 9 × TS2304 in Adw-1, naming 6 Gtk enums.
+      if (owner && owner !== module && declaresWidgets(owner)) {
+        importFromSurface(owner, nickAliasOf(enumeration.gtype));
+        continue;
+      }
+      enums.set(enumeration.gtype, enumeration);
+    }
+  };
+
+  const needed = new Map<string, IntrospectedBaseClass>();
+  const chains = new Map<string, IntrospectedBaseClass[]>();
+  for (const widget of widgetClasses) {
+    const chain = declarationChain(module, widget);
+    chains.set(keyOf(widget), chain);
+    for (const decl of chain) needed.set(keyOf(decl), decl);
+  }
+
+  const dropped: string[] = [];
+  const inlined: string[] = [];
+  const declarations = new Map<string, SurfaceDecl>();
+
+  for (const [key, cls] of needed) {
+    const gtype = cls.glibTypeName;
+    // A declaration GIR gives no GType is not a GObject type: it cannot be keyed,
+    // looked up in the typelib, or named in GtkBuilder XML.
+    if (!gtype) {
+      if ((cls.props as IntrospectedProperty[]).some((p) => p.writable)) {
+        throw new SurfaceError(`${key} has writable properties but no glib:type-name`);
+      }
+      dropped.push(key);
+      continue;
+    }
+    const owner = cls.namespace as GirModule;
+    const own = owner.namespace === module.namespace;
+    const foreignWithoutSurface = !own && !declaresWidgets(owner);
+    if (foreignWithoutSurface && !(cls.props as IntrospectedProperty[]).some((p) => p.writable)) {
+      dropped.push(key);
+      continue;
+    }
+    const emitted = own || foreignWithoutSurface;
+    if (!emitted) {
+      importFromSurface(owner, propsInterfaceOf(gtype));
+      importFromSurface(owner, constructOnlyAliasOf(gtype));
+    }
+    if (foreignWithoutSurface) inlined.push(key);
+    declarations.set(key, {
+      key,
+      namespace: owner.namespace,
+      local: cls.name,
+      gtype,
+      emitted,
+      inlined: foreignWithoutSurface,
+      bases: [],
+      // A foreign declaration's members are computed but its IMPORTS are not collected:
+      // the interface is emitted by its owner, so a `Pango` reference inside it is the
+      // owner's import to make, and adding it here would leave `noUnusedLocals` staring at
+      // an import nothing in this file reads.
+      props: ownProps(module, config, cls, emitted ? collect : () => {}),
+      doc: emitted ? blurb(cls.doc) : undefined,
+    });
+  }
+
+  // Bases second, so a base dropped above is dropped from every `extends` too.
+  const withBases = new Map<string, SurfaceDecl>();
+  for (const [key, decl] of declarations) {
+    const cls = needed.get(key)!;
+    const bases: string[] = [];
+    if (cls.superType) {
+      const parent = resolveClassLike(module, cls.superType);
+      if (parent && declarations.has(keyOf(parent))) bases.push(keyOf(parent));
+    }
+    for (const id of implementedBy(cls)) {
+      const iface = resolveClassLike(module, id);
+      if (iface && declarations.has(keyOf(iface))) bases.push(keyOf(iface));
+    }
+    withBases.set(key, { ...decl, bases });
+  }
+
+  const widgets: SurfaceWidget[] = widgetClasses
+    .filter((widget) => withBases.has(keyOf(widget)))
+    .map((widget) => ({
+      key: keyOf(widget),
+      namespace: widget.namespace.namespace,
+      local: widget.name,
+      gtype: widget.glibTypeName!,
+      slotCandidates: slotCandidatesOf(module, config, widget),
+      chain: (chains.get(keyOf(widget)) ?? [])
+        .filter((decl) => withBases.has(keyOf(decl)))
+        .map((decl) => decl.glibTypeName!),
+      signals: [...widget.signals].map((signal) => signal.name).sort(),
+    }))
+    .sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
+
+  for (const widget of widgets) {
+    const owner = module.getInstalledImport(widget.namespace);
+    if (owner) namespaceImports.set(widget.namespace, owner.importPath);
+  }
+
+  // EVERY registered enum this namespace declares gets a nick union, not only the ones
+  // its own widget properties happen to reference.
+  //
+  // The alternative — emit what you reference — is what shipped first, and the
+  // per-package `tsc --project` failed it: `GtkSourceView.text-window-type` reaches
+  // `Gtk.TextWindowType`, no Gtk-4.0 widget property does, so `@girs/gtk-4.0/surface` had
+  // no `GtkTextWindowTypeNick` for `@girs/gtksource-5/surface` to import (TS2305, plus the
+  // same shape for `GtkPackTypeNick` in Handy-1 against Gtk-3.0). The nick vocabulary of a
+  // namespace is a property of the NAMESPACE, not of which of its own properties use it —
+  // and emitting all of them also makes `ENUM_NICKS` a complete answer for a consumer
+  // checking nicks against the installed library.
+  for (const member of module.members.values()) {
+    for (const candidate of Array.isArray(member) ? member : [member]) {
+      if (!(candidate instanceof IntrospectedEnum)) continue;
+      // Flags stay `number` everywhere, so a nick union for one would type something
+      // every host has to reject; an unregistered enum has no nicks GObject knows.
+      if (candidate.flags || !candidate.glibTypeName) continue;
+      enums.set(candidate.glibTypeName, {
+        gtype: candidate.glibTypeName,
+        reference: `${module.namespace}.${candidate.name}`,
+        nicks: [...candidate.members.values()].map((m) => m.nick),
+      });
+    }
+  }
+
+  const since = new Map<string, string>();
+  for (const decl of withBases.values()) {
+    if (!decl.emitted) continue;
+    for (const prop of decl.props) if (prop.since) since.set(`${decl.gtype}.${prop.girName}`, prop.since);
+  }
+
+  const provenanceParts = [`${module.packageName}`];
+  if (module.libraryVersion?.declaredByLibrary) provenanceParts.push(`library ${module.libraryVersion}`);
+  // Named, not counted: both lists are how a GTK or dependency release that changes the
+  // shape of the base graph shows up in a diff rather than in a support question.
+  if (dropped.length > 0) provenanceParts.push(`dropped empty base(s): ${dropped.join(" ")}`);
+  if (inlined.length > 0) provenanceParts.push(`inlined base(s) from a namespace with no surface: ${inlined.join(" ")}`);
+
+  return {
+    namespace: module.namespace,
+    version: module.version,
+    importName: module.importName,
+    provenance: provenanceParts.join(" — "),
+    widgets,
+    declarations: withBases,
+    enums,
+    namespaceImports,
+    surfaceImports: new Map([...surfaceImports].map(([k, v]) => [k, [...v].sort()])),
+    omissions: computeOmissions(withBases),
+    since,
+  };
+}

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -54,6 +54,26 @@ const WIDGET_ROOT_GTYPE = "GtkWidget";
 /** Thrown with the offending member named — never swallowed into a fallback type. */
 export class SurfaceError extends Error {}
 
+/**
+ * A property whose printed type accepts no value at all.
+ *
+ * There are two ways a property can end up unusable, and only one of them is a
+ * generator defect. An UNRESOLVABLE identifier is: the model has no such type, so the
+ * surface would reference a name the main emitter never emitted, and
+ * {@link printPropType} throws. A RESOLVABLE type TypeScript cannot express is not:
+ * `GcrTreeSelector:columns` is a writable `gpointer` and `GimpDialog:help-func` is a C
+ * callback, and the model prints both as `never` on purpose — a caller cannot pass one
+ * from GJS either.
+ *
+ * So `never` stays in the interface rather than being dropped (dropping shrinks the
+ * vocabulary by a property nobody would notice was missing, and the name is still a
+ * real writable ParamSpec a consumer's runtime check must find in `OWN_PROPS`), and
+ * every occurrence is NAMED in the provenance line. Measured across Gtk-4.0, Gtk-3.0,
+ * Adw-1, GimpUi-3.0 and GcrUi-3: two, both above. Naming them is what makes a third
+ * one a diff instead of a property that silently stopped accepting values.
+ */
+const acceptsNothing = (ts: string): boolean => /\bnever\b/.test(ts);
+
 export interface SurfaceProp {
   /** The name GObject registered — `icon-name`, dashed. */
   readonly girName: string;
@@ -652,6 +672,13 @@ export function buildWidgetSurface(module: GirModule, config: OptionsGeneration)
   // shape of the base graph shows up in a diff rather than in a support question.
   if (dropped.length > 0) provenanceParts.push(`dropped empty base(s): ${dropped.join(" ")}`);
   if (inlined.length > 0) provenanceParts.push(`inlined base(s) from a namespace with no surface: ${inlined.join(" ")}`);
+  const unsettable = [...withBases.values()]
+    .filter((decl) => decl.emitted)
+    .flatMap((decl) => decl.props.filter((prop) => acceptsNothing(prop.ts)).map((prop) => `${decl.key}.${prop.girName}`))
+    .sort();
+  if (unsettable.length > 0) {
+    provenanceParts.push(`prop(s) no TypeScript value satisfies: ${unsettable.join(" ")}`);
+  }
 
   return {
     namespace: module.namespace,

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -70,13 +70,18 @@ export class SurfaceError extends Error {}
  * real writable ParamSpec a consumer's runtime check must find in `OWN_PROPS`), and
  * every occurrence is NAMED in the provenance line.
  *
- * No corpus-wide count is written down here, deliberately. Fourteen widget namespaces
- * were measured and four turned up — a writable `gpointer` in `GcrTreeSelector:columns`,
- * `Gtk.Object:user-data` and `Gtk.Notebook:group`, a C callback in
- * `GimpDialog:help-func` — and the first five namespaces looked at had said "two", which
- * is how a number in a comment becomes wrong. Each surface names its OWN, which is the
- * answer that cannot go stale, and is what makes the next one a diff instead of a
- * property that silently stopped accepting values.
+ * No count is written down here, deliberately. The first pass measured five namespaces
+ * and said "two"; widening to fourteen said four; widening to forty-four found more than
+ * twenty, eleven of them on `AgsGui.Cartesian` alone — a widget that loses most of its
+ * settable properties and, before the provenance line existed, said nothing about it.
+ * Any number here is a number that is already wrong.
+ *
+ * The RULE does not drift, and it is the useful half: every case measured is a writable
+ * `gpointer` — `GcrTreeSelector:columns`, `Gtk.Object:user-data`, `Gtk.Notebook:group`,
+ * `Wnck.ActionMenu:window`, `Phosh.LayerSurface:wl-output` — plus one C callback,
+ * `GimpDialog:help-func`. Nothing EXPRESSIBLE is being flattened. Each surface names its
+ * own in its own provenance line, which is the answer that cannot go stale, and is what
+ * makes the next one a diff instead of a property that silently stopped taking values.
  */
 const acceptsNothing = (ts: string): boolean => /\bnever\b/.test(ts);
 

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -68,9 +68,15 @@ export class SurfaceError extends Error {}
  * So `never` stays in the interface rather than being dropped (dropping shrinks the
  * vocabulary by a property nobody would notice was missing, and the name is still a
  * real writable ParamSpec a consumer's runtime check must find in `OWN_PROPS`), and
- * every occurrence is NAMED in the provenance line. Measured across Gtk-4.0, Gtk-3.0,
- * Adw-1, GimpUi-3.0 and GcrUi-3: two, both above. Naming them is what makes a third
- * one a diff instead of a property that silently stopped accepting values.
+ * every occurrence is NAMED in the provenance line.
+ *
+ * No corpus-wide count is written down here, deliberately. Fourteen widget namespaces
+ * were measured and four turned up — a writable `gpointer` in `GcrTreeSelector:columns`,
+ * `Gtk.Object:user-data` and `Gtk.Notebook:group`, a C callback in
+ * `GimpDialog:help-func` — and the first five namespaces looked at had said "two", which
+ * is how a number in a comment becomes wrong. Each surface names its OWN, which is the
+ * answer that cannot go stale, and is what makes the next one a diff instead of a
+ * property that silently stopped accepting values.
  */
 const acceptsNothing = (ts: string): boolean => /\bnever\b/.test(ts);
 

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -164,8 +164,17 @@ function classLikeMembers(module: GirModule): IntrospectedBaseClass[] {
  *
  * Deliberately NOT `resolveParents()`: its `implements()` THROWS on an interface it
  * cannot resolve, which would take down a whole 705-namespace run for one namespace
- * with a missing dependency. Here an unresolvable base is a base that contributes
- * nothing, and the gate below reports it if it would have contributed a property.
+ * with a missing dependency.
+ *
+ * The trade is real and stated rather than papered over: an unresolvable base is simply
+ * absent from the chain, so the widget loses whatever it declared and NOTHING here says
+ * so — and if the root `GtkWidget` itself were the unresolvable one, the namespace would
+ * emit no surface at all, silently. What bounds it is a measurement, not a guard: over
+ * Gtk-4.0, Gtk-3.0, Adw-1, GtkSource-5, WebKit-6.0, Handy-1, Shumate-1.0, GimpUi-3.0 and
+ * GcrUi-3 — every widget chain in them — the count of unresolvable supers and interfaces
+ * is ZERO, and every one of those namespaces emits its surface. A guard for a case with
+ * no instance is a cost with no finding; the backstop is the committed `types-*` diff,
+ * where a surface that stopped being emitted is a deleted file.
  */
 function resolveClassLike(module: GirModule, id: TypeIdentifier): IntrospectedBaseClass | null {
   const target = module.getInstalledImport(id.namespace);

--- a/packages/lib/src/gir-module.ts
+++ b/packages/lib/src/gir-module.ts
@@ -127,6 +127,18 @@ export class GirModule implements IGirModule {
 	extends?: string;
 
 	/**
+	 * Set by the generator once this namespace's `./surface` files exist.
+	 *
+	 * The package.json and tsconfig.json templates need to know whether the subpath
+	 * was actually emitted, and that is not the same question as the `widgetSurface`
+	 * config flag: with the flag on, the 700-odd namespaces that declare no
+	 * `GtkWidget` descendant still emit nothing. An `exports` entry pointing at a
+	 * file that was never written is a package that fails to resolve at install time,
+	 * which is the worst place to find out.
+	 */
+	hasWidgetSurface = false;
+
+	/**
 	 * To prevent constants from being exported twice, the names already exported are saved here for comparison.
 	 * Please note: Such a case is only known for Zeitgeist-2.0 with the constant "ATTACHMENT"
 	 */

--- a/packages/lib/src/gir/enum-member.ts
+++ b/packages/lib/src/gir/enum-member.ts
@@ -9,11 +9,30 @@ import { IntrospectedBase } from "./introspected-base.ts";
 export class GirEnumMember extends IntrospectedBase<IntrospectedEnum> {
 	value: string;
 	c_identifier: string;
+	/**
+	 * The nick GObject registered for this member — GIR's `glib:nick`.
+	 *
+	 * This is the string a `g_object_set()` on an enum property accepts, and the
+	 * only string form GTK will answer to; the C identifier is not. The parser has
+	 * modelled the attribute since the beginning and nothing read it, so every
+	 * consumer that needed a nick derived one from the member name instead.
+	 *
+	 * The derivation is right by luck rather than by construction: measured across
+	 * the 705 GIR files in `girs/`, 40 940 of 59 789 members carry `glib:nick` and
+	 * 889 of those do NOT equal `name.toLowerCase().replace(/_/g, "-")`. Gtk-4.0
+	 * and Adw-1 happen to be among the zero-disagreement namespaces (799 of 807 and
+	 * 120 of 120 carry the attribute, none contradicting), which is exactly how a
+	 * derived nick survives review and then breaks somewhere else. So the attribute
+	 * is the answer wherever it exists and the derivation is the fallback for the
+	 * members GIR leaves without one.
+	 */
+	nick: string;
 
-	constructor(name: string, value: string, parent: IntrospectedEnum, c_identifier: string) {
+	constructor(name: string, value: string, parent: IntrospectedEnum, c_identifier: string, nick: string) {
 		super(name, parent);
 		this.value = value;
 		this.c_identifier = c_identifier;
+		this.nick = nick;
 	}
 
 	get namespace() {
@@ -26,16 +45,19 @@ export class GirEnumMember extends IntrospectedBase<IntrospectedEnum> {
 	}
 
 	copy(): GirEnumMember {
-		const { value, name, parent, c_identifier } = this;
+		const { value, name, parent, c_identifier, nick } = this;
 
-		return new GirEnumMember(name, value, parent, c_identifier)._copyBaseProperties(this);
+		return new GirEnumMember(name, value, parent, c_identifier, nick)._copyBaseProperties(this);
 	}
 
 	static fromXML(element: GirMemberElement, parent: IntrospectedEnum, options: OptionsLoad): GirEnumMember {
 		const upper = element.$.name.toUpperCase();
 		const c_identifier = element.$["c:identifier"];
+		// The fallback reads the ORIGINAL member name, not `upper`: GIR writes
+		// `baseline_fill` and the nick GObject registered is `baseline-fill`.
+		const nick = element.$["glib:nick"] ?? element.$.name.toLowerCase().replace(/_/g, "-");
 
-		const enumMember = new GirEnumMember(upper, element.$.value, parent, c_identifier);
+		const enumMember = new GirEnumMember(upper, element.$.value, parent, c_identifier, nick);
 
 		if (options.loadDocs) {
 			enumMember.doc = parseDoc(element);

--- a/packages/lib/src/gir/enum.ts
+++ b/packages/lib/src/gir/enum.ts
@@ -96,6 +96,7 @@ export class IntrospectedEnum extends IntrospectedNamespaceMember {
 
 		if (element.$["glib:type-name"]) {
 			em.isRegistered = true;
+			em.glibTypeName = element.$["glib:type-name"];
 			em.resolve_names.push(element.$["glib:type-name"]);
 
 			ns.registerResolveName(element.$["glib:type-name"], ns.namespace, em.name);

--- a/packages/lib/src/gir/introspected-base.ts
+++ b/packages/lib/src/gir/introspected-base.ts
@@ -14,6 +14,18 @@ export abstract class IntrospectedBase<Parent extends IntrospectedNamespace | An
 	doc?: string | null;
 	metadata?: IntrospectedMetadata;
 	deprecated?: boolean;
+	/**
+	 * GIR's `glib:type-name` — the GType a class, interface, enum or bitfield
+	 * registers under (`GtkBox`, `GtkOrientation`).
+	 *
+	 * It is NOT derivable from {@link name}: the TS name is namespace-local and
+	 * sanitized, while the GType is the C prefix plus the type name and the two
+	 * disagree wherever a namespace's `c:prefix` is not its namespace (`Adw` vs
+	 * `AdwaitaFoo`, `WebKit` vs `WebKitWebView`). `resolve_names` already carried
+	 * it, mixed in with `c:type` and `glib:type-struct` and therefore unusable as
+	 * an answer to "which GType is this".
+	 */
+	glibTypeName?: string;
 	resolve_names: string[] = [];
 	private _emit = true;
 	private _commentWarning?: string;
@@ -73,6 +85,7 @@ export abstract class IntrospectedBase<Parent extends IntrospectedNamespace | An
 		this.doc = from.doc;
 		this.metadata = from.metadata;
 		this.deprecated = from.deprecated;
+		this.glibTypeName = from.glibTypeName;
 		this.resolve_names = from.resolve_names;
 
 		// Whether this node should be emitted.

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -1120,6 +1120,7 @@ export class IntrospectedClass extends IntrospectedBaseClass {
 		name: string,
 	): void {
 		if (element.$["glib:type-name"]) {
+			clazz.glibTypeName = element.$["glib:type-name"];
 			clazz.resolve_names.push(element.$["glib:type-name"]);
 			ns.registerResolveName(element.$["glib:type-name"], ns.namespace, name);
 		}
@@ -1426,6 +1427,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 		name: string,
 	): void {
 		if (element.$["glib:type-name"]) {
+			iface.glibTypeName = element.$["glib:type-name"];
 			iface.resolve_names.push(element.$["glib:type-name"]);
 			namespace.registerResolveName(element.$["glib:type-name"], namespace.namespace, name);
 		}

--- a/packages/lib/src/gir/property.ts
+++ b/packages/lib/src/gir/property.ts
@@ -102,6 +102,18 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 	defaultValue?: string;
 	/** GIR getter attribute: name of the getter method for this property (used for nullable inference). */
 	getter?: string;
+	/**
+	 * The property name exactly as GIR spells it — `icon-name`, not `icon_name`.
+	 *
+	 * {@link name} is rewritten twice on the way in: `fromXML` replaces `-` with
+	 * `_` so the name is a legal identifier, and `propertyCase: "both"` then emits
+	 * a second camelCase COPY of every property. Neither spelling is the name
+	 * GObject registered, and `g_object_set()`, GtkBuilder XML and Blueprint all
+	 * want the registered one. Carrying it costs one string and removes a
+	 * derivation; it is also the key that pairs the two `propertyCase` copies back
+	 * up, since both copies keep it.
+	 */
+	girName?: string;
 
 	get namespace() {
 		return this.parent.namespace;
@@ -124,6 +136,7 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 		})._copyBaseProperties(this);
 		prop.defaultValue = this.defaultValue;
 		prop.getter = this.getter;
+		prop.girName = this.girName;
 		return prop;
 	}
 
@@ -208,6 +221,8 @@ export class IntrospectedProperty extends IntrospectedBase<IntrospectedEnum | In
 		property.defaultValue = element.$["default-value"];
 
 		property.getter = element.$.getter;
+
+		property.girName = name;
 
 		if (element.$.nullable === "1" || element.$["allow-none"] === "1") {
 			property.type = makeNullable(property.type);

--- a/packages/lib/src/types/options-generation.ts
+++ b/packages/lib/src/types/options-generation.ts
@@ -17,6 +17,17 @@ export interface OptionsGeneration extends OptionsBase {
 	/** Generate promisified functions for async/finish calls */
 	promisify: boolean;
 	/**
+	 * Emit the GIR-derived widget vocabulary on an opt-in `./surface` subpath, for
+	 * every namespace that declares descendants of `GtkWidget`.
+	 *
+	 * Off by default: it is a separate subpath, so a consumer that never imports it
+	 * parses zero additional bytes, but the FILES still cost generation time and
+	 * tarball size for the 700-odd namespaces that have no widgets at all. The
+	 * namespace gate is automatic — a namespace with no `GtkWidget` descendant
+	 * never emits a surface even with this on.
+	 */
+	widgetSurface: boolean;
+	/**
 	 * Scope of the generated NPM packages
 	 * @see https://docs.npmjs.com/cli/v7/using-npm/scope
 	 */

--- a/packages/lib/src/types/user-config.ts
+++ b/packages/lib/src/types/user-config.ts
@@ -24,6 +24,17 @@ export interface UserConfig {
 	noComments: boolean;
 	/** Generate promisified functions for async/finish calls */
 	promisify: boolean;
+	/**
+	 * Emit the GIR-derived widget vocabulary on an opt-in `./surface` subpath, for
+	 * every namespace that declares descendants of `GtkWidget`.
+	 *
+	 * Off by default: it is a separate subpath, so a consumer that never imports it
+	 * parses zero additional bytes, but the FILES still cost generation time and
+	 * tarball size for the 700-odd namespaces that have no widgets at all. The
+	 * namespace gate is automatic — a namespace with no `GtkWidget` descendant
+	 * never emits a surface even with this on.
+	 */
+	widgetSurface: boolean;
 	/** Scope of the generated NPM packages */
 	npmScope: string;
 	/** Uses the workspace protocol for the generated packages which can be used with package managers like Yarn and PNPM */

--- a/packages/templates/templates/package.json
+++ b/packages/templates/templates/package.json
@@ -63,6 +63,18 @@ _%>
         "default": "./<%- entryPointName %>-import.js"
       },
       <%_ } _%>
+      <%_ /* The GIR-derived widget vocabulary (ADR 0029 in the gjsify repository). Its own
+             subpath on purpose: a consumer that never imports it parses zero extra bytes,
+             because TypeScript reads only the files a program reaches. Emitted only for
+             namespaces that declare GtkWidget descendants, so the entry is conditional on the
+             FILE existing rather than on the flag being set. */ _%>
+      <%_ if (typeof girModule !== "undefined" && girModule && girModule.hasWidgetSurface) { _%>
+      "./surface": {
+        "types": "./<%- entryPointName %>-surface.d.ts",
+        "import": "./<%- entryPointName %>-surface.js",
+        "default": "./<%- entryPointName %>-surface.js"
+      },
+      <%_ } _%>
       "./<%- entryPointName %>": {
         "types": "./<%- entryPointName %>.d.ts",
         "import": "./<%- entryPointName %>.js",

--- a/packages/templates/templates/tsconfig.json
+++ b/packages/templates/templates/tsconfig.json
@@ -12,6 +12,14 @@ if (packageName === 'Gjs') {
 }
 includes.push(`./${entryPointName}.d.ts`)
 
+// The widget surface is type-checked by the package's own `npm test`
+// (`tsc --project tsconfig.json`). That is the only thing that can catch a surface
+// referencing a name the main emitter did not emit — the generator cannot, because
+// it is emitting both halves from the same model and would agree with itself.
+if (typeof girModule !== 'undefined' && girModule && girModule.hasWidgetSurface) {
+  includes.push(`./${entryPointName}-surface.d.ts`)
+}
+
 // Build paths mappings for cross-package type resolution (needed for TypeDoc inheritance)
 let paths = {}
 if (typeof girModule !== 'undefined' && girModule && girModule.transitiveDependencies) {

--- a/tests/widget-surface/.ts-for-gir.broken.rc.js
+++ b/tests/widget-surface/.ts-for-gir.broken.rc.js
@@ -1,0 +1,11 @@
+// The NEGATIVE half: same generator, a widget with a settable property whose GIR type
+// resolves to nothing. Must exit non-zero and name the property.
+export default {
+  girDirectories: ["./fixtures-broken", "../../girs"],
+  modules: ["Broken-1.0"],
+  outdir: "./generated-broken",
+  npmScope: "@girs",
+  package: true,
+  widgetSurface: true,
+  reporter: false,
+};

--- a/tests/widget-surface/.ts-for-gir.cross.rc.js
+++ b/tests/widget-surface/.ts-for-gir.cross.rc.js
@@ -1,0 +1,11 @@
+// Two widget namespaces: the second imports the first's props interfaces instead of copying
+// them, and redeclares one inherited property with an incompatible type.
+export default {
+  girDirectories: ["./fixtures-cross", "../../girs"],
+  modules: ["Derived-1.0"],
+  outdir: "./generated-cross",
+  npmScope: "@girs",
+  package: true,
+  widgetSurface: true,
+  reporter: false,
+};

--- a/tests/widget-surface/.ts-for-gir.inline.rc.js
+++ b/tests/widget-surface/.ts-for-gir.inline.rc.js
@@ -1,0 +1,11 @@
+// A widget whose base lives in a namespace with no widgets AND carries settable
+// properties: the base is inlined into the consuming surface rather than dropped.
+export default {
+  girDirectories: ["./fixtures-inline", "../../girs"],
+  modules: ["Hosted-1.0"],
+  outdir: "./generated-inline",
+  npmScope: "@girs",
+  package: true,
+  widgetSurface: true,
+  reporter: false,
+};

--- a/tests/widget-surface/.ts-for-gir.off.rc.js
+++ b/tests/widget-surface/.ts-for-gir.off.rc.js
@@ -1,0 +1,11 @@
+// The flag-OFF control: identical input, `widgetSurface` absent. Nothing may be emitted,
+// and no `./surface` may appear in the package.json — otherwise "the flag works" is a
+// claim about a run that would have produced the same files either way.
+export default {
+  girDirectories: ["./fixtures", "../../girs"],
+  modules: ["Mini-1.0"],
+  outdir: "./generated-off",
+  npmScope: "@girs",
+  package: true,
+  reporter: false,
+};

--- a/tests/widget-surface/.ts-for-gir.rc.js
+++ b/tests/widget-surface/.ts-for-gir.rc.js
@@ -1,0 +1,9 @@
+export default {
+  girDirectories: ["./fixtures", "../../girs"],
+  modules: ["Mini-1.0"],
+  outdir: "./generated",
+  npmScope: "@girs",
+  package: true,
+  widgetSurface: true,
+  reporter: false,
+};

--- a/tests/widget-surface/assert.mjs
+++ b/tests/widget-surface/assert.mjs
@@ -1,0 +1,288 @@
+// Asserts the `@girs/<ns>/surface` subpath: what it emits, what it must NOT emit, that
+// the type half and the runtime half state the SAME facts, and that the generator refuses
+// an input it cannot describe.
+//
+// WHY THE NEGATIVE HALVES ARE NOT OPTIONAL. A suite of positive assertions over a
+// generator's own output cannot tell "the rule works" from "the rule never ran": a
+// `mustNot` list that passes because the emitter produced nothing at all reads exactly
+// like one that passes because the emitter filtered correctly. So this file carries three
+// controls beside the positives, each of which has to go the other way:
+//
+//   1. FLAG OFF, same input — no surface file and no `./surface` in the package.json. A
+//      subpath that appears either way is not opt-in.
+//   2. A BROKEN input — a widget with a settable property whose GIR type resolves to
+//      nothing. The main emitter degrades that to `never`, which is right for a method
+//      signature and wrong for a vocabulary: a property offered as `never` accepts no
+//      value, so the widget quietly loses it. The generator must exit non-zero and name
+//      the property.
+//   3. TYPE HALF vs RUNTIME HALF — the two are read independently (regex over the `.d.ts`,
+//      `import()` of the `.js`) and compared. Emitting both from one model means the
+//      generator agrees with itself; this is the only check that notices if it stops.
+//
+// And one positive case that is easy to get wrong in the safe-looking direction: a base
+// from a namespace with no surface of its own. Dropping it is what a reader would do; it
+// would shrink the vocabulary by properties nobody would notice were missing. Measured in
+// the real corpus exactly once — Gcr.Prompt, ten writable properties — so the fixture is a
+// stand-in for a real case, not a hypothetical.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = join(here, "generated", "mini-1.0");
+const typesFile = join(pkgDir, "mini-1.0-surface.d.ts");
+const dataFile = join(pkgDir, "mini-1.0-surface.js");
+
+/** @type {string[]} */
+const failures = [];
+const fail = (message) => failures.push(message);
+
+if (!existsSync(typesFile)) throw new Error(`surface types not generated: ${typesFile}`);
+if (!existsSync(dataFile)) throw new Error(`surface data not generated: ${dataFile}`);
+
+const types = readFileSync(typesFile, "utf8");
+
+const must = [
+  // The property axis: writable only, optional, keyed as GObject registered it.
+  ["dashed property key", /'css-classes'\?: string\[\];/],
+  ["plain property key stays unquoted", /\n\s+spacing\?: number;/],
+  ["interface property reaches the implementor", /orientation\?: GtkOrientationNick \| Mini\.Orientation;/],
+  ["array property keeps its element type", /'css-classes'\?: string\[\];/],
+  ["construct-only union names the property", /GtkWidgetConstructOnly = 'css-name'/],
+  ["a declaration with no own construct-only props is `never`-rooted", /GtkOrientableConstructOnly = never/],
+  ["construct-only unions inherit", /GtkBoxConstructOnly = GtkWidgetConstructOnly \| GtkOrientableConstructOnly/],
+  // The nick axis: read from `glib:nick`, never derived from the member name.
+  ["nick union from glib:nick", /GtkOrientationNick = 'horizontal' \| 'vertical' \| 'sideways';/],
+  // Every registered enum the namespace declares, not only the ones its own properties
+  // reference: another namespace's widget can reach this one, and the version that emitted
+  // only what it referenced left a real consumer importing a name that did not exist.
+  ["nick union for an unreferenced enum", /GtkUnreferencedNick = 'one' \| 'two';/],
+  // The widget map: GType-keyed, pointing at the SignalSignatures already emitted.
+  ["widget row keyed by GType", /\n {4}GtkBox: \{/],
+  ["row carries the instance type", /class: Mini\.Box;/],
+  ["row points at the existing signal table", /signals: Mini\.Box\.SignalSignatures;/],
+  ["slot candidate derived from set_child", /'child': 'set_child';/],
+  ["slot candidate that parents nothing is listed too", /'activatable': 'set_activatable_widget';/],
+  // The own-namespace import is a sibling file, not a package self-reference.
+  ["own namespace imported relatively", /import type Mini from '\.\/mini-1\.0\.js';/],
+  // Runtime data is declared here and defined in the sibling `.js`.
+  ["runtime data declared", /export const OWN_PROPS: Readonly<Record<string, readonly string\[\]>>;/],
+  ["since map declared", /export const SINCE: Readonly<Record<string, string>>;/],
+  ["helper types", /export type WidgetGType = keyof Widgets;/],
+];
+
+const mustNot = [
+  // The correctness bug `ConstructorProps` has: a read-only property offered as settable.
+  // GTK's failure mode for writing one is exit 0.
+  ["read-only property offered", /\n\s+parent\?:/],
+  // Flags stay `number`: GObject exposes no way to resolve a nick SET.
+  ["flags widened to a nick union", /GtkStateFlagsNick/],
+  // Dialect, all of it, and a JSX namespace is a GLOBAL declaration.
+  ["a JSX namespace", /namespace JSX/],
+  ["intrinsic elements", /IntrinsicElements/],
+  ["a Vue GlobalComponents interface", /GlobalComponents/],
+  ["a global augmentation", /declare (global|module)/],
+  ["a kebab TAG spelling", /'mini-box'|'gtk-box'/],
+  ["an on<Signal> handler prop", /onChildAdded/],
+  ["a camelCase property key", /cssClasses\?:/],
+  // An abstract class cannot be created, so it gets no row — but it does get an interface.
+  ["abstract class as a widget row", /\n {4}GtkWidget: \{/],
+  // A non-widget gets neither.
+  ["non-widget row", /GtkAdjustment: \{/],
+  ["non-widget props interface", /GtkAdjustmentProps/],
+];
+
+// The `mustNot` list runs against the DECLARATIONS with comments stripped. The header
+// explains what the surface deliberately omits, and it names those things — so a naive
+// match on the whole file reports the explanation as the violation. Measured: the first
+// run of this file failed on the word `GlobalComponents` inside its own prose.
+const code = types.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
+for (const [label, re] of must) if (!re.test(types)) fail(`missing from surface .d.ts: ${label} (${re})`);
+for (const [label, re] of mustNot) if (re.test(code)) fail(`must not appear in surface .d.ts: ${label} (${re})`);
+
+// ---------------------------------------------------------------- both halves agree
+
+const data = await import(`file://${dataFile}`);
+
+const declaredNames = new Set(
+  [...types.matchAll(/^export const (\w+):/gm)].map((match) => match[1]),
+);
+for (const name of declaredNames) {
+  if (!(name in data)) fail(`declared in the .d.ts but not exported by the .js: ${name}`);
+}
+for (const name of Object.keys(data)) {
+  if (!declaredNames.has(name)) fail(`exported by the .js but not declared in the .d.ts: ${name}`);
+}
+
+// The runtime data must name the same widgets the type map does.
+const rowGTypes = new Set([...types.matchAll(/^ {4}(\w+): \{$/gm)].map((match) => match[1]));
+const dataGTypes = new Set(Object.keys(data.DECLS ?? {}));
+for (const gtype of rowGTypes) {
+  if (!dataGTypes.has(gtype)) fail(`in the Widgets map but not in DECLS: ${gtype}`);
+}
+for (const gtype of dataGTypes) {
+  if (!rowGTypes.has(gtype)) fail(`in DECLS but not in the Widgets map: ${gtype}`);
+}
+
+// Every property the runtime data offers must be a key of the interface it belongs to.
+for (const [gtype, props] of Object.entries(data.OWN_PROPS ?? {})) {
+  const block = new RegExp(`export interface ${gtype}Props[^{]*\\{([^}]*)\\}`, "s").exec(types);
+  if (!block) {
+    fail(`OWN_PROPS names ${gtype} but the .d.ts has no ${gtype}Props`);
+    continue;
+  }
+  for (const prop of props) {
+    if (!block[1].includes(`${/^[A-Za-z_$][\w$]*$/.test(prop) ? prop : `'${prop}'`}?:`)) {
+      fail(`OWN_PROPS[${gtype}] offers '${prop}', absent from ${gtype}Props`);
+    }
+  }
+}
+
+if (data.ENUM_NICKS?.GtkOrientation?.join(",") !== "horizontal,vertical,sideways") {
+  fail(`ENUM_NICKS.GtkOrientation is ${JSON.stringify(data.ENUM_NICKS?.GtkOrientation)}`);
+}
+if (!data.ENUM_NICKS?.GtkUnreferenced) {
+  fail("ENUM_NICKS omits the enum no property references — a consumer in another namespace can");
+}
+if (data.ENUM_NICKS?.GtkStateFlags) {
+  fail("ENUM_NICKS carries a bitfield; a nick SET is not something GObject can resolve");
+}
+if (data.SINCE?.["GtkOrientable.orientation"] !== "1.2") {
+  fail(`SINCE lost the GIR version attribute: ${JSON.stringify(data.SINCE)}`);
+}
+if (data.OWN_SIGNALS?.GtkBox?.join(",") !== "child-added") {
+  fail(`OWN_SIGNALS.GtkBox is ${JSON.stringify(data.OWN_SIGNALS?.GtkBox)}`);
+}
+if (data.SLOT_CANDIDATES?.GtkBox?.child !== "set_child") {
+  fail(`SLOT_CANDIDATES.GtkBox is ${JSON.stringify(data.SLOT_CANDIDATES?.GtkBox)}`);
+}
+
+// ---------------------------------------------------------------- the package shape
+
+const pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+const surfaceExport = pkg.exports?.["./surface"];
+if (surfaceExport?.types !== "./mini-1.0-surface.d.ts" || surfaceExport?.import !== "./mini-1.0-surface.js") {
+  fail(`package.json exports["./surface"] is ${JSON.stringify(surfaceExport)}`);
+}
+// The generated tsconfig carries `//` comments, so it is JSONC rather than JSON.
+const tsconfig = JSON.parse(readFileSync(join(pkgDir, "tsconfig.json"), "utf8").replace(/^\s*\/\/.*$/gm, ""));
+if (!tsconfig.include?.includes("./mini-1.0-surface.d.ts")) {
+  // Without this the surface is never compiled, and a surface referencing a name the
+  // main emitter did not emit is exactly what nothing else can catch.
+  fail(`tsconfig.json include does not cover the surface: ${JSON.stringify(tsconfig.include)}`);
+}
+
+// A namespace with no widgets gets nothing — the whole point of the per-namespace gate.
+for (const dir of ["gobject-2.0", "glib-2.0"]) {
+  const other = join(here, "generated", dir);
+  if (!existsSync(other)) continue;
+  const stray = readdirSync(other).filter((name) => name.includes("-surface."));
+  if (stray.length > 0) fail(`${dir} declares no widgets but emitted ${stray.join(", ")}`);
+  const otherPkg = JSON.parse(readFileSync(join(other, "package.json"), "utf8"));
+  if (otherPkg.exports?.["./surface"]) fail(`${dir} declares no widgets but exports ./surface`);
+}
+
+// ---------------------------------------------------------------- control 1: flag off
+
+const offDir = join(here, "generated-off", "mini-1.0");
+if (!existsSync(offDir)) {
+  fail("the flag-off control did not generate at all, so it proves nothing");
+} else {
+  const strayOff = readdirSync(offDir).filter((name) => name.includes("-surface."));
+  if (strayOff.length > 0) fail(`widgetSurface off still emitted ${strayOff.join(", ")}`);
+  const offPkg = JSON.parse(readFileSync(join(offDir, "package.json"), "utf8"));
+  if (offPkg.exports?.["./surface"]) fail("widgetSurface off still wrote exports['./surface']");
+  // …and the control has to be a real run of the same generator, not an empty directory.
+  if (!existsSync(join(offDir, "mini-1.0.d.ts"))) fail("the flag-off control emitted no module .d.ts");
+}
+
+// ------------------------------------------------- a base from a namespace with no surface
+
+const inlineFile = join(here, "generated-inline", "hosted-1.0", "hosted-1.0-surface.d.ts");
+if (!existsSync(inlineFile)) {
+  fail(`the inline fixture did not generate: ${inlineFile}`);
+} else {
+  const inline = readFileSync(inlineFile, "utf8");
+  if (!/export interface CarrierHolderProps \{[^}]*title\?: string;/s.test(inline)) {
+    fail("Carrier.Holder was not inlined — its `title` property is missing from the surface");
+  }
+  if (!/interface GtkWidgetProps extends CarrierHolderProps/.test(inline)) {
+    fail("the inlined base is emitted but nothing extends it");
+  }
+  if (!/inlined base\(s\) from a namespace with no surface: Carrier\.Holder/.test(inline)) {
+    // Named in the provenance line, so a dependency release that changes the base graph
+    // shows up in a diff instead of in a support question.
+    fail("the provenance line does not name the inlined base");
+  }
+  if (/from '@girs\/carrier-1\.0\/surface'/.test(inline)) {
+    fail("the surface imports from @girs/carrier-1.0/surface, which does not exist");
+  }
+  if (existsSync(join(here, "generated-inline", "carrier-1.0", "carrier-1.0-surface.d.ts"))) {
+    fail("Carrier declares no widgets and still got a surface of its own");
+  }
+}
+
+// ------------------------------------------------- a base imported from another namespace
+
+const crossFile = join(here, "generated-cross", "derived-1.0", "derived-1.0-surface.d.ts");
+if (!existsSync(crossFile)) {
+  fail(`the cross-namespace fixture did not generate: ${crossFile}`);
+} else {
+  const cross = readFileSync(crossFile, "utf8");
+  if (!/from '@girs\/base-1\.0\/surface'/.test(cross)) {
+    fail("Base's interfaces were copied instead of imported from its surface");
+  }
+  if (/export interface GtkWidgetProps/.test(cross)) {
+    fail("Base's GtkWidgetProps is emitted a second time here — two nominally distinct copies");
+  }
+  // TypeScript requires a declaration's OWN member to be assignable to its base's, and this
+  // fixture breaks that on purpose. Without the `Omit` the emitted file is TS2430 — the
+  // shape GimpUi-3.0 hit in the real corpus, invisible until the base's members were
+  // computed for a declaration whose interface another package emits.
+  if (!/interface DrvPanelProps extends Omit<GtkWidgetProps, 'holder'>/.test(cross)) {
+    fail("the redeclared property is not Omit-ed from the imported base");
+  }
+  if (!/holder\?: Derived\.Thing/.test(cross)) fail("the redeclared property lost its own type");
+}
+
+// ---------------------------------------------------------------- control 2: broken input
+
+const cli = join(here, "..", "..", "packages", "cli", "bin", "ts-for-gir-dev");
+let brokenExit = 0;
+let brokenOutput = "";
+try {
+  brokenOutput = execFileSync(process.execPath, [cli, "generate", "--configName", ".ts-for-gir.broken.rc.js"], {
+    cwd: here,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+} catch (error) {
+  brokenExit = typeof error.status === "number" ? error.status : 1;
+  brokenOutput = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+}
+if (brokenExit === 0) {
+  fail("the broken fixture generated successfully — an unmappable property type is not refused");
+} else if (!/GtkPanel\.mystery|Broken\.Panel\.mystery/.test(brokenOutput)) {
+  // A non-zero exit for some other reason would be a gate that goes red without
+  // measuring anything, which is the failure this whole file is shaped against.
+  fail(`the broken fixture failed without naming the property:\n${brokenOutput.slice(-2000)}`);
+}
+const brokenSurface = join(here, "generated-broken", "broken-1.0", "broken-1.0-surface.d.ts");
+if (existsSync(brokenSurface)) fail("the broken fixture wrote a surface file before failing");
+
+// ----------------------------------------------------------------------------------
+
+if (failures.length > 0) {
+  console.error("widget-surface assertion failures:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  `OK: ${rowGTypes.size} widget row(s), ${Object.keys(data.OWN_PROPS).length} declaration(s) with props, ` +
+    `${Object.keys(data.ENUM_NICKS).length} nick union(s); flag-off control clean; ` +
+    `broken fixture rejected with exit ${brokenExit}`,
+);

--- a/tests/widget-surface/assert.mjs
+++ b/tests/widget-surface/assert.mjs
@@ -14,13 +14,12 @@
 //      NOTHING. The surface would reference a name the main emitter never emitted, so the
 //      generator must exit non-zero and name the property. Note the scope: what is refused
 //      is an unresolvable identifier, NOT every property that prints `never`. A writable
-//      `gpointer` resolves fine and no TypeScript value satisfies it — four found over
-//      fourteen widget namespaces, in `GcrTreeSelector:columns`, `Gtk.Object:user-data`,
-//      `Gtk.Notebook:group` and (as a C callback) `GimpDialog:help-func`. Those are
-//      emitted as `never`, kept in `OWN_PROPS` because the ParamSpec is real, and NAMED in
-//      the provenance line of the surface that carries them. The `user-data` assertions
-//      below hold that second half, because a rule stated in a comment and enforced
-//      nowhere is the one that drifts.
+//      `gpointer` resolves fine and no TypeScript value satisfies it — `GcrTreeSelector:
+//      columns`, `Wnck.ActionMenu:window`, eleven on `AgsGui.Cartesian` — as does one C
+//      callback, `GimpDialog:help-func`. Those are emitted as `never`, kept in `OWN_PROPS`
+//      because the ParamSpec is real, and NAMED in the provenance line of the surface that
+//      carries them. The `user-data` assertions below hold that second half, because a
+//      rule stated in a comment and enforced nowhere is the one that drifts.
 //   3. TYPE HALF vs RUNTIME HALF — the two are read independently (regex over the `.d.ts`,
 //      `import()` of the `.js`) and compared. Emitting both from one model means the
 //      generator agrees with itself; this is the only check that notices if it stops.

--- a/tests/widget-surface/assert.mjs
+++ b/tests/widget-surface/assert.mjs
@@ -14,11 +14,13 @@
 //      NOTHING. The surface would reference a name the main emitter never emitted, so the
 //      generator must exit non-zero and name the property. Note the scope: what is refused
 //      is an unresolvable identifier, NOT every property that prints `never`. A writable
-//      `gpointer` resolves fine and no TypeScript value satisfies it (`GcrTreeSelector:
-//      columns`, `GimpDialog:help-func` — two in the whole corpus); those are emitted as
-//      `never`, kept in `OWN_PROPS` because the ParamSpec is real, and NAMED in the
-//      provenance line. The `user-data` assertions below hold that second half, because a
-//      rule that is stated in a comment and enforced nowhere is the one that drifts.
+//      `gpointer` resolves fine and no TypeScript value satisfies it — four found over
+//      fourteen widget namespaces, in `GcrTreeSelector:columns`, `Gtk.Object:user-data`,
+//      `Gtk.Notebook:group` and (as a C callback) `GimpDialog:help-func`. Those are
+//      emitted as `never`, kept in `OWN_PROPS` because the ParamSpec is real, and NAMED in
+//      the provenance line of the surface that carries them. The `user-data` assertions
+//      below hold that second half, because a rule stated in a comment and enforced
+//      nowhere is the one that drifts.
 //   3. TYPE HALF vs RUNTIME HALF — the two are read independently (regex over the `.d.ts`,
 //      `import()` of the `.js`) and compared. Emitting both from one model means the
 //      generator agrees with itself; this is the only check that notices if it stops.

--- a/tests/widget-surface/assert.mjs
+++ b/tests/widget-surface/assert.mjs
@@ -11,10 +11,14 @@
 //   1. FLAG OFF, same input — no surface file and no `./surface` in the package.json. A
 //      subpath that appears either way is not opt-in.
 //   2. A BROKEN input — a widget with a settable property whose GIR type resolves to
-//      nothing. The main emitter degrades that to `never`, which is right for a method
-//      signature and wrong for a vocabulary: a property offered as `never` accepts no
-//      value, so the widget quietly loses it. The generator must exit non-zero and name
-//      the property.
+//      NOTHING. The surface would reference a name the main emitter never emitted, so the
+//      generator must exit non-zero and name the property. Note the scope: what is refused
+//      is an unresolvable identifier, NOT every property that prints `never`. A writable
+//      `gpointer` resolves fine and no TypeScript value satisfies it (`GcrTreeSelector:
+//      columns`, `GimpDialog:help-func` — two in the whole corpus); those are emitted as
+//      `never`, kept in `OWN_PROPS` because the ParamSpec is real, and NAMED in the
+//      provenance line. The `user-data` assertions below hold that second half, because a
+//      rule that is stated in a comment and enforced nowhere is the one that drifts.
 //   3. TYPE HALF vs RUNTIME HALF — the two are read independently (regex over the `.d.ts`,
 //      `import()` of the `.js`) and compared. Emitting both from one model means the
 //      generator agrees with itself; this is the only check that notices if it stops.
@@ -55,6 +59,12 @@ const must = [
   ["construct-only unions inherit", /GtkBoxConstructOnly = GtkWidgetConstructOnly \| GtkOrientableConstructOnly/],
   // The nick axis: read from `glib:nick`, never derived from the member name.
   ["nick union from glib:nick", /GtkOrientationNick = 'horizontal' \| 'vertical' \| 'sideways';/],
+  // Resolvable, inexpressible, and therefore emitted rather than refused — see the header.
+  ["a gpointer property is kept as never", /'user-data'\?: never;/],
+  [
+    "…and named in the provenance line",
+    /prop\(s\) no TypeScript value satisfies: Mini\.Box\.user-data/,
+  ],
   // Every registered enum the namespace declares, not only the ones its own properties
   // reference: another namespace's widget can reach this one, and the version that emitted
   // only what it referenced left a real consumer importing a name that did not exist.
@@ -152,6 +162,11 @@ if (data.ENUM_NICKS?.GtkStateFlags) {
 }
 if (data.SINCE?.["GtkOrientable.orientation"] !== "1.2") {
   fail(`SINCE lost the GIR version attribute: ${JSON.stringify(data.SINCE)}`);
+}
+if (!data.OWN_PROPS?.GtkBox?.includes("user-data")) {
+  // Dropping it from the runtime data would hide a real writable ParamSpec from the
+  // consumer check that asks the installed library whether every name here exists.
+  fail(`OWN_PROPS.GtkBox lost the gpointer property: ${JSON.stringify(data.OWN_PROPS?.GtkBox)}`);
 }
 if (data.OWN_SIGNALS?.GtkBox?.join(",") !== "child-added") {
   fail(`OWN_SIGNALS.GtkBox is ${JSON.stringify(data.OWN_SIGNALS?.GtkBox)}`);

--- a/tests/widget-surface/fixtures-broken/Broken-1.0.gir
+++ b/tests/widget-surface/fixtures-broken/Broken-1.0.gir
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!-- Broken-1.0.gir — a widget with a settable property whose GIR type resolves to nothing.
+     The main emitter degrades an unresolvable type to `never`, which is the right answer
+     for a method signature and the wrong one for a vocabulary: a property offered as
+     `never` accepts no value at all, so the widget quietly loses it. The surface generator
+     must REFUSE and name the property. -->
+<repository version="1.2" xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <include name="GLib" version="2.0"/>
+  <package name="broken"/>
+  <c:include name="broken.h"/>
+  <namespace name="Broken" version="1.0" shared-library="libbroken.so" c:prefix="Gtk" c:identifier-prefixes="Gtk" c:symbol-prefixes="gtk">
+    <class name="Widget" c:symbol-prefix="widget" c:type="GtkWidget" glib:type-name="GtkWidget" glib:get-type="gtk_widget_get_type" parent="GObject.Object" abstract="1">
+      <property name="visible" writable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <class name="Panel" c:symbol-prefix="panel" c:type="GtkPanel" glib:type-name="GtkPanel" glib:get-type="gtk_panel_get_type" parent="Widget">
+      <property name="mystery" writable="1" transfer-ownership="none">
+        <type name="NoSuchType" c:type="GtkNoSuchType*"/>
+      </property>
+    </class>
+  </namespace>
+</repository>

--- a/tests/widget-surface/fixtures-broken/Broken-1.0.gir
+++ b/tests/widget-surface/fixtures-broken/Broken-1.0.gir
@@ -1,9 +1,13 @@
 <?xml version="1.0"?>
-<!-- Broken-1.0.gir — a widget with a settable property whose GIR type resolves to nothing.
+<!-- Broken-1.0.gir — a widget with a settable property whose GIR type resolves to NOTHING.
      The main emitter degrades an unresolvable type to `never`, which is the right answer
-     for a method signature and the wrong one for a vocabulary: a property offered as
-     `never` accepts no value at all, so the widget quietly loses it. The surface generator
-     must REFUSE and name the property. -->
+     for a method signature and the wrong one here: the surface would carry a property the
+     model has no type for, so a later rename in the main emitter could not be detected.
+     The surface generator must REFUSE and name the property.
+
+     What this fixture does NOT cover, deliberately: a type that resolves fine and no
+     TypeScript value satisfies (a writable `gpointer`, a C callback). Those are emitted as
+     `never` and named in the provenance line — `Mini-1.0.gir` carries that case. -->
 <repository version="1.2" xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
   <include name="GObject" version="2.0"/>
   <include name="GLib" version="2.0"/>

--- a/tests/widget-surface/fixtures-cross/Base-1.0.gir
+++ b/tests/widget-surface/fixtures-cross/Base-1.0.gir
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!-- Base-1.0.gir — a widget namespace another one inherits from, so its props interfaces
+     are IMPORTED rather than copied. `Widget.holder` is deliberately typed `Base.Widget`
+     and redeclared in Derived-1.0.gir with a different type: TypeScript requires a
+     declaration's own member to be assignable to its base's, and GimpUi-3.0 breaks exactly
+     that in the real corpus (`GimpDialog` redeclares `parent` as `Gtk.Widget` where GTK 3's
+     writable `GtkWidget:parent` is a `Gtk.Container`). The repair is `Omit` on the base. -->
+<repository version="1.2" xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <include name="GLib" version="2.0"/>
+  <package name="base"/>
+  <c:include name="base.h"/>
+  <namespace name="Base" version="1.0" shared-library="libbase.so" c:prefix="Gtk" c:identifier-prefixes="Gtk" c:symbol-prefixes="gtk">
+    <class name="Widget" c:symbol-prefix="widget" c:type="GtkWidget" glib:type-name="GtkWidget" glib:get-type="gtk_widget_get_type" parent="GObject.Object" abstract="1">
+      <property name="visible" writable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="holder" writable="1" transfer-ownership="none">
+        <type name="Widget" c:type="GtkWidget*"/>
+      </property>
+    </class>
+    <class name="Bin" c:symbol-prefix="bin" c:type="GtkBin" glib:type-name="GtkBin" glib:get-type="gtk_bin_get_type" parent="Widget"/>
+  </namespace>
+</repository>

--- a/tests/widget-surface/fixtures-cross/Derived-1.0.gir
+++ b/tests/widget-surface/fixtures-cross/Derived-1.0.gir
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!-- Derived-1.0.gir — a second widget namespace, so Base's interfaces are imported from
+     `@girs/base-1.0/surface`. `Panel.holder` redeclares the inherited property with an
+     incompatible type; see Base-1.0.gir. -->
+<repository version="1.2" xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <include name="GLib" version="2.0"/>
+  <include name="Base" version="1.0"/>
+  <package name="derived"/>
+  <c:include name="derived.h"/>
+  <namespace name="Derived" version="1.0" shared-library="libderived.so" c:prefix="Drv" c:identifier-prefixes="Drv" c:symbol-prefixes="drv">
+    <class name="Thing" c:symbol-prefix="thing" c:type="DrvThing" glib:type-name="DrvThing" glib:get-type="drv_thing_get_type" parent="GObject.Object"/>
+    <class name="Panel" c:symbol-prefix="panel" c:type="DrvPanel" glib:type-name="DrvPanel" glib:get-type="drv_panel_get_type" parent="Base.Widget">
+      <property name="holder" writable="1" transfer-ownership="none">
+        <type name="Thing" c:type="DrvThing*"/>
+      </property>
+    </class>
+  </namespace>
+</repository>

--- a/tests/widget-surface/fixtures-inline/Carrier-1.0.gir
+++ b/tests/widget-surface/fixtures-inline/Carrier-1.0.gir
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!-- Carrier-1.0.gir — a namespace that declares NO widgets and yet contributes a settable
+     property to a widget's base chain. There is no `@girs/carrier-1.0/surface` to import
+     `CarrierHolderProps` from, and dropping the base would shrink the vocabulary by a
+     property nobody would notice was missing — so the consuming surface inlines it. A
+     surface for Carrier itself is the wrong answer: it would be a widget surface with no
+     widgets in it. -->
+<repository version="1.2" xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <include name="GLib" version="2.0"/>
+  <package name="carrier"/>
+  <c:include name="carrier.h"/>
+  <namespace name="Carrier" version="1.0" shared-library="libcarrier.so" c:prefix="Carrier" c:identifier-prefixes="Carrier" c:symbol-prefixes="carrier">
+    <class name="Holder" c:symbol-prefix="holder" c:type="CarrierHolder" glib:type-name="CarrierHolder" glib:get-type="carrier_holder_get_type" parent="GObject.Object">
+      <property name="title" writable="1" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+    </class>
+  </namespace>
+</repository>

--- a/tests/widget-surface/fixtures-inline/Hosted-1.0.gir
+++ b/tests/widget-surface/fixtures-inline/Hosted-1.0.gir
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!-- Hosted-1.0.gir — declares widgets and roots them on a base from a namespace that does
+     not. Pairs with Carrier-1.0.gir: `Carrier.Holder` has settable properties and no
+     surface to be imported from, so the generator INLINES it here rather than dropping it.
+     Measured in the real corpus exactly once (Gcr.Prompt), which is why this is a positive
+     fixture and not an error case. -->
+<repository version="1.2" xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <include name="GLib" version="2.0"/>
+  <include name="Carrier" version="1.0"/>
+  <package name="hosted"/>
+  <c:include name="hosted.h"/>
+  <namespace name="Hosted" version="1.0" shared-library="libhosted.so" c:prefix="Gtk" c:identifier-prefixes="Gtk" c:symbol-prefixes="gtk">
+    <class name="Widget" c:symbol-prefix="widget" c:type="GtkWidget" glib:type-name="GtkWidget" glib:get-type="gtk_widget_get_type" parent="Carrier.Holder" abstract="1">
+      <property name="visible" writable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+    </class>
+    <class name="Panel" c:symbol-prefix="panel" c:type="GtkPanel" glib:type-name="GtkPanel" glib:get-type="gtk_panel_get_type" parent="Widget">
+      <property name="spacing" writable="1" transfer-ownership="none">
+        <type name="gint" c:type="gint"/>
+      </property>
+    </class>
+  </namespace>
+</repository>

--- a/tests/widget-surface/fixtures/Mini-1.0.gir
+++ b/tests/widget-surface/fixtures/Mini-1.0.gir
@@ -78,6 +78,16 @@
       <property name="spacing" writable="1" transfer-ownership="none">
         <type name="gint" c:type="gint"/>
       </property>
+      <!-- RESOLVABLE and inexpressible. A writable `gpointer` is a real ParamSpec the
+           runtime data must carry, and there is no TypeScript value that satisfies it —
+           the model prints `never`, and so does the surface. Distinct from the Broken
+           fixture, whose type resolves to NOTHING and is refused: this one is emitted and
+           NAMED in the provenance line, so a second such property is a diff rather than a
+           property that silently stopped accepting values. Real cases: two, in
+           `GcrTreeSelector:columns` and `GimpDialog:help-func`. -->
+      <property name="user-data" writable="1" transfer-ownership="none">
+        <type name="gpointer" c:type="gpointer"/>
+      </property>
       <glib:signal name="child-added" when="last">
         <parameters>
           <parameter name="child" transfer-ownership="none">

--- a/tests/widget-surface/fixtures/Mini-1.0.gir
+++ b/tests/widget-surface/fixtures/Mini-1.0.gir
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!-- Mini-1.0.gir — synthetic widget-toolkit fixture for ts-for-gir-test/widget-surface.
+
+     Small on purpose: the surface generator's rules are all decidable on a handful of
+     declarations, and a fixture that generates in under a second is a fixture the gate
+     can be run against a DELIBERATELY BROKEN variant of. The one thing it borrows from
+     the real world is the GType `GtkWidget`, because that name is the root the surface
+     tests membership against. -->
+<repository version="1.2" xmlns="http://www.gtk.org/introspection/core/1.0" xmlns:c="http://www.gtk.org/introspection/c/1.0" xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <include name="GLib" version="2.0"/>
+  <package name="mini"/>
+  <c:include name="mini.h"/>
+  <namespace name="Mini" version="1.0" shared-library="libmini.so" c:prefix="Gtk" c:identifier-prefixes="Gtk" c:symbol-prefixes="gtk">
+
+    <!-- The enum whose nicks the surface must read from `glib:nick`. `SIDE_WAYS` is the
+         load-bearing member: its nick is `sideways`, which the underscore substitution
+         would spell `side-ways`. -->
+    <enumeration name="Orientation" c:type="GtkOrientation" glib:type-name="GtkOrientation" glib:get-type="gtk_orientation_get_type">
+      <member name="horizontal" value="0" c:identifier="GTK_ORIENTATION_HORIZONTAL" glib:nick="horizontal"/>
+      <member name="vertical" value="1" c:identifier="GTK_ORIENTATION_VERTICAL" glib:nick="vertical"/>
+      <member name="side_ways" value="2" c:identifier="GTK_ORIENTATION_SIDE_WAYS" glib:nick="sideways"/>
+    </enumeration>
+
+    <!-- Registered, non-flags, and referenced by NO property in this namespace. It must
+         still get a nick union: a consumer in another namespace can reach it (measured —
+         `GtkSourceView.text-window-type` reaches `Gtk.TextWindowType`, which no Gtk-4.0
+         widget property uses, and the emit-what-you-reference version left
+         `@girs/gtksource-5/surface` importing a name `@girs/gtk-4.0/surface` did not have). -->
+    <enumeration name="Unreferenced" c:type="GtkUnreferenced" glib:type-name="GtkUnreferenced" glib:get-type="gtk_unreferenced_get_type">
+      <member name="one" value="0" c:identifier="GTK_UNREFERENCED_ONE" glib:nick="one"/>
+      <member name="two" value="1" c:identifier="GTK_UNREFERENCED_TWO" glib:nick="two"/>
+    </enumeration>
+
+    <!-- A bitfield, which must stay `number`: GObject exposes no way to resolve a nick SET. -->
+    <bitfield name="StateFlags" c:type="GtkStateFlags" glib:type-name="GtkStateFlags" glib:get-type="gtk_state_flags_get_type">
+      <member name="active" value="1" c:identifier="GTK_STATE_FLAG_ACTIVE" glib:nick="active"/>
+      <member name="focused" value="2" c:identifier="GTK_STATE_FLAG_FOCUSED" glib:nick="focused"/>
+    </bitfield>
+
+    <!-- The interface that carries `orientation`. GObject installs interface properties on
+         the implementor at runtime while GIR keeps them once, here — a class-only walk
+         emits a Box without its most-written property. -->
+    <interface name="Orientable" c:symbol-prefix="orientable" c:type="GtkOrientable" glib:type-name="GtkOrientable" glib:get-type="gtk_orientable_get_type">
+      <property name="orientation" writable="1" transfer-ownership="none" version="1.2">
+        <doc xml:space="preserve">The orientation of the orientable.</doc>
+        <type name="Orientation" c:type="GtkOrientation"/>
+      </property>
+    </interface>
+
+    <!-- Abstract, so it must NOT get a `Widgets` row, and it must still get a props
+         interface because every widget inherits from it. -->
+    <class name="Widget" c:symbol-prefix="widget" c:type="GtkWidget" glib:type-name="GtkWidget" glib:get-type="gtk_widget_get_type" parent="GObject.Object" abstract="1">
+      <property name="visible" writable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <property name="css-classes" writable="1" transfer-ownership="none">
+        <array>
+          <type name="utf8" c:type="gchar*"/>
+        </array>
+      </property>
+      <property name="state-flags" writable="1" transfer-ownership="none">
+        <type name="StateFlags" c:type="GtkStateFlags"/>
+      </property>
+      <!-- READ-ONLY. `ConstructorProps` offers this as settable; writing it is exit 0. -->
+      <property name="parent" readable="1" writable="0" transfer-ownership="none">
+        <type name="Widget" c:type="GtkWidget*"/>
+      </property>
+      <!-- CONSTRUCT-ONLY: a renderer must rebuild rather than patch. -->
+      <property name="css-name" writable="1" construct-only="1" transfer-ownership="none">
+        <type name="utf8" c:type="gchar*"/>
+      </property>
+      <glib:signal name="destroy" when="cleanup"/>
+    </class>
+
+    <class name="Box" c:symbol-prefix="box" c:type="GtkBox" glib:type-name="GtkBox" glib:get-type="gtk_box_get_type" parent="Widget">
+      <implements name="Orientable"/>
+      <property name="spacing" writable="1" transfer-ownership="none">
+        <type name="gint" c:type="gint"/>
+      </property>
+      <glib:signal name="child-added" when="last">
+        <parameters>
+          <parameter name="child" transfer-ownership="none">
+            <type name="Widget" c:type="GtkWidget*"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+      <!-- A slot candidate: exactly one widget argument. -->
+      <method name="set_child" c:identifier="gtk_box_set_child">
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.Box" c:type="GtkBox*"/></instance-parameter>
+          <parameter name="child" transfer-ownership="none"><type name="Widget" c:type="GtkWidget*"/></parameter>
+        </parameters>
+      </method>
+      <!-- ALSO a candidate, and it parents nothing. Same C signature, same transfer —
+           nothing in the GIR separates the two, which is why curation decides. -->
+      <method name="set_activatable_widget" c:identifier="gtk_box_set_activatable_widget">
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.Box" c:type="GtkBox*"/></instance-parameter>
+          <parameter name="widget" transfer-ownership="none"><type name="Widget" c:type="GtkWidget*"/></parameter>
+        </parameters>
+      </method>
+      <!-- NOT a candidate: the single argument is not a widget. -->
+      <method name="set_label" c:identifier="gtk_box_set_label">
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.Box" c:type="GtkBox*"/></instance-parameter>
+          <parameter name="label" transfer-ownership="none"><type name="utf8" c:type="const gchar*"/></parameter>
+        </parameters>
+      </method>
+    </class>
+
+    <!-- Not a widget: no row, no props interface. -->
+    <class name="Adjustment" c:symbol-prefix="adjustment" c:type="GtkAdjustment" glib:type-name="GtkAdjustment" glib:get-type="gtk_adjustment_get_type" parent="GObject.Object">
+      <property name="value" writable="1" transfer-ownership="none">
+        <type name="gdouble" c:type="gdouble"/>
+      </property>
+    </class>
+
+  </namespace>
+</repository>

--- a/tests/widget-surface/package.json
+++ b/tests/widget-surface/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "@ts-for-gir-test/widget-surface",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "test": "gjsify run clear && gjsify run generate && gjsify run generate:off && gjsify run generate:inline && gjsify run generate:cross && gjsify run assert",
+        "generate": "ts-for-gir-dev generate --configName .ts-for-gir.rc.js",
+        "generate:off": "ts-for-gir-dev generate --configName .ts-for-gir.off.rc.js",
+        "generate:inline": "ts-for-gir-dev generate --configName .ts-for-gir.inline.rc.js",
+        "generate:cross": "ts-for-gir-dev generate --configName .ts-for-gir.cross.rc.js",
+        "assert": "node --no-warnings assert.mjs",
+        "clear": "rm -rf generated generated-off generated-inline generated-cross generated-broken"
+    },
+    "devDependencies": {
+        "@ts-for-gir/cli": "workspace:^"
+    }
+}


### PR DESCRIPTION
Implements the ts-for-gir half of **gjsify ADR 0029** — the GIR-derived widget
vocabulary moves out of one renderer and into the type layer, on an opt-in
`@girs/<ns>/surface` subpath.

## What the subpath carries

Module-scoped exports only, four kinds of name:

```ts
import type { Widgets, GtkBoxProps, GtkOrientationNick } from '@girs/gtk-4.0/surface';
import { OWN_PROPS, ENUM_NICKS, SINCE } from '@girs/gtk-4.0/surface';
```

- **one props interface per GIR DECLARATION**, mirroring GIR's own inheritance —
  writable-only, optional, keyed by the name GObject registered (`'css-classes'`,
  not `css_classes` or `cssClasses`);
- **the construct-only name union**, which is what tells a renderer to rebuild
  rather than patch;
- **enum nick unions** from `glib:nick`;
- **a GType-keyed `Widgets` map** whose `signals` axis POINTS AT the
  `SignalSignatures` this generator already emits, rather than re-deriving handler
  types.

Plus the same facts as runtime data in the sibling `.js` (`OWN_PROPS`,
`OWN_SIGNALS`, `DECLS`, `ENUM_NICKS`, `SLOT_CANDIDATES`, `SINCE`), because types are
erased and the check worth having is a consumer asking the *installed* library
whether every name is real.

### Why not `X.ConstructorProps`

It is the wrong shape on three axes and the first is a correctness bug. Measured on
Gtk-4.0: it offers **150 read-only properties across 68 classes** as settable —
`Gtk.Widget` alone contributes `has_default`, `has_focus`, `parent`, `root`,
`scale_factor` — and GTK's failure mode for writing one is **exit 0**. Its members
are required, so every consumer wraps it in `Partial<>`. And it never spells the
dashed name `g_object_set()`, GtkBuilder XML and Blueprint all want.

### What is deliberately absent

Tag spellings, `on<Signal>` prop names, `JSX.IntrinsicElements`, a Vue
`GlobalComponents` interface, camelCase property keys. Those are framework dialect;
a JSX namespace in particular is a *global* declaration, so a second library
declaring one collides on every shared tag — and `@girs/*` is the package that must
not do that.

## Measurements

| | |
|---|---:|
| `.gir` files in `girs/` | 705 |
| distinct namespaces after version de-duplication | 475 |
| namespaces declaring a concrete `GtkWidget` descendant | 102 |
| packages a full run emits / carrying a `./surface` | 703 / **138** |
| Gtk-4.0: widgets / declarations / nick unions / slot candidates | 102 / 123 / 38 / 60 |
| Adw-1: widgets / declarations / nick unions / slot candidates | 62 / 63 / 16 / 62 |
| Gtk-4.0 surface `.d.ts` | 151 KB / 3 126 lines |
| …against the base `gtk-4.0.d.ts` | 5.86 MB / 147 574 lines — **2.6 % if imported, 0 % if not** |
| Gtk-4.0 runtime data `.js` | 39 KB / 533 lines |

102 + 62 = 164, matching `@gjsify/gtk-host`'s own concrete-widget count exactly.

**All 138 emitted surfaces type-check clean** (`tsc --project` per package, the
generated `tsconfig.json` with the surface added to `include`).

## Three model fields the parser read and the model threw away

- `GirEnumMember.nick` — `glib:nick` has been in `@gi.ts/parser` since the
  beginning and nothing read it, so every consumer derived a nick from the member
  name instead. That derivation is right by *luck*: across the 705 GIRs, 40 940 of
  59 789 members carry the attribute and **889** of those disagree with
  `name.toLowerCase().replace(/_/g, "-")`. Gtk-4.0 and Adw-1 happen to be
  zero-disagreement namespaces (799/807 and 120/120 carry it, none contradicting),
  which is exactly how a derived nick passes review and breaks elsewhere.
- `IntrospectedBase.glibTypeName` — the GType was reachable only inside
  `resolve_names`, mixed with `c:type` and `glib:type-struct`.
- `IntrospectedProperty.girName` — `fromXML` rewrites `-` to `_`, and
  `propertyCase: "both"` then pushes a camelCase COPY, so neither spelling in the
  model is the registered name. It is also the key that pairs the two copies up.

## Corrections the implementation forced on the ADR

Recorded in the gjsify PR, because the repo treats an ADR that was already wrong
when it was adopted as a known and expensive mistake.

1. **Cross-namespace bases are imported, not copied.** The ADR's prototype inlined
   the whole Gtk chain into Adw's file (its 81 declarations / 28 nick unions measure
   that). Two nominally distinct `GtkWidgetProps` in one program is a confusing
   error waiting for the first consumer that mixes them.
2. **"Only namespaces that declare widgets" needed one exception, and it is real.**
   A base can live in a namespace with no widgets and still carry settable
   properties. Dropping it shrinks the vocabulary silently; giving its namespace a
   surface publishes a widget surface with no widgets in it. So it is INLINED into
   the consumer and named in that file's provenance line. Across all 475 namespaces
   this happens **exactly once** — `Gcr.Prompt`, a GObject interface with ten
   writable properties, implemented by widgets in `GcrUi` — and the first version of
   this generator refused it and took a 705-namespace run down at namespace 265.
3. **The reader is this repo's own MODEL, not a second `parseGir()` pass**, so a
   name the surface references is literally a name the main emitter emitted.

## The gate, and the proof it goes red

`tests/widget-surface` (`@ts-for-gir-test/widget-surface`, part of `test:tests`):
positives over a small fixture toolkit plus four things a positive suite cannot see.

**Controls, each of which must go the other way:**

1. **Flag off, same input** — no surface file, no `./surface` export, and a module
   `.d.ts` that proves the control was a real run.
2. **A broken input** — a settable property whose GIR type resolves to nothing. The
   main emitter degrades that to `never`, which is right for a method signature and
   wrong for a vocabulary. Must exit non-zero *and name the property*:
   ```
   Broken.Panel.mystery: cannot resolve Broken.NoSuchType
   ```
   A non-zero exit for any other reason fails too.
3. **Type half vs runtime half** — read independently (regex over the `.d.ts`,
   `import()` of the `.js`) and compared both ways.
4. **The two cross-namespace shapes**, both stand-ins for real corpus cases: an
   inlined base is emitted and named in the provenance line, and a property
   redeclared incompatibly over an *imported* base is `Omit`-ed from it.

**Demonstrated red on tampered generators**, not only on synthetic fixtures:

| tamper | result |
|---|---|
| drop the `if (!prop.writable) continue` filter | `must not appear: read-only property offered (/\n\s+parent\?:/)`, exit 1 |
| derive the nick instead of reading `glib:nick` | `missing: nick union from glib:nick` + `ENUM_NICKS.GtkOrientation is ["horizontal","vertical","side-ways"]`, exit 1 |

**And the per-package `tsc --project` caught two real defects before review:**

- 9 × TS2304 in Adw-1 — nick unions owned by Gtk were skipped locally without being
  imported. Fixed by emitting a nick union for **every** registered non-flags enum a
  namespace declares, not only the ones its own properties reference:
  `GtkSourceView.text-window-type` reaches `Gtk.TextWindowType` and no Gtk-4.0
  widget property does, so `@girs/gtksource-5/surface` was importing a name
  `@girs/gtk-4.0/surface` did not have (same shape for `GtkPackTypeNick` in Handy-1
  against Gtk-3.0).
- TS2430 in GimpUi-3.0 — `GimpDialog` redeclares `parent` as `Gtk.Widget` where GTK
  3's writable `GtkWidget:parent` is a `Gtk.Container`. TypeScript requires a
  declaration's own member to be assignable to its base's, and repairing that needs
  an `Omit` on an *imported* base, which needs that base's members computed even
  though another package emits its interface.

## Scope notes

- Off by default (`widgetSurface: false`); `.ts-for-gir.packages-all.rc.js` turns it
  on so the published `@girs/*` carry it. `--package` mode only — the subpath needs
  an `exports` entry to be reachable, and `externalDeps` mode emits one flat ambient
  `.d.ts` with no package around it.
- The `@girs/*` main `.d.ts` is untouched. A consumer that never imports the subpath
  parses zero additional bytes.
- `SINCE` is populated from GIR's `version` attribute, which the model only carries
  when `loadDocs` is on (i.e. `--noComments` off).
- Interface signals are still absent from the model (18 in Gtk-4.0, 0 in Adw-1) and
  are being fixed separately. `OWN_SIGNALS` is derived from the same model as
  `SignalSignatures`, so the two agree; the check's direction is claims → reality.
