### PR TITLE
fix(ci): give the docs build room for a growing corpus

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -66,14 +66,22 @@ jobs:
         # the parent ts-for-gir version on each release run).
         git checkout -B main origin/main
 
+    # `NODE_OPTIONS`: TypeDoc holds the whole corpus in memory, and the corpus
+    # grows every cycle. v4.3.0 added GNOME 51, taking it from 703 namespaces to
+    # 716, and `build:doc` died at 3.8 GB against Node's ~4 GB default with
+    # "Ineffective mark-compacts near heap limit". `build:json` survived the same
+    # run, which is the reason both steps get the headroom rather than only the
+    # one that happened to fail first. The runner has 16 GB.
     - name: Generate JSON files
       env:
         WS_PATH: ${{ github.workspace }}
+        NODE_OPTIONS: --max-old-space-size=12288
       run: PATH="$WS_PATH/node_modules/.bin:$PATH" gjsify run build:json
 
     - name: Generate HTML documentation
       env:
         WS_PATH: ${{ github.workspace }}
+        NODE_OPTIONS: --max-old-space-size=12288
       run: PATH="$WS_PATH/node_modules/.bin:$PATH" gjsify run build:doc
 
     - name: Check for changes in docs submodule


### PR DESCRIPTION
`Release Docs` for v4.3.0 failed. `build:doc` ran out of heap:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
Mark-Compact 3839.5 (4130.3) -> 3805.5 (4109.3) MB
```

TypeDoc holds the whole corpus in memory, and the corpus grows every cycle. GNOME 51 took it from 703 namespaces to 716, plus the widget surfaces, and that was enough to cross Node's ~4 GB default.

Both TypeDoc steps get the headroom, not only the one that failed. `build:json` survived this run, but it walks the same corpus and it survived by margin rather than by design. The runner has 16 GB.

## Scope

Nothing about the npm publish was affected. Release App and Release Types both finished, `@ts-for-gir/cli` and `@ts-for-gir/lib` are on 4.3.0, and the `@girs/*` sweep is running. Only the documentation site is stale until this lands and I re-dispatch `Release Docs` for `v4.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ci5gmUojZSbm5JXkgwYKj