### PR TITLE
docs: plain prose across the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
   <img src=".github/feeling.gif" />
 </p>
 
-`ts-for-gir` generates accurate TypeScript definitions from [GObject Introspection](https://gi.readthedocs.io/en/latest/) for [GJS](https://gitlab.gnome.org/GNOME/gjs/) projects — strong typing, IDE jump-to-definition, autocompletion across the whole GNOME stack.
+`ts-for-gir` reads [GObject Introspection](https://gi.readthedocs.io/en/latest/) data and writes TypeScript definitions for [GJS](https://gitlab.gnome.org/GNOME/gjs/) projects. Your editor then knows the whole GNOME stack: jump to definition, autocompletion, and a type error when you pass the wrong thing to `g_object_set()`.
 
-📖 **Project page on the gjsify website**: [gjsify.github.io/gjsify/projects/ts-for-gir](https://gjsify.github.io/gjsify/projects/ts-for-gir/) — install paths, quickstart, generator usage, links to the related [Patterns](https://gjsify.github.io/gjsify/patterns/) docs.
+**Project page on the gjsify website**: [gjsify.github.io/gjsify/projects/ts-for-gir](https://gjsify.github.io/gjsify/projects/ts-for-gir/). Install paths, quickstart, generator usage, and links to the [Patterns](https://gjsify.github.io/gjsify/patterns/) docs.
 
 Browse the full **[TypeScript API Documentation](https://gjsify.github.io/docs)** for GLib, GTK, GStreamer, and more.
 
@@ -34,7 +34,7 @@ Pick a template interactively, or pass `--template <id>`:
 
 | Template | Best for |
 |---|---|
-| **`types-gjsify`** | Node-free GJS app — all dev scripts (install, build, run, format) routed through [gjsify](https://gjsify.github.io/gjsify/) |
+| **`types-gjsify`** | A GJS app with no Node.js. Install, build, run and format all go through [gjsify](https://gjsify.github.io/gjsify/) |
 | **`types-npm`** | Single-package, types from [`@girs/*`](https://github.com/gjsify/types) NPM, esbuild + node |
 | **`types-locally`** | Generate types into `./@types/` (no `@girs/*` dep) |
 | **`types-workspace`** | npm workspace with `@girs/*` as locally-generated workspace packages |
@@ -45,7 +45,7 @@ cd my-app && npm start    # or `gjsify run start` for types-gjsify
 
 ## Installation
 
-### GJS — no Node.js required
+### GJS, without Node.js
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gjsify/ts-for-gir/main/install.js -o /tmp/install.js
@@ -54,7 +54,7 @@ gjs -m /tmp/install.js && rm /tmp/install.js
 
 Installs to `~/.local/bin/`. Update later with `ts-for-gir self-update`. Powered by [GJSify](https://gjsify.github.io/gjsify/).
 
-Alternative — if you already have the [gjsify CLI](https://gjsify.github.io/gjsify/) installed: `gjsify dlx @ts-for-gir/cli <args>` (npx-style, no install) or `gjsify install -g @ts-for-gir/cli` (managed global).
+If you already have the [gjsify CLI](https://gjsify.github.io/gjsify/), skip that. `gjsify dlx @ts-for-gir/cli <args>` runs it without installing, `gjsify install -g @ts-for-gir/cli` installs it globally.
 
 ### Node.js
 
@@ -99,55 +99,55 @@ All packages are listed at [gjsify/types](https://github.com/gjsify/types). Miss
 
 **GNOME Applications**
 
-- [Audio Player](https://flathub.org/apps/org.gnome.Decibels) — Play audio files
-- [Counters](https://flathub.org/apps/io.gitlab.guillermop.Counters) — Keep track of anything
-- [Ignition](https://flathub.org/apps/io.github.flattool.Ignition) — Manage startup apps and scripts
-- [Learn 6502](https://flathub.org/apps/eu.jumplink.Learn6502) — Learn programming on vintage game consoles
-- [Sound Recorder](https://flathub.org/apps/org.gnome.SoundRecorder) — A simple, modern sound recorder
-- [Sticky Notes](https://flathub.org/apps/com.vixalien.sticky) — Pin notes to your desktop
-- [Weather](https://flathub.org/apps/org.gnome.Weather) — Show weather conditions and forecast
-- [K'uychi](https://flathub.org/en/apps/one.naiara.Kuychi) — Generate color palettes
+- [Audio Player](https://flathub.org/apps/org.gnome.Decibels): Play audio files
+- [Counters](https://flathub.org/apps/io.gitlab.guillermop.Counters): Keep track of anything
+- [Ignition](https://flathub.org/apps/io.github.flattool.Ignition): Manage startup apps and scripts
+- [Learn 6502](https://flathub.org/apps/eu.jumplink.Learn6502): Learn programming on vintage game consoles
+- [Sound Recorder](https://flathub.org/apps/org.gnome.SoundRecorder): A simple, modern sound recorder
+- [Sticky Notes](https://flathub.org/apps/com.vixalien.sticky): Pin notes to your desktop
+- [Weather](https://flathub.org/apps/org.gnome.Weather): Show weather conditions and forecast
+- [K'uychi](https://flathub.org/en/apps/one.naiara.Kuychi): Generate color palettes
 
 **GNOME Shell Extensions**
 
-- [gTile](https://github.com/gTile/gTile) — Tiling window management for GNOME Shell
-- [Copyous](https://github.com/boerdereinar/copyous) — Clipboard manager for GNOME Shell
-- [Rounded Window Corners](https://github.com/flexagoon/rounded-window-corners) — Add rounded corners to windows
+- [gTile](https://github.com/gTile/gTile): Tiling window management for GNOME Shell
+- [Copyous](https://github.com/boerdereinar/copyous): Clipboard manager for GNOME Shell
+- [Rounded Window Corners](https://github.com/flexagoon/rounded-window-corners): Add rounded corners to windows
 
 ## Example Projects
 
-Looking for a starting point? These example projects demonstrate how to use the TypeScript definitions with various bundlers:
+These example projects wire the definitions up with different bundlers:
 
-- [GTK 4 Template with Vite](/examples/gtk-4-template-vite) — Modern UI with Vite bundling
-- [GNOME TypeScript Template](https://codeberg.org/nyx_lyb3ra/gnome-ts-template) — A template using GTK, libadwaita, TypeScript, Flatpak, and Meson
+- [GTK 4 Template with Vite](/examples/gtk-4-template-vite): Modern UI with Vite bundling
+- [GNOME TypeScript Template](https://codeberg.org/nyx_lyb3ra/gnome-ts-template): A template using GTK, libadwaita, TypeScript, Flatpak, and Meson
 
-More examples with screenshots and descriptions can be found in the [Examples directory](/examples/README.md). For information on using the examples with different CLI options, refer to the [CLI documentation](/packages/cli/README.md#using-the-generated-types).
+The [Examples directory](/examples/README.md) has more, with screenshots. The [CLI documentation](/packages/cli/README.md#using-the-generated-types) covers running them under different CLI options.
 
 ## Project Structure
 
 ts-for-gir consists of several packages:
 
-- [`@ts-for-gir/cli`](/packages/cli) — Command-line interface for generating TypeScript definitions, documentation, and analyzing reports
-- [`@gi.ts/parser`](/packages/parser) — Parser for GObject Introspection XML files
-- [`@ts-for-gir/lib`](/packages/lib) — Core library for processing GIR data
-- [`@ts-for-gir/reporter`](/packages/reporter) — Reporting system for problems and statistics with dependency injection
-- [`@ts-for-gir/generator-typescript`](/packages/generator-typescript) — TypeScript definition generator
-- [`@ts-for-gir/generator-json`](/packages/generator-json) — TypeDoc JSON generator with GIR metadata enrichment
-- [`@ts-for-gir/generator-html-doc`](/packages/generator-html-doc) — HTML documentation generator using TypeDoc
-- [`@ts-for-gir/generator-base`](/packages/generator-base) — Shared base class for generators
-- [`@ts-for-gir/typedoc-theme`](/packages/typedoc-theme) — Custom TypeDoc theme inspired by gi-docgen
-- [`@ts-for-gir/gir-module-metadata`](/packages/gir-module-metadata) — Curated metadata (descriptions, logos, licenses) for GIR namespaces
-- [`@ts-for-gir/templates`](/packages/templates) — Template files for generated packages (tsconfig, typedoc config, ambient declarations)
-- [`@ts-for-gir/tsconfig`](/packages/tsconfig) — Shared TypeScript configuration
-- [`@ts-for-gir/language-server`](/packages/language-server) — Language server for GIR files (experimental)
+- [`@ts-for-gir/cli`](/packages/cli): Command-line interface for generating TypeScript definitions, documentation, and analyzing reports
+- [`@gi.ts/parser`](/packages/parser): Parser for GObject Introspection XML files
+- [`@ts-for-gir/lib`](/packages/lib): Core library for processing GIR data
+- [`@ts-for-gir/reporter`](/packages/reporter): Reporting system for problems and statistics with dependency injection
+- [`@ts-for-gir/generator-typescript`](/packages/generator-typescript): TypeScript definition generator
+- [`@ts-for-gir/generator-json`](/packages/generator-json): TypeDoc JSON generator with GIR metadata enrichment
+- [`@ts-for-gir/generator-html-doc`](/packages/generator-html-doc): HTML documentation generator using TypeDoc
+- [`@ts-for-gir/generator-base`](/packages/generator-base): Shared base class for generators
+- [`@ts-for-gir/typedoc-theme`](/packages/typedoc-theme): Custom TypeDoc theme inspired by gi-docgen
+- [`@ts-for-gir/gir-module-metadata`](/packages/gir-module-metadata): Curated metadata (descriptions, logos, licenses) for GIR namespaces
+- [`@ts-for-gir/templates`](/packages/templates): Template files for generated packages (tsconfig, typedoc config, ambient declarations)
+- [`@ts-for-gir/tsconfig`](/packages/tsconfig): Shared TypeScript configuration
+- [`@ts-for-gir/language-server`](/packages/language-server): Language server for GIR files (experimental)
 
 ### Submodules
 
 This repo contains Git submodules for pre-generated types and documentation:
 
-- `types-dev` (branch `dev`) — used during local development. Scripts write generated packages here.
-- `types-release` (branch `main`) — updated by the release workflow on tags.
-- `docs` (branch `main`) — generated HTML documentation, deployed to [gjsify.github.io/docs](https://gjsify.github.io/docs).
+- `types-dev` (branch `dev`): used during local development. Scripts write generated packages here.
+- `types-release` (branch `main`): updated by the release workflow on tags.
+- `docs` (branch `main`): generated HTML documentation, deployed to [gjsify.github.io/docs](https://gjsify.github.io/docs).
 
 Useful scripts:
 
@@ -162,7 +162,7 @@ gjsify run build:doc            # build HTML docs into ./docs
 - [TypeScript API Documentation](https://gjsify.github.io/docs)
 - [Examples](/examples/README.md)
 - [CLI Documentation](/packages/cli/README.md)
-- [Using ts-for-gir as a library](/packages/lib/README.md#using-ts-for-gir-as-a-library) — building your
-  own TSX / framework types from GIR, and which of the three routes needs no library at all
-- [gjsify/types](https://github.com/gjsify/types) — pre-generated NPM packages
-- [gjsify/gnome-shell](https://github.com/gjsify/gnome-shell) — hand-written Shell Extension types
+- [Using ts-for-gir as a library](/packages/lib/README.md#using-ts-for-gir-as-a-library): building
+  your own TSX or framework types from GIR, and which of the three routes needs no library at all
+- [gjsify/types](https://github.com/gjsify/types): pre-generated NPM packages
+- [gjsify/gnome-shell](https://github.com/gjsify/gnome-shell): hand-written Shell Extension types

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ CLI tool to generate TypeScript type definitions and HTML documentation for GObj
 
 ## Getting started
 
-### Install (GJS — no Node.js required)
+### Install (GJS, without Node.js)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gjsify/ts-for-gir/main/install.js -o /tmp/ts-for-gir-install.js
@@ -59,9 +59,9 @@ The GJS bundle (`ts-for-gir-gjs`) supports the full TypeScript /
 TypeDoc pipeline thanks to gjsify's runtime-relative `import.meta.url`
 rewrite. All non-interactive commands run natively on GJS:
 
-- `ts-for-gir generate` — `.d.ts` generation
-- `ts-for-gir json` — TypeDoc-backed JSON export
-- `ts-for-gir doc` — HTML documentation. TypeDoc's shiki highlighter
+- `ts-for-gir generate`: `.d.ts` generation
+- `ts-for-gir json`: TypeDoc-backed JSON export
+- `ts-for-gir doc`: HTML documentation. TypeDoc's shiki highlighter
   loads the [oniguruma](https://github.com/kkos/oniguruma) regex
   engine via `WebAssembly.compile(...)`. GJS 1.88 (SpiderMonkey 140)
   exposes the synchronous `WebAssembly.{Module,Instance}` constructors
@@ -72,7 +72,7 @@ rewrite. All non-interactive commands run natively on GJS:
   natively in the GJS bundle.
 - `ts-for-gir list` / `copy` / `analyze` / `self-update`
 
-The only command still gated on Node.js is `create` — its
+The only command still gated on Node.js is `create`. Its
 [`inquirer`](https://www.npmjs.com/package/inquirer)-based interactive
 prompt cannot run on GJS without a TTY-aware port. Use
 `npx @ts-for-gir/cli create ...` from a Node install for now.
@@ -531,7 +531,7 @@ ts-for-gir generate * --noAdvancedVariants=false
 ### widgetSurface
 
 Emits the GIR-derived widget **vocabulary** on an opt-in `@girs/<ns>/surface` subpath, for the
-namespaces that declare concrete descendants of `GtkWidget` — `Gtk-4.0`, `Adw-1`, `Gtk-3.0`,
+namespaces that declare concrete descendants of `GtkWidget`: `Gtk-4.0`, `Adw-1`, `Gtk-3.0`,
 `GtkSource`, `WebKit` and so on. Every other namespace emits nothing regardless of the flag, so
 this is not something a Gio-only project pays for. Requires `--package`.
 
@@ -551,13 +551,13 @@ type BoxSignals = Widgets['GtkBox']['signals'];
 
 Three things this is and `X.ConstructorProps` is not: **writable-only** (measured on Gtk-4.0,
 `ConstructorProps` offers 150 read-only properties across 68 classes as settable, and GTK's
-failure mode for writing one is exit 0), **optional**, and **keyed by the registered name** —
+failure mode for writing one is exit 0), **optional**, and **keyed by the registered name**,
 the dashed spelling `g_object_set()`, GtkBuilder XML and Blueprint all use.
 
 What it deliberately does **not** contain: tag spellings, `on<Signal>` handler prop names,
 `JSX.IntrinsicElements`, a Vue `GlobalComponents` interface, camelCase property keys. Those are
 framework dialect, every framework answers them differently, and a JSX namespace is a global
-declaration — a second library declaring one collides on every shared tag. Build your dialect on
+declaration. A second library declaring one collides on every shared tag. Build your dialect on
 these names instead.
 
 Beside the `.d.ts`, the same subpath exports the facts as runtime **data** (`OWN_PROPS`,

--- a/packages/cli/templates/types-workspace/README.md
+++ b/packages/cli/templates/types-workspace/README.md
@@ -20,7 +20,7 @@ The application lives in [`packages/app/`](./packages/app/). Its dependencies on
 
 Two deliberate choices keep the template portable:
 
-1. **Generated `@girs/*` packages** reference each other via `^<version>` (not `workspace:^`). Controlled by `depVersionFormat: "caret"` in [`.ts-for-girrc.js`](./.ts-for-girrc.js). npm and yarn/pnpm all prefer the local workspace match; the registry serves as fallback for transitive GIR packages outside your `modules` set.
+1. **Generated `@girs/*` packages** reference each other via `^<version>` (not `workspace:^`). Controlled by `depVersionFormat: "caret"` in [`.ts-for-girrc.js`](./.ts-for-girrc.js). npm and yarn/pnpm all prefer the local workspace match; the registry is the fallback for transitive GIR packages outside your `modules` set.
 2. **Sub-package deps** (`packages/app/package.json`) use `"*"`. Same reasoning — all managers resolve to the local workspace.
 
 If you run yarn or pnpm exclusively and want strict workspace-only resolution, switch both: add `workspace: true` and `depVersionFormat: "workspace"` in `.ts-for-girrc.js`, plus `"workspace:^"` specs in `packages/app/package.json`. npm does **not** support the `workspace:` protocol.

--- a/packages/generator-base/README.md
+++ b/packages/generator-base/README.md
@@ -22,7 +22,7 @@ This package defines the base interface that all generators in the ts-for-gir ec
 
 ## Purpose
 
-The generator-base package serves as the foundation for creating specific generators like:
+Every concrete generator extends the base class here:
 - TypeScript definition generators (implemented in `@ts-for-gir/generator-typescript`)
 - HTML documentation generators (placeholder in `@ts-for-gir/generator-html-doc`)
 - Potentially other output formats in the future
@@ -52,5 +52,5 @@ The package also includes a `GeneratorType` enum that defines the available gene
 
 ## Usage
 
-This package is not used directly by end users but serves as a dependency for concrete generator implementations and the main CLI tool.
+End users never import this package. The concrete generators and the CLI depend on it.
 

--- a/packages/generator-html-doc/README.md
+++ b/packages/generator-html-doc/README.md
@@ -20,11 +20,11 @@
 
 ## Status: Not Yet Implemented
 
-This package currently serves as a placeholder and basic framework for implementing an HTML documentation generator based on GIR types. It does not contain actual functionality yet.
+This package is a placeholder. It has the shape an HTML documentation generator for GIR types would take, and none of the behaviour.
 
 ## Purpose
 
-The intended purpose of this package is to provide a way to generate HTML documentation from GObject introspection data, similar to how the `generator-typescript` package generates TypeScript definitions. When implemented, it would allow for generating human-readable API documentation websites.
+The plan is to generate HTML documentation from GObject introspection data, the way `generator-typescript` generates TypeScript definitions.
 
 ## Implementation
 

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -254,4 +254,4 @@ describe('GIR Type Tests', () => {
 
 ## Development
 
-This package provides the foundation for building GIR type validation and inspection tools. The type expectation functionality enables precise testing of whether generated TypeScript definitions match the expected types, making it ideal for automated testing and validation of GIR type generation.
+Use this package to check generated TypeScript against the types you expect. That is what the type-expectation API is for, and it is how the generator's own type tests assert their results.

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -18,28 +18,23 @@
 
 # Library
 
-Core library to generate TypeScript type definitions from GObject Introspection Repository (GIR) data. This package provides the foundation for processing, transforming, and generating TypeScript interfaces based on GIR definitions.
+`@ts-for-gir/lib` is the model the `ts-for-gir` CLI builds from a GIR before anything
+emits TypeScript. It sits on `@gi.ts/parser`'s XML reader and hands
+`@ts-for-gir/generator-typescript` a tree of `IntrospectedClass`,
+`IntrospectedProperty`, `IntrospectedEnum` and their siblings, grouped per namespace by
+`GirModule` and resolved across namespaces by `DependencyManager`.
 
-## Features
-
-- Complete type system for representing GObject types in TypeScript
-- Dependency management for GIR modules and their relationships
-- Transformation engine to convert GIR introspection data to TypeScript types
-- Support for type generics, promises, and complex type expressions
-- Type conflict resolution and validation
-- Extensible architecture with visitor pattern support
-- Customizable code generation through formatters and generators
-
-This library serves as the core engine for the `ts-for-gir` toolchain, handling the translation of GObject types to their TypeScript equivalents.
+Most people never import it. Two cheaper routes cover almost every reason to want GIR
+data, and both are below.
 
 ## Using ts-for-gir as a library
 
-The intended way to build your own framework types — TSX intrinsics, a Vue
-`GlobalComponents` map, a signal-prop convention — out of GObject Introspection data.
-Three routes; take the cheapest one that answers your question, because two of them do
-not need this package at all.
+The intended way to build your own framework types out of GObject Introspection data:
+TSX intrinsics, a Vue `GlobalComponents` map, a signal-prop convention. Three routes
+below. Take the cheapest one that answers your question, because two of them do not need
+this package at all.
 
-### 1. Widget types for a published namespace — generate nothing
+### 1. Widget types for a published namespace, generating nothing
 
 If the namespace already has a `@girs/*` package, the GIR-derived widget vocabulary is
 published beside it on an opt-in subpath, and that is the whole input a framework
@@ -60,12 +55,12 @@ What the subpath exports, per namespace:
 | `WidgetGType`, `PropsOf<G>`, `SignalsOf<G>`, `InstanceOf<G>`, `ConstructOnlyOf<G>`, `SlotCandidatesOf<G>` | helpers over that map |
 | `OWN_PROPS`, `OWN_SIGNALS`, `DECLS`, `ENUM_NICKS`, `SLOT_CANDIDATES`, `SINCE`, `SURFACE_PROVENANCE` | the same facts as RUNTIME data in the sibling `.js` |
 
-Signal handler types are not re-derived here: `Widgets[G]['signals']` points at the
-`X.SignalSignatures` the main `@girs` package already emits, with the parent chain,
+The subpath does not re-derive signal handler types. `Widgets[G]['signals']` points at
+the `X.SignalSignatures` the main `@girs` package already emits, with the parent chain,
 every implemented interface and the `notify::<prop>` keys folded in.
 
-**What you must contribute, because it is not in the GIR.** Four decisions, and every
-framework answers them differently — which is exactly why the subpath refuses to:
+**What you must contribute, because it is not in the GIR.** Four decisions. Every
+framework answers them differently, which is why the subpath answers none of them.
 
 - **Tag spelling.** GIR knows `AdwToolbarView`. `adw-toolbar-view` is your choice.
 - **Signal prop names.** GObject says `clicked`; Solid and React want `onClicked`, a
@@ -76,8 +71,8 @@ framework answers them differently — which is exactly why the subpath refuses 
   `g_object_set()`, GtkBuilder XML and Blueprint all use. `top_bar_style` and
   `topBarStyle` are binding conveniences, so they are yours to add.
 
-All four together are a mapped type, not a code generator — you supply `TagOf`, the
-rest is mechanical:
+All four together are a mapped type, not a code generator. You supply `TagOf`, the rest
+is mechanical:
 
 ```ts
 import type { Widgets, WidgetGType } from '@girs/gtk-4.0/surface'
@@ -89,29 +84,32 @@ export type IntrinsicElements = {
 }
 ```
 
-**Do not reach for a clever `TagOf`.** The obvious camel-to-kebab conditional type — dash
-before every capital that starts a new word — resolves `GtkGLArea` to `gtk-g-l-area`,
-which no toolkit spells that way (verified against `tsc`, not guessed). Acronyms have no
-rule in the GIR, so a tag map is a place where you either hand-correct a short list or
-match whatever your template compiler does. If you target Vue, note that Volar resolves
-a tag back to a `GlobalComponents` key by camelizing it, so your spelling has to survive
-that round trip; gjsify's gtk-host reproduces Volar's rule in a test for precisely this
-reason.
+**Do not reach for a clever `TagOf`.** The obvious camel-to-kebab conditional type, a
+dash before every capital that starts a new word, resolves `GtkGLArea` to
+`gtk-g-l-area`. No toolkit spells it that way. That is measured against `tsc`, not
+guessed. Acronyms have no rule in the GIR, so a tag map is a place where you either
+hand-correct a short list or match whatever your template compiler does. If you target
+Vue, note that Volar resolves a tag back to a `GlobalComponents` key by camelizing it,
+so your spelling has to survive that round trip. gjsify's gtk-host reproduces Volar's
+rule in a test for that reason.
 
-**Declare the namespace module-scoped, not global.** The shape that collides is `declare global`
-on `React.JSX` — every library augmenting it fights over shared tags. A `JSX` namespace
-reached through your own `jsxImportSource` does not collide, and one package can ship
-several: gjsify's `@gjsify/gtk-host` ships a Solid one and a React one side by side.
+**Declare the namespace module-scoped, not global.** The shape that collides is
+`declare global` on `React.JSX`. Every library augmenting it fights over shared tags. A
+`JSX` namespace reached through your own `jsxImportSource` does not collide, and one
+package can ship several. gjsify's `@gjsify/gtk-host` ships a Solid one and a React one
+side by side.
 
 Two consequences worth knowing before you build on this. A consumer that never imports
 the subpath parses zero extra bytes, because TypeScript only reads files a program
-reaches — the Gtk-4.0 surface is ~158 KB against a 5.86 MB base `.d.ts`. And
-`slotCandidates` is honestly named: it is derived from method signatures, so it contains
-candidates the GIR cannot distinguish from real slots (`AdwActionRow.set_activatable_widget`
-parents nothing, and is `void f(GtkWidget*)` exactly like the ones that do). Which
-candidate is a real slot is runtime behaviour; decide it in your renderer.
+reaches. The Gtk-4.0 surface is 159 KB against a 5.6 MB base `.d.ts`.
 
-### 2. Types for a GIR nobody published — use the CLI
+`slotCandidates` is honestly named. It comes from method signatures, so it holds
+candidates the GIR cannot tell apart from real slots.
+`AdwActionRow.set_activatable_widget` parents nothing and is `void f(GtkWidget*)`, the
+same shape as the ones that do. Which candidate is a real slot is runtime behaviour.
+Decide it in your renderer.
+
+### 2. Types for a GIR nobody published, via the CLI
 
 For a private, vendored or freshly built `.gir`, run the CLI as a subprocess. No library
 API, no TypeScript build on your side:
@@ -125,23 +123,23 @@ Add `--widgetSurface` to get the subpath above for your own widgets. This is how
 types its six native bridges, each against the `.gir` shipped next to its prebuilt
 binary.
 
-### 3. Changing what gets emitted — the actual library
+### 3. Changing what gets emitted, the actual library
 
-Only when routes 1 and 2 cannot express it. `@ts-for-gir/lib` holds the model —
-`IntrospectedClass`, `IntrospectedProperty`, `IntrospectedEnum`, `GirModule`,
-`DependencyManager` — over `@gi.ts/parser`'s GIR reader, and
-`@ts-for-gir/generator-typescript` turns that model into declarations.
+Only when routes 1 and 2 cannot express it. `@ts-for-gir/lib` holds the model over
+`@gi.ts/parser`'s GIR reader: `IntrospectedClass`, `IntrospectedProperty`,
+`IntrospectedEnum`, `GirModule`, `DependencyManager`. `@ts-for-gir/generator-typescript`
+turns that model into declarations.
 
 Build on the MODEL rather than adding a second GIR reader. A parallel parse gives you a
 second opinion about what a class is, and then a type you emit can reference a name the
-main emitter never produced — invisible until some namespace with an unusual shape hits
-it. The widget surface is built this way for exactly that reason.
+main emitter never produced. That stays invisible until a namespace with an unusual
+shape hits it. The widget surface is built this way for that reason.
 
 #### Loading a namespace
 
-Four steps, and the fourth is the one that is easy to miss: **`load()` resolves and
+Four steps, and the fourth is the one that is easy to miss. **`load()` resolves and
 registers the module, `parse()` fills it.** A `GirModule` you never parsed has
-`members.size === 0` and reports no error — it is a valid empty module, not a failure.
+`members.size === 0` and reports no error. It is a valid empty module, not a failure.
 
 ```ts
 import { defaults } from "@ts-for-gir/cli";
@@ -162,7 +160,7 @@ console.log(gtk.namespace, gtk.version, String(gtk.libraryVersion));
 ```
 
 `deps.get()` returns a `Dependency` whose `.exists` is `false` when no GIR was found in
-`girDirectories` — check it, because `GirModule.load()` turns that into a thrown
+`girDirectories`. Check it, because `GirModule.load()` turns that into a thrown
 `Failed to load gir xml of <package>` one line later.
 
 #### Walking the model
@@ -186,11 +184,11 @@ console.log(`${classes.length} classes, ${enums.length} enums`);
 ```
 
 `IntrospectedError` extends `IntrospectedEnum`, so the 132 above includes the 9 error
-domains — which is usually what you want, and always worth knowing.
+domains. That is usually what you want, and always worth knowing.
 
 #### Properties: `writable`, `constructOnly`, and both spellings
 
-`cls.props` is the class's OWN properties — not the inherited chain. Each carries
+`cls.props` is the class's OWN properties, not the inherited chain. Each carries
 `writable`, `readable` and `constructOnly`, which is the distinction
 `X.ConstructorProps` does not make:
 
@@ -201,9 +199,9 @@ console.log(readOnly.join(", "));
 // has_default, hasDefault, has_focus, hasFocus, parent, root, scale_factor, scaleFactor
 ```
 
-Note the doubling. **The model carries every property twice — once `snake_case`, once
-`camelCase`** — because both are valid ways to reach it from generated bindings. Neither
-is GObject's own name: `g_object_set()` takes `has-default`, in kebab. If you are
+Note the doubling. **The model carries every property twice, once `snake_case` and once
+`camelCase`**, because both are valid ways to reach it from generated bindings. Neither
+is GObject's own name. `g_object_set()` takes `has-default`, in kebab. If you are
 emitting kebab keys, normalise and de-duplicate rather than mapping `props` one to one,
 or you emit two keys for one property.
 
@@ -214,8 +212,8 @@ writing one is exit 0.
 
 #### Enums and their nicks
 
-`enum.members` is a `Map` too, and `nick` is GIR's `glib:nick` — the string GObject
-itself accepts, which is what an attribute or a JSX prop carries:
+`enum.members` is a `Map` too. `nick` is GIR's `glib:nick`, the string GObject itself
+accepts, which is what an attribute or a JSX prop carries:
 
 ```ts
 const align = enums.find((e) => e.name === "Align")!;
@@ -224,19 +222,19 @@ console.log([...align.members.values()].map((m) => m.nick).join(" | "));
 ```
 
 Read the nick; do not derive it from the member name. The derivation that lowercases is
-wrong for 792 members across the 705 GIRs in `girs/` — see
-`scripts/check-nick-derivation.mjs`, which measures it and asserts the invariants.
+wrong for 876 members across the 718 GIRs in `girs/`. `scripts/check-nick-derivation.mjs`
+measures it and asserts the invariants.
 
 #### Running it
 
-**One hard constraint: these packages are deliberately build-step-free.**
+**One hard constraint. These packages are deliberately build-step-free.**
 `@ts-for-gir/lib`, `@ts-for-gir/cli` and `@gi.ts/parser` all resolve
 `exports["."]` to `./src/index.ts`, so importing one means importing TypeScript source.
 Your build has to compile or bundle it; plain Node cannot `import` it, and you must not
 put it in the `dependencies` of a package you publish, or every one of your consumers
-inherits raw TS. A `devDependency` you bundle is the seam that works.
+inherits raw TS. A `devDependency` you bundle is what works.
 
-For a one-off script, Node 24 runs the examples above directly — but only in the full
+For a one-off script, Node 24 runs the examples above directly, but only in the full
 transform mode:
 
 ```sh

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -139,7 +139,7 @@ constructor(
 
 - `reportProblem(problem: ProblemEntry): void` - Report a single problem
 - `reportProblems(problems: ProblemEntry[]): void` - Report multiple problems
-- `generateReport(): GenerationReport` - Generate comprehensive report
+- `generateReport(): GenerationReport` - Build the report over every recorded problem
 - `exportToFile(filename: string): Promise<void>` - Export report to file
 
 ### ReporterBase
@@ -164,7 +164,7 @@ Service for managing multiple reporter instances.
 
 ## Integration with ts-for-gir
 
-This package is designed to integrate seamlessly with the ts-for-gir generator system:
+Pass a reporter to `GirModule` and it collects every problem the generation run finds:
 
 ```typescript
 import { ConsoleReporter } from '@ts-for-gir/reporter';

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -22,7 +22,7 @@ Template collection for `ts-for-gir`. This package contains EJS templates and st
 
 ## Purpose
 
-The templates package serves as the template repository for the `ts-for-gir` ecosystem, providing:
+This package holds every template the generator writes from:
 
 - **EJS Templates**: Dynamic templates for generating TypeScript declaration files (.d.ts)
 - **Static Templates**: Pre-built type definitions for core GJS modules and runtime APIs


### PR DESCRIPTION
Stacked on #445, which is stacked on #444. Merge in that order.

Nine READMEs edited against the house rules for prose. No em dashes, no "serves as" where "is" works, no bullet list that would read the same in another project's repo.

## What was worth cutting

The lib README opened with this:

> Core library to generate TypeScript type definitions from GObject Introspection Repository (GIR) data. This package provides the foundation for processing, transforming, and generating TypeScript interfaces based on GIR definitions.

followed by a seven-bullet Features list ("Complete type system", "Extensible architecture with visitor pattern support") and a closing "This library serves as the core engine for the ts-for-gir toolchain".

None of it says anything you could not paste into any other code generator's README. It is now replaced by what the package holds, which types you import from it, and the fact that most people should not import it at all, because two cheaper routes are documented right below it.

Same shape in `generator-base`, `generator-html-doc`, `language-server`, `reporter` and `templates`, each of which had one "serves as the foundation" or "integrates seamlessly" paragraph doing no work.

## Two stale numbers

I re-measured these rather than adjusting them to look plausible:

- The nick-derivation claim said 792 members across 705 GIRs. The corpus is 718 GIRs now, and `gjsify run check:girs` counts 876 disagreements.
- The widget surface was "~158 KB against a 5.86 MB base .d.ts". Measured on the generated Gtk-4.0: 159 KB against 5.6 MB.

## The gate still holds

`check:docs` pins two things in `packages/lib/README.md`. The fenced `ts` blocks under section 3 have to run and print their `//` claims, and it finds that section by prefix match on the heading. The code blocks are untouched and the heading keeps its first six words, so the file is still held to its own output. `check` = 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ci5gmUojZSbm5JXkgwYKj