### PR TITLE
docs: plain prose in the remaining READMEs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -131,7 +131,7 @@ This collaborative approach helps us improve the quality of the type definitions
 
 | Example                                          | Description                              | Bundler |
 | ------------------------------------------------ | ---------------------------------------- | ------- |
-| [Virtual Interface Test](virtual-interface-test) | Comprehensive virtual interface examples | esbuild |
+| [Virtual Interface Test](virtual-interface-test) | Virtual interfaces, several shapes of them | esbuild |
 
 ## How to Run Examples
 
@@ -199,7 +199,7 @@ For more information on CLI options and type generation, see the [CLI documentat
 
 ## Contributing Examples
 
-Feel free to contribute new examples that showcase:
+New examples are welcome. Useful ones cover:
 - Different libraries from the GObject ecosystem
 - Different bundlers or build systems
 - Interesting UI patterns or application architectures

--- a/examples/gio-2-dbus/README.md
+++ b/examples/gio-2-dbus/README.md
@@ -22,7 +22,7 @@ const data = variant.deepUnpack<{ [key: string]: GLib.Variant }>();
 const data = variant.deepUnpack();
 ```
 
-Both approaches work simultaneously, providing seamless migration paths.
+Both work at the same time, so you can move one call site at a time.
 
 ### Benefits of Advanced Variants
 

--- a/examples/gio-2-list-model/README.md
+++ b/examples/gio-2-list-model/README.md
@@ -84,5 +84,5 @@ Item type: [object GObject_GType]
 
 ## Related Examples
 
-- [`virtual-interface-test`](../virtual-interface-test/): More comprehensive virtual interface examples
+- [`virtual-interface-test`](../virtual-interface-test/): more virtual interface cases
 - [`gtk-4-list-store`](../gtk-4-list-store/): Using list models with GTK widgets 

--- a/examples/gobject-static-block-ordering/README.md
+++ b/examples/gobject-static-block-ordering/README.md
@@ -1,4 +1,4 @@
-# GObject.registerClass — static-block ordering trap
+# GObject.registerClass, and the static-block ordering trap
 
 Reproducer for the bug behind [GNOME/gjs#704](https://gitlab.gnome.org/GNOME/gjs/-/work_items/704): a `GObject.registerClass()` call inside a `static { … }` block runs in source-order, so any `static [GObject.interfaces] = …` / `static [GObject.properties] = …` field declared **after** the block is invisible to `registerClass`. The result is silent at type-check time but blows up at runtime when an unregistered vfunc is invoked.
 
@@ -8,9 +8,9 @@ This example demonstrates three class shapes side-by-side and asserts each one b
 |---|---|---|
 | `BrokenFoo` | `static { registerClass }` first, `static [GObject.interfaces]` after | `Initable.init()` throws *Could not find definition of virtual function init* |
 | `WorkingFoo` | `static [GObject.interfaces]` first, `static { registerClass }` last | `init()` runs the vfunc body |
-| `InlineFoo` | metadata passed inline to `registerClass({ Implements: [...] }, Class)` | `init()` runs the vfunc body — no ordering question |
+| `InlineFoo` | metadata passed inline to `registerClass({ Implements: [...] }, Class)` | `init()` runs the vfunc body, so there is no ordering question |
 
-`InlineFoo` is the form `patterns/gobject-classes` on the website recommends, because the ordering rule is not enforceable at the type level — a refactor that moves a static field around silently breaks `WorkingFoo`'s pattern.
+`InlineFoo` is the form `patterns/gobject-classes` on the website recommends, because the ordering rule is not enforceable at the type level. A refactor that moves a static field around breaks `WorkingFoo`'s pattern, and nothing says so.
 
 ## Run
 
@@ -24,16 +24,16 @@ Expected output:
 
 ```
 ✓ BrokenFoo.init() threw as expected: Could not find definition of virtual function init
-[WorkingFoo] vfunc_init body — should print
+[WorkingFoo] vfunc_init body, should print
 ✓ WorkingFoo.init() ran the vfunc body
-[InlineFoo] vfunc_init body — should print
+[InlineFoo] vfunc_init body, should print
 ✓ InlineFoo.init() ran the vfunc body
 ```
 
-The script exits with status 1 if `BrokenFoo` doesn't throw — that's the regression assertion: if a future upstream gjs change fixes the bug, this example will start failing and we'll know to update the pattern guidance.
+The script exits with status 1 if `BrokenFoo` doesn't throw. That is the regression assertion. If a future gjs release fixes the bug, this example starts failing and the pattern guidance needs updating.
 
 ## See also
 
-- [Patterns → GObject classes](https://gjsify.github.io/gjsify/patterns/gobject-classes/) — full pattern reference covering the three `registerClass()` shapes, the recommended `registerClass({...}, this)` idiom, and when (rarely) `static override $gtype: GType<This>` is worth adding.
-- [`examples/gobject-param-spec`](../gobject-param-spec) — the recommended Form A in production-shaped use with the full ParamSpec surface.
-- [`examples/gobject-register-class-inference`](../gobject-register-class-inference) — Form C (functional / no static block) with type-inference assertions.
+- [Patterns → GObject classes](https://gjsify.github.io/gjsify/patterns/gobject-classes/): the full reference, covering the three `registerClass()` shapes, the recommended `registerClass({...}, this)` idiom, and when (rarely) `static override $gtype: GType<This>` is worth adding.
+- [`examples/gobject-param-spec`](../gobject-param-spec): Form A in production-shaped use, with the full ParamSpec set.
+- [`examples/gobject-register-class-inference`](../gobject-register-class-inference): Form C, functional and with no static block, plus type-inference assertions.

--- a/examples/gtk-4-signal-helpers/README.md
+++ b/examples/gtk-4-signal-helpers/README.md
@@ -6,11 +6,11 @@ meta-programming scenarios such as JSX runtimes.
 
 ## Key concepts
 
-* `$signals` — a **compile-time only** instance property that every
+* `$signals`, a **compile-time only** instance property that every
   `GObject.Object`-derived class now carries.  It exposes the
   `SignalSignatures` interface for that class and can be overridden in
   subclasses.
-* `GObject.SignalCallback<Emitter, Fn>` — helper that prepends the
+* `GObject.SignalCallback<Emitter, Fn>`, a helper that prepends the
   emitter (`this`) to the inline callback type.
 
 ## Direct usage

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -373,10 +373,10 @@ Examples:
                                             Export unresolved type errors to file
 ```
 
-The `analyze` command helps debug type generation issues by providing powerful filtering and analysis capabilities for ts-for-gir report files.
+`analyze` reads a report file and narrows it down. A full run reports thousands of problems; this is how you get to the twelve that concern you.
 
 **Key Features:**
-- **Comprehensive Filtering**: Filter by severity, category, namespace, type name, or search text
+- **Filtering.** By severity, category, namespace, type name, or free text
 - **Multiple Output Formats**: Table, JSON, or CSV format for different use cases
 - **Statistical Analysis**: Show most problematic types, namespaces, and categories
 - **Export Capabilities**: Save filtered results for further analysis

--- a/packages/cli/templates/types-gjsify/README.md
+++ b/packages/cli/templates/types-gjsify/README.md
@@ -1,6 +1,6 @@
 # __PROJECT_NAME__
 
-GJS + TypeScript starter, fully Node-free at runtime. Uses pre-generated [`@girs/*`](https://www.npmjs.com/org/girs) types and the [`gjsify` CLI](https://gjsify.github.io/gjsify/) for install, build, run, format and lint — no `npm`, no `node`, no `esbuild` ceremony.
+GJS + TypeScript starter, fully Node-free at runtime. Uses pre-generated [`@girs/*`](https://www.npmjs.com/org/girs) types and the [`gjsify` CLI](https://gjsify.github.io/gjsify/) for install, build, run, format and lint. No `npm`, no `node`, no `esbuild` setup.
 
 ## Setup
 

--- a/packages/cli/templates/types-workspace/README.md
+++ b/packages/cli/templates/types-workspace/README.md
@@ -14,13 +14,13 @@ npm start
 
 Or shorthand: `npm run build` runs all three steps in order.
 
-The application lives in [`packages/app/`](./packages/app/). Its dependencies on `@girs/*` are written as `"*"` which works across all three package managers — npm, yarn, pnpm all resolve to the locally generated workspace packages in `./@girs/`.
+The application lives in [`packages/app/`](./packages/app/). Its dependencies on `@girs/*` are written as `"*"`, which works across npm, yarn and pnpm. All three resolve to the locally generated workspace packages in `./@girs/`.
 
 ### About the dependency version format
 
 Two deliberate choices keep the template portable:
 
 1. **Generated `@girs/*` packages** reference each other via `^<version>` (not `workspace:^`). Controlled by `depVersionFormat: "caret"` in [`.ts-for-girrc.js`](./.ts-for-girrc.js). npm and yarn/pnpm all prefer the local workspace match; the registry is the fallback for transitive GIR packages outside your `modules` set.
-2. **Sub-package deps** (`packages/app/package.json`) use `"*"`. Same reasoning — all managers resolve to the local workspace.
+2. **Sub-package deps** (`packages/app/package.json`) use `"*"`. Same reasoning. All managers resolve to the local workspace.
 
 If you run yarn or pnpm exclusively and want strict workspace-only resolution, switch both: add `workspace: true` and `depVersionFormat: "workspace"` in `.ts-for-girrc.js`, plus `"workspace:^"` specs in `packages/app/package.json`. npm does **not** support the `workspace:` protocol.

--- a/packages/generator-base/README.md
+++ b/packages/generator-base/README.md
@@ -18,7 +18,7 @@
 
 # Generator Base
 
-This package defines the base interface that all generators in the ts-for-gir ecosystem must implement. It provides a common contract for various types of generators, ensuring they have a consistent API.
+Every generator in ts-for-gir implements the interface defined here, so the CLI can drive one without knowing which it got.
 
 ## Purpose
 
@@ -29,7 +29,7 @@ Every concrete generator extends the base class here:
 
 ## Interface
 
-The package defines a simple but powerful `Generator` interface with three lifecycle methods:
+The `Generator` interface has three lifecycle methods:
 
 ```typescript
 interface Generator {

--- a/packages/generator-json/README.md
+++ b/packages/generator-json/README.md
@@ -119,7 +119,7 @@ The JSON output can be useful for:
 ## Integration
 
 The JSON generator integrates with the ts-for-gir ecosystem through:
-- **Reporter System**: Comprehensive logging and error reporting
+- **Reporter system**: logs and error reporting, shared with the rest of the toolchain
 - **Generator Interface**: Standard lifecycle methods (`start`, `generate`, `finish`)
 - **TypeDoc**: Programmatic usage of TypeDoc for JSON serialization with custom `SerializerComponent`
 - **Configuration**: Respects all standard ts-for-gir options and settings

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -5,16 +5,18 @@
 <img src="https://img.shields.io/npm/dw/@ts-for-gir/reporter" />
 </p>
 
-Comprehensive reporting system for the ts-for-gir project that provides structured problem tracking, statistics generation, and flexible output formatting with dependency injection pattern.
+A generation run turns up hundreds of small problems: a type that will not
+resolve, a name that collides with an inherited one, a namespace that is not
+where its dependency says it is. This package collects them.
 
-## Features
+Every problem carries a severity and a category, so a run of 700 namespaces can
+be read as "17 critical type_resolution issues in Gdaui" rather than as scroll.
+`ConsoleReporter` prints them; the same entries serialise to JSON for
+`ts-for-gir analyze` to filter later.
 
-- **🔧 Dependency Injection**: Abstract base class with configurable reporter implementations
-- **📊 Problem Tracking**: Structured tracking of type resolution issues, conflicts, and generation problems
-- **📈 Statistics**: Comprehensive statistics collection and reporting
-- **🎨 Flexible Output**: Multiple output formats (console, files) with colorized output
-- **🔍 Categorization**: Problems are categorized by severity and type for better analysis
-- **💾 Export Capabilities**: Export reports to JSON, text, or custom formats
+Reporters are passed in rather than reached for. `GirModule` takes one, which is
+how the generator writes to a console reporter, a file reporter, or a test
+double without knowing the difference.
 
 ## Installation
 
@@ -104,18 +106,18 @@ const consolidatedReport = service.generateConsolidatedReport();
 
 The reporter system categorizes problems into the following types:
 
-- **TYPE_RESOLUTION**: Issues with resolving types from GIR data
-- **TYPE_CONFLICT**: Conflicts between different type definitions
-- **GENERATION_ERROR**: Errors during TypeScript generation
-- **VALIDATION_WARNING**: Validation warnings for generated code
-- **DEPENDENCY_ISSUE**: Problems with dependency resolution
-- **DOCUMENTATION_MISSING**: Missing or incomplete documentation
+- `TYPE_RESOLUTION`: Issues with resolving types from GIR data
+- `TYPE_CONFLICT`: Conflicts between different type definitions
+- `GENERATION_ERROR`: Errors during TypeScript generation
+- `VALIDATION_WARNING`: Validation warnings for generated code
+- `DEPENDENCY_ISSUE`: Problems with dependency resolution
+- `DOCUMENTATION_MISSING`: Missing or incomplete documentation
 
 ## Problem Severities
 
-- **ERROR**: Critical issues that prevent successful generation
-- **WARNING**: Issues that may affect quality but don't block generation
-- **INFO**: Informational messages for debugging and analysis
+- `ERROR`: Critical issues that prevent successful generation
+- `WARNING`: Issues that may affect quality but don't block generation
+- `INFO`: Informational messages for debugging and analysis
 
 ## API Reference
 

--- a/packages/templates/templates/README-GJS.md
+++ b/packages/templates/templates/README-GJS.md
@@ -6,11 +6,11 @@
 
 <%- PACKAGE_DESC %> using [<%- APP_NAME %>](<%- APP_SOURCE %>) v<%- APP_VERSION %>.
 
-[GJS](https://gitlab.gnome.org/GNOME/gjs) is a JavaScript runtime for the GNOME ecosystem. Using GJS and the type definitions in this NPM package, you can build GTK applications in JavaScript or TypeScript with type checking, better autocompletion and inline documentations.
+[GJS](https://gitlab.gnome.org/GNOME/gjs) is GNOME's JavaScript runtime. With these type definitions your editor knows the GTK API: it type-checks calls, completes method names, and shows the upstream C documentation inline.
 
 ## Install
 
-To use this type definitions, install them with NPM:
+Install the type definitions with npm:
 ```bash
 npm install <%- npmScope %>/<%- importName %>
 ```
@@ -22,12 +22,12 @@ npm install <%- npmScope %>/<%- importName %>
 
 ## Usage
 
-You can import this package into your project like this:
+Import it like any other module:
 ```ts
 import <%- pkg.namespace %> from '<%- pkg.importPath %>';
 ```
 
-Or if you prefer CommonJS, you can also use this:
+For CommonJS:
 ```ts
 const <%- pkg.namespace %> = require('<%- pkg.importPath %>');
 ```
@@ -49,7 +49,7 @@ const ByteArray = imports.byteArray;
 ### Global DOM types
 
 Some types that conflict with the DOM are outsourced to allow frameworks like Gjsify to rebuild the DOM API without causing type conflicts.
-But you can easily import them:
+Import them explicitly:
 
 ```ts
 import '@girs/gjs/dom';
@@ -66,11 +66,11 @@ setTimeout(() => {
 // And so on...
 ```
 
-To avoid a type conflict with the DOM types it is recommended to either modify your `tsconfig.json` or `jsconfig.json` file to exclude the DOM lib, or to enable the `noLib` property.
+These collide with the DOM types. Exclude the DOM lib in your `tsconfig.json` or `jsconfig.json`, or set `noLib`.
 
 ### Ambient Modules
 
-You can import the built in [ambient modules](https://github.com/gjsify/ts-for-gir/tree/main/packages/cli#ambient-modules) of GJS.
+GJS's built-in [ambient modules](https://github.com/gjsify/ts-for-gir/tree/main/packages/cli#ambient-modules) are importable too.
 For this you need to include the `<%- npmScope %>/<%- importName %>` or `<%- npmScope %>/<%- importName %>/ambient` in your `tsconfig` or entry point Typescript file:
     
 `index.ts`:
@@ -89,7 +89,7 @@ import '<%- npmScope %>/<%- importName %>'
 }
 ```
 
-Now you can import `gettext`, `system` and `cairo` in ESM style with Typescript support:
+`gettext`, `system` and `cairo` now resolve as ESM imports, with types:
 
 ```ts
 import gettext from 'gettext';
@@ -122,7 +122,7 @@ const button = new Gtk.Button();
 
 ### Bundle
 
-Depending on your project configuration, it is recommended to use a bundler like [esbuild](https://esbuild.github.io/). You can find examples using different bundlers [here](https://github.com/gjsify/ts-for-gir/tree/main/examples).
+Most projects want a bundler. [esbuild](https://esbuild.github.io/) is the smallest thing that works; the [examples directory](https://github.com/gjsify/ts-for-gir/tree/main/examples) has setups for several others.
 
 ## Other packages
 

--- a/packages/templates/templates/README.md
+++ b/packages/templates/templates/README.md
@@ -9,7 +9,7 @@
 
 ## Install
 
-To use this type definitions, install them with NPM:
+Install the type definitions with npm:
 ```bash
 npm install <%- npmScope %>/<%- importName %>
 ```
@@ -20,14 +20,14 @@ npm install <%- npmScope %>/<%- importName %>
 <%_ } _%>
 ## Usage
 
-You can import this package into your project like this:
+Import it like any other module:
 ```ts
 import <%- pkg.namespace %> from '<%- pkg.importPath %>';
 ```
 
 ### Ambient Modules
 
-You can also use [ambient modules](https://github.com/gjsify/ts-for-gir/tree/main/packages/cli#ambient-modules) to import this module like you would do this in JavaScript.
+[Ambient modules](https://github.com/gjsify/ts-for-gir/tree/main/packages/cli#ambient-modules) let you write the same import you would in plain JavaScript.
 For this you need to include `<%- npmScope %>/<%- importName %>` or `<%- npmScope %>/<%- importName %>/ambient` in your `tsconfig` or entry point Typescript file:
 
 `index.ts`:
@@ -46,7 +46,7 @@ import '<%- npmScope %>/<%- importName %>'
 }
 ```
 
-Now you can import the ambient module with TypeScript support: 
+The ambient module now resolves with types:
 
 ```ts
 import <%= pkg.namespace %> from 'gi://<%= pkg.namespace %>?version=<%= pkg.version %>';
@@ -54,7 +54,7 @@ import <%= pkg.namespace %> from 'gi://<%= pkg.namespace %>?version=<%= pkg.vers
 
 ### Global import
 
-You can also import the module with Typescript support using the global `imports.gi` object of GJS.
+GJS's global `imports.gi` works too, with types.
 For this you need to include `<%- npmScope %>/<%- importName %>` or `<%- npmScope %>/<%- importName %>/import` in your `tsconfig` or entry point Typescript file:
 
 `index.ts`:
@@ -73,7 +73,7 @@ import '<%- npmScope %>/<%- importName %>'
 }
 ```
 
-Now you have also type support for this, too:
+That form carries types as well:
 
 ```ts
 const <%= pkg.namespace %> = imports.gi.<%= pkg.namespace %>;
@@ -81,7 +81,7 @@ const <%= pkg.namespace %> = imports.gi.<%= pkg.namespace %>;
 
 ### Bundle
 
-Depending on your project configuration, it is recommended to use a bundler like [esbuild](https://esbuild.github.io/). You can find examples using different bundlers [here](https://github.com/gjsify/ts-for-gir/tree/main/examples).
+Most projects want a bundler. [esbuild](https://esbuild.github.io/) is the smallest thing that works; the [examples directory](https://github.com/gjsify/ts-for-gir/tree/main/examples) has setups for several others.
 
 ## Other packages
 

--- a/tests/language-server-validation/README.md
+++ b/tests/language-server-validation/README.md
@@ -1,6 +1,6 @@
 # Language Server Validation Tests
 
-This package provides validation tests for TypeScript type generation in ts-for-gir, ensuring the generated type definitions work correctly with the TypeScript language server.
+These tests load generated type definitions into the TypeScript language server and ask it what it sees. A definition that compiles can still give the wrong hover, the wrong completion, or the wrong inferred type, and only the language server can tell you.
 
 ## Purpose
 
@@ -9,7 +9,7 @@ Tests the correct TypeScript type generation for GIR (GObject Introspection) bin
 - **GLib.Variant Types**: Testing variant unpacking methods and type inference
 - **Type Generation Issues**: Validating fixes for known problems from PRs
 - **Advanced Type Features**: Testing with different configuration options
-- **Real-world Usage Patterns**: Ensuring common patterns work as expected
+- **Real-world usage patterns.** The shapes people actually write, not the ones easiest to assert on
 
 ## Running Tests
 


### PR DESCRIPTION
Second pass, on top of #446 which you just merged. Every tracked README rather than the three biggest. Fourteen files, mostly small.

## Two of these ship

`packages/templates/templates/README.md` and `README-GJS.md` are emitted into every generated `@girs/*` package, so their prose is what 703 npm pages show a first-time visitor. Both had:

- "To use this type definitions, install them with NPM"
- "You can import this package into your project like this"
- "Now you have also type support for this, too"
- "Depending on your project configuration, it is recommended to use a bundler like esbuild", which hedges its way out of making a recommendation

They now say what to run and what happens.

## The reporter README

It opened with "Comprehensive reporting system for the ts-for-gir project that provides structured problem tracking, statistics generation, and flexible output formatting with dependency injection pattern", then six emoji-prefixed Features bullets.

Replaced with what the package is for. A generation run turns up hundreds of small problems, and this collects them with a severity and a category, so 700 namespaces read as "17 critical type_resolution issues in Gdaui" instead of as scroll. Its enum members were bolded; they are identifiers, so they are code spans now.

## One that was missing its reason

The language-server test README said it "provides validation tests ... ensuring the generated type definitions work correctly", without saying why a language server is involved at all. It is because a definition that compiles can still give the wrong hover, the wrong completion, or the wrong inferred type, and only the language server can tell you that.

## Rest

`generator-base`, `generator-json`, `examples/README.md`, `examples/gio-2-dbus`, `examples/gio-2-list-model`, `examples/gobject-static-block-ordering`, `examples/gtk-4-signal-helpers`, `packages/cli`, and both `types-*` scaffold templates. One line to a paragraph each.

Every em dash is gone from prose across all 32 tracked READMEs. One remains in generator-json's table, where the cell means "none".

`check:docs` = 0, so the lib README still prints what its comments claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ci5gmUojZSbm5JXkgwYKj