### PR TITLE
feat(gir-files): publish the original GIR XML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ repo/
 # Staging dir of scripts/fetch-fedora-girs.sh (container harvest, reviewed then
 # copied into girs/ — never a source of truth on its own)
 .fedora-girs-*/
+
+# Generated payload of packages/gir-files (rebuilt by build:app from girs/).
+# NOTICE.md and provenance.json ARE committed: they are the licence record and
+# have to be reviewable in a diff.
+packages/gir-files/payload/

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "update:submodules": "git submodule foreach git pull",
     "update:packages": "gjsify upgrade --latest",
     "update": "gjsify run update:submodules && gjsify run update:packages",
-    "publish:app": "gjsify run build:app && gjsify foreach -v -p --no-private --include '@ts-for-gir/*' --include '@gi.ts/*' --exec -- gjsify publish --trusted --tolerate-republish --tag latest --access public --provenance",
+    "publish:app": "gjsify run build:app && gjsify foreach -v -p --no-private --include '@ts-for-gir/*' --include '@gi.ts/*' --exec -- gjsify publish --trusted --tolerate-untrusted-new --tolerate-republish --tag latest --access public --provenance",
     "publish:types": "gjsify foreach -v -p --no-private --include '@girs/*' --exec -- gjsify publish --tolerate-republish --tag latest --access public",
     "publish": "gjsify run publish:app && gjsify run publish:types",
     "test:types": "gjsify run build:types && gjsify run check:types",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "ts-for-gir-dev",
     "start:prod": "ts-for-gir",
     "format": "gjsify fix",
-    "build:app": "gjsify workspace @ts-for-gir/cli build",
+    "build:app": "gjsify workspace @ts-for-gir/cli build && gjsify workspace @ts-for-gir/gir-files build",
     "build:app:gjs": "gjsify workspace @ts-for-gir/cli build:gjs",
     "build:examples": "gjsify foreach build -v -p --include '@ts-for-gir-example/*'",
     "build:types": "ts-for-gir-dev generate --configName='.ts-for-gir.packages-all.rc.js' --girDirectories='./girs' --workspace=true --outdir='./types-dev' && gjsify install",

--- a/packages/gir-files/NOTICE.md
+++ b/packages/gir-files/NOTICE.md
@@ -1,0 +1,639 @@
+# NOTICE — third-party content in `@ts-for-gir/gir-files`
+
+This package redistributes **GObject Introspection (GIR) XML files that this project did
+not author**. They are verbatim copies of files shipped by upstream projects and by the
+Fedora packages built from them.
+
+## Licensing
+
+The packaging around them — `src/`, `scripts/`, `provenance.json` — is **Apache-2.0**,
+like the rest of ts-for-gir.
+
+The `payload/` files are **not**. Each carries the licence of the project it was generated
+from, and those are predominantly copyleft. The table below records, for every file in this
+package, the licence expression declared by the upstream source it came from. That is why
+`package.json` says `"license": "SEE LICENSE IN NOTICE.md"` rather than naming one licence:
+no single identifier is true of this package's contents.
+
+**This table is evidence, not a legal determination.** A distribution's `License:` tag is an
+expression covering everything in that package, not a per-file finding, and nothing here is
+legal advice. If you redistribute these files onward, satisfy the terms below yourself.
+
+Files that no source could attribute are **not included** in this package. See
+`provenance.json` → `unattributed` for what was left out and why.
+
+## Licence expressions present (93 distinct, over 510 files)
+
+- `LGPL-2.1-or-later` — 114 file(s)
+- `GPL-2.0-or-later` — 103 file(s)
+- `LGPL-2.0-or-later` — 46 file(s)
+- `LicenseRef-Callaway-LGPLv2+` — 30 file(s)
+- `LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note` — 19 file(s)
+- `GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause` — 14 file(s)
+- `LGPL-3.0-or-later` — 13 file(s)
+- `GPL-3.0-or-later` — 10 file(s)
+- `MIT` — 7 file(s)
+- `GPL-2.0-or-later AND LGPL-2.1-or-later` — 6 file(s)
+- `LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0` — 6 file(s)
+- `GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+` — 5 file(s)
+- `LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1` — 5 file(s)
+- `Apache-2.0` — 4 file(s)
+- `LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later` — 4 file(s)
+- `GPL-3.0-or-later AND LGPL-3.0-or-later` — 4 file(s)
+- `LGPL-2.1-or-later AND CC-BY-SA-3.0` — 4 file(s)
+- `LicenseRef-Callaway-LGPLv2` — 3 file(s)
+- `GPL-3.0-or-later AND AGPL-3.0-or-later AND LicenseRef-Callaway-GFDL` — 3 file(s)
+- `GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later` — 3 file(s)
+- `(LGPL-3.0-only OR LGPL-2.1-only) AND GPL-3.0-only` — 3 file(s)
+- `LGPL-2.1-or-later AND Apache-2.0` — 3 file(s)
+- `LGPL-2.1-or-later AND LicenseRef-Fedora-Public-Domain AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs` — 3 file(s)
+- `LGPL-2.1-only` — 3 file(s)
+- `GPL-3.0-only` — 3 file(s)
+- `LGPL-3.0-only AND LGPL-2.1-or-later` — 3 file(s)
+- `GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-MIT` — 2 file(s)
+- `GPL-3.0-only AND LGPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only)` — 2 file(s)
+- `GPL-3.0-or-later AND LGPL-2.0-or-later AND GPL-2.0-only AND CC-BY-SA-2.0 AND GPL-2.0-or-later WITH GStreamer-exception-2008` — 2 file(s)
+- `GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later AND CC0-1.0 AND CC-BY-SA-4.0` — 2 file(s)
+- `GPL-3.0-or-later AND LGPL-2.1-or-later` — 2 file(s)
+- `LGPL-3.0-only` — 2 file(s)
+- `GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND X11 AND MIT AND Afmparse` — 2 file(s)
+- `LicenseRef-Callaway-LGPLv2+ AND GPL-2.0-or-later` — 2 file(s)
+- `GPL-3.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0` — 2 file(s)
+- `LGPL-2.0-or-later AND GPL-2.0-or-later` — 2 file(s)
+- `BSD-2-Clause` — 2 file(s)
+- `LGPL-2.1-or-later AND CC0-1.0` — 2 file(s)
+- `LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-GFDL` — 2 file(s)
+- `LGPL-2.1-or-later AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs` — 2 file(s)
+- `GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND MIT` — 2 file(s)
+- `(MPL-2.0 OR LGPL-2.1-or-later) AND Apache-2.0 WITH LLVM-exception AND BSD-3-Clause AND CC0-1.0 AND GPL-3.0-or-later AND IJG AND ISC AND MIT AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)` — 2 file(s)
+- `LGPL-2.1-only OR MPL-2.0` — 2 file(s)
+- `GPL-2.0-or-later AND CC0-1.0 AND MIT` — 2 file(s)
+- `LGPL-2.1-only AND CC-BY-3.0` — 2 file(s)
+- `GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT AND libtiff AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND LicenseRef-BSD-2-Clause-WITH-AdditionRef-AOMPL-1.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND Zlib AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause AND ISC) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)` — 2 file(s)
+- `LGPL-2.0-only` — 2 file(s)
+- `LGPL-2.1-or-later AND MIT AND MIT-open-group and BSD-3-Clause` — 2 file(s)
+- `LGPL-2.1-or-later AND MIT` — 1 file(s)
+- `LicenseRef-Callaway-LGPLv2 AND LGPL-3.0-only` — 1 file(s)
+- `LGPL-2.0-or-later AND GPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only)` — 1 file(s)
+- `LGPL-3.0-or-later AND GPL-3.0-or-later` — 1 file(s)
+- `GPL-2.0-only OR GPL-3.0-only` — 1 file(s)
+- `LGPL-2.1-only AND LGPL-2.1-or-later` — 1 file(s)
+- `GPL-2.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0` — 1 file(s)
+- `LGPL-2.1-or-later AND NIST-PD` — 1 file(s)
+- `LicenseRef-Callaway-BSD AND GPL-3.0-or-later` — 1 file(s)
+- `GPL-2.0-or-later and LGPL-2.0-or-later` — 1 file(s)
+- `GPL-2.0-or-later AND BSD-3-Clause` — 1 file(s)
+- `zlib` — 1 file(s)
+- `BSD-3-Clause AND GPL-2.0-or-later` — 1 file(s)
+- `GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND GFDL-1.1-or-later` — 1 file(s)
+- `LGPL-2.0-or-later AND BSD-3-Clause` — 1 file(s)
+- `LGPL-2.1-or-later AND GPL-3.0-or-later` — 1 file(s)
+- `LGPL-2.0-or-later AND LGPL-2.1-or-later AND GPL-2.0-or-later` — 1 file(s)
+- `GPL-3.0-or-later AND GFDL-1.3-or-later AND CC0-1.0` — 1 file(s)
+- `GPL-2.0-or-later AND CC0-1.0` — 1 file(s)
+- `LGPL-2.0-or-later AND CC-BY-SA-4.0` — 1 file(s)
+- `LGPL-2.1-or-later AND GFDL-1.1-or-later` — 1 file(s)
+- `LGPL-2.0-or-later AND LGPL-2.1-only` — 1 file(s)
+- `LGPL-3.0-or-later and MIT` — 1 file(s)
+- `GPL-3.0-or-later AND MIT` — 1 file(s)
+- `GPL-3.0-or-later AND GFDL-1.3-or-later AND Unicode-DFS-2016` — 1 file(s)
+- `MIT-Modern-Variant` — 1 file(s)
+- `GPL-2.0-or-later AND GFDL-1.1-no-invariants-or-later AND CC-BY-SA-4.0` — 1 file(s)
+- `GPL-3.0-or-later AND GPL-2.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later AND LGPL-2.0-or-later AND MIT AND CC0-1.0 AND CC-BY-3.0` — 1 file(s)
+- `(LGPL-2.1-or-later OR MIT) AND (Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND MIT AND (MIT OR Apache-2.0) AND (Unlicense OR MIT)` — 1 file(s)
+- `LGPL-3.0-or-later OR MPL-2.0` — 1 file(s)
+- `GPL-2.0-or-later AND LGPL-2.0-or-later` — 1 file(s)
+- `(LGPL-2.0-only OR LGPL-3.0-only) AND GPL-3.0-or-later` — 1 file(s)
+- `ISC` — 1 file(s)
+- `LGPL-2.1-or-later OR MPL-1.1` — 1 file(s)
+- `GPL-2.0-or-later AND LGPL-2.1-or-later AND FSFAP` — 1 file(s)
+- `(GPL-2.0-only OR GPL-3.0-only) AND GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT` — 1 file(s)
+- `LGPL-2.1-or-later AND Apache-2.0 AND BSD-3-Clause AND MIT AND MPL-2.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)` — 1 file(s)
+- `LGPL-2.1-or-later AND Apache-2.0 AND (GPL-2.0-or-later OR TGPPL-1.0) AND LicenseRef-Fedora-Public-Domain AND GCR-docs` — 1 file(s)
+- `LGPL-2.1-or-later AND LGPL-2.0-or-later` — 1 file(s)
+- `LGPL-2.0-only OR LGPL-3.0-only` — 1 file(s)
+- `LGPL-2.0-or-later AND LGPL-2.1-or-later` — 1 file(s)
+- `GPL-2.0-or-later WITH GStreamer-exception-2008 AND CC0-1.0 AND (LGPL-2.0-or-later AND LGPL-2.1-or-later WITH GStreamer-exception-2005)` — 1 file(s)
+- `GPL-2.0-or-later AND (GPL-2.0-or-later WITH GStreamer-exception-2008) AND LGPL-2.0-or-later AND CC0-1.0` — 1 file(s)
+- `LGPL-2.0-or-later AND (LGPL-2.1-or-later WITH GStreamer-exception-2005)` — 1 file(s)
+- `GPL-2.0-only` — 1 file(s)
+
+## Per-file attribution
+
+| Namespace | Declared licence | Origin | Upstream |
+|---|---|---|---|
+| `Abi-3.0` | GPL-2.0-or-later | libabiword-devel (fedora) | [link](https://gitlab.gnome.org/World/AbiWord) |
+| `Accounts-1.0` | LicenseRef-Callaway-LGPLv2 | libaccounts-glib-devel (fedora) | [link](https://gitlab.com/accounts-sso/libaccounts-glib) |
+| `AccountsService-1.0` | GPL-3.0-or-later | accountsservice-devel (fedora) | [link](https://www.freedesktop.org/wiki/Software/AccountsService/) |
+| `Adw-1` | LGPL-2.1-or-later AND MIT | libadwaita-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libadwaita) |
+| `Ags-8.0` | GPL-3.0-or-later AND AGPL-3.0-or-later AND LicenseRef-Callaway-GFDL | gsequencer-devel (fedora) | [link](http://nongnu.org/gsequencer) |
+| `AgsAudio-8.0` | GPL-3.0-or-later AND AGPL-3.0-or-later AND LicenseRef-Callaway-GFDL | gsequencer-devel (fedora) | [link](http://nongnu.org/gsequencer) |
+| `AgsGui-8.0` | GPL-3.0-or-later AND AGPL-3.0-or-later AND LicenseRef-Callaway-GFDL | gsequencer-devel (fedora) | [link](http://nongnu.org/gsequencer) |
+| `Amtk-5` | LGPL-3.0-or-later | libgedit-amtk-devel (fedora) | [link](https://gedit-text-editor.org/) |
+| `Anjuta-3.0` | GPL-2.0-or-later | anjuta-devel (fedora) | [link](http://www.anjuta.org/) |
+| `Anthy-9000` | GPL-2.0-or-later | ibus-anthy-devel (fedora) | [link](https://github.com/ibus/ibus/wiki) |
+| `AppIndicator3-0.1` | LicenseRef-Callaway-LGPLv2 AND LGPL-3.0-only | libappindicator-gtk3-devel (fedora) | [link](https://launchpad.net/libappindicator) |
+| `AppStream-1.0` | GPL-2.0-or-later AND LGPL-2.1-or-later | appstream-devel (fedora) | [link](https://github.com/ximion/appstream) |
+| `AppStreamCompose-1.0` | GPL-2.0-or-later AND LGPL-2.1-or-later | appstream-compose-devel (fedora) | [link](https://github.com/ximion/appstream) |
+| `AppStreamGlib-1.0` | LGPL-2.1-or-later | libappstream-glib-devel (fedora) | [link](http://people.freedesktop.org/~hughsient/appstream-glib/) |
+| `Arrow-23.0` | Apache-2.0 | libarrow-glib-devel (fedora) | [link](https://arrow.apache.org/) |
+| `ArrowDataset-23.0` | Apache-2.0 | libarrow-dataset-glib-devel (fedora) | [link](https://arrow.apache.org/) |
+| `ArrowFlight-23.0` | Apache-2.0 | libarrow-flight-devel (fedora) | [link](https://arrow.apache.org/) |
+| `Atk-1.0` | LGPL-2.1-or-later | atk-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/at-spi2-core/) |
+| `AtrilDocument-1.5.0` | GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-MIT | atril-devel (fedora) | [link](http://mate-desktop.org) |
+| `AtrilView-1.5.0` | GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-MIT | atril-devel (fedora) | [link](http://mate-desktop.org) |
+| `Atspi-2.0` | LGPL-2.1-or-later | at-spi2-core-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/at-spi2-core/) |
+| `AyatanaAppIndicator-0.1` | GPL-3.0-only AND LGPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only) | libayatana-appindicator-gtk2-devel (fedora) | [link](https://github.com/AyatanaIndicators/libayatana-appindicator) |
+| `AyatanaAppIndicator3-0.1` | GPL-3.0-only AND LGPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only) | libayatana-appindicator-gtk3-devel (fedora) | [link](https://github.com/AyatanaIndicators/libayatana-appindicator) |
+| `AyatanaIdo3-0.4` | LGPL-2.0-or-later AND GPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only) | libayatana-ido-gtk3-devel (fedora) | [link](https://github.com/AyatanaIndicators/ayatana-ido) |
+| `Babl-0.1` | LGPL-3.0-or-later AND GPL-3.0-or-later | babl-devel (fedora) | [link](https://www.gegl.org/babl/) |
+| `Bamf-3` | GPL-2.0-only OR GPL-3.0-only | bamf-devel (fedora) | [link](https://launchpad.net/bamf) |
+| `BlockDev-3.0` | LGPL-2.1-or-later | libblockdev-devel (fedora) | [link](https://github.com/storaged-project/libblockdev) |
+| `BraseroBurn-3.1` | GPL-3.0-or-later AND LGPL-2.0-or-later AND GPL-2.0-only AND CC-BY-SA-2.0 AND GPL-2.0-or-later WITH GStreamer-exception-2008 | brasero-devel (fedora) | [link](https://wiki.gnome.org/Apps/Brasero) |
+| `BraseroMedia-3.1` | GPL-3.0-or-later AND LGPL-2.0-or-later AND GPL-2.0-only AND CC-BY-SA-2.0 AND GPL-2.0-or-later WITH GStreamer-exception-2008 | brasero-devel (fedora) | [link](https://wiki.gnome.org/Apps/Brasero) |
+| `Budgie-3.0` | GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later AND CC0-1.0 AND CC-BY-SA-4.0 | budgie-desktop-devel (fedora) | [link](https://github.com/BuddiesOfBudgie/budgie-desktop) |
+| `BudgieRaven-3.0` | GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later AND CC0-1.0 AND CC-BY-SA-4.0 | budgie-desktop-devel (fedora) | [link](https://github.com/BuddiesOfBudgie/budgie-desktop) |
+| `CDesktopEnums-3.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later | cinnamon-desktop-devel (fedora) | [link](https://github.com/linuxmint/cinnamon-desktop) |
+| `CMenu-3.0` | LGPL-2.0-or-later | cinnamon-menus-devel (fedora) | [link](https://github.com/linuxmint/cinnamon-menus) |
+| `Caja-2.0` | GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ | caja-devel (fedora) | [link](http://mate-desktop.org) |
+| `Cally-1.0` | LicenseRef-Callaway-LGPLv2+ | clutter-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `CambalachePrivate-3.0` | LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later | cambalache (fedora) | [link](https://gitlab.gnome.org/jpu/cambalache) |
+| `CambalachePrivate-4.0` | LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later | cambalache (fedora) | [link](https://gitlab.gnome.org/jpu/cambalache) |
+| `Camel-1.2` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `Caribou-1.0` | LicenseRef-Callaway-LGPLv2+ | caribou-devel (fedora) | [link](https://wiki.gnome.org/Projects/Caribou) |
+| `Casilda-1.0` | LGPL-2.1-only AND LGPL-2.1-or-later | casilda-devel (fedora) | [link](https://gitlab.gnome.org/jpu/casilda) |
+| `Champlain-0.12` | LicenseRef-Callaway-LGPLv2+ | libchamplain-devel (fedora) | [link](https://wiki.gnome.org/Projects/libchamplain) |
+| `CinnamonDesktop-3.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later | cinnamon-desktop-devel (fedora) | [link](https://github.com/linuxmint/cinnamon-desktop) |
+| `Clapper-0.0` | GPL-3.0-or-later AND LGPL-2.1-or-later | clapper-devel (fedora) | [link](https://github.com/Rafostar/clapper) |
+| `ClapperGtk-0.0` | GPL-3.0-or-later AND LGPL-2.1-or-later | clapper-devel (fedora) | [link](https://github.com/Rafostar/clapper) |
+| `CloudProviders-0.3` | LGPL-3.0-or-later | libcloudproviders-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libcloudproviders) |
+| `Clutter-1.0` | LicenseRef-Callaway-LGPLv2+ | clutter-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `Clutter-10` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-11` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-12` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-13` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-14` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-15` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-16` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-17` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-18` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-3` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-4` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-5` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-51` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-6` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-7` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-8` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Clutter-9` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `ClutterGdk-1.0` | LicenseRef-Callaway-LGPLv2+ | clutter-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `ClutterGst-3.0` | LicenseRef-Callaway-LGPLv2+ | clutter-gst3-devel (fedora) | [link](https://developer.gnome.org/clutter-gst/stable/) |
+| `ClutterX11-1.0` | LicenseRef-Callaway-LGPLv2+ | clutter-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `CmbCatalogUtils-3.0` | LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later | cambalache (fedora) | [link](https://gitlab.gnome.org/jpu/cambalache) |
+| `CmbCatalogUtils-4.0` | LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later | cambalache (fedora) | [link](https://gitlab.gnome.org/jpu/cambalache) |
+| `Cogl-1.0` | LicenseRef-Callaway-LGPLv2+ | cogl-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `Cogl-10` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-11` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-12` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-13` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-14` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-15` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-16` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-17` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-18` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-2.0` | LicenseRef-Callaway-LGPLv2+ | cogl-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `Cogl-3` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-4` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-5` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-51` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-6` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-7` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-8` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Cogl-9` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `CoglPango-1.0` | LicenseRef-Callaway-LGPLv2+ | cogl-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `CoglPango-2.0` | LicenseRef-Callaway-LGPLv2+ | cogl-devel (fedora) | [link](http://www.clutter-project.org/) |
+| `Colord-1.0` | GPL-2.0-or-later AND LGPL-2.1-or-later | colord-devel (fedora) | [link](https://www.freedesktop.org/software/colord/) |
+| `ColordGtk-1.0` | LGPL-2.1-or-later | colord-gtk-devel (fedora) | [link](http://www.freedesktop.org/software/colord/) |
+| `Colorhug-1.0` | GPL-2.0-or-later AND LGPL-2.1-or-later | colord-devel (fedora) | [link](https://www.freedesktop.org/software/colord/) |
+| `CryptUI-0.0` | LicenseRef-Callaway-LGPLv2+ | libcryptui-devel (fedora) | [link](http://projects.gnome.org/seahorse/) |
+| `CudaGst-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `Cvc-1.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later | cinnamon-desktop-devel (fedora) | [link](https://github.com/linuxmint/cinnamon-desktop) |
+| `DBus-1.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `DBusGLib-1.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `Dazzle-1.0` | GPL-3.0-or-later | libdazzle-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libdazzle) |
+| `Dbusmenu-0.4` | (LGPL-3.0-only OR LGPL-2.1-only) AND GPL-3.0-only | libdbusmenu-devel (fedora) | [link](https://launchpad.net/libdbusmenu) |
+| `DbusmenuGtk-0.4` | (LGPL-3.0-only OR LGPL-2.1-only) AND GPL-3.0-only | libdbusmenu-gtk2-devel (fedora) | [link](https://launchpad.net/libdbusmenu) |
+| `DbusmenuGtk3-0.4` | (LGPL-3.0-only OR LGPL-2.1-only) AND GPL-3.0-only | libdbusmenu-gtk3-devel (fedora) | [link](https://launchpad.net/libdbusmenu) |
+| `Dee-1.0` | LGPL-3.0-only | dee-devel (fedora) | [link](https://launchpad.net/dee) |
+| `Devhelp-3.0` | GPL-3.0-or-later | devhelp-devel (fedora) | [link](https://wiki.gnome.org/Apps/Devhelp) |
+| `Dex-1` | LGPL-2.1-or-later | libdex-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libdex) |
+| `Dmap-4.0` | LGPL-2.1-or-later | libdmapsharing4-devel (fedora) | [link](https://www.flyn.org/projects/libdmapsharing/) |
+| `EBackend-1.2` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `EBook-1.2` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `EBookContacts-1.2` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `ECal-2.0` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `EDataBook-1.2` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `EDataCal-2.0` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `EDataServer-1.2` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `EDataServerUI-1.2` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `EDataServerUI4-1.0` | LGPL-2.0-or-later | evolution-data-server-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/evolution/-/wikis/home) |
+| `Easyfc-0.14` | LGPL-3.0-or-later | libeasyfc-gobject-devel (fedora) | [link](https://gitlab.com/tagoh/libeasyfc/) |
+| `Entangle-0.1` | GPL-3.0-or-later | entangle (fedora) | [link](https://entangle-photo.org/) |
+| `Eog-3.0` | GPL-2.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0 | eog (fedora) | [link](https://wiki.gnome.org/Apps/EyeOfGnome) |
+| `Eom-1.0` | GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ | eom-devel (fedora) | [link](http://mate-desktop.org) |
+| `EvinceDocument-3.0` | GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND X11 AND MIT AND Afmparse | evince-devel (fedora) | [link](https://wiki.gnome.org/Apps/Evince) |
+| `EvinceView-3.0` | GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND X11 AND MIT AND Afmparse | evince-devel (fedora) | [link](https://wiki.gnome.org/Apps/Evince) |
+| `FPrint-2.0` | LGPL-2.1-or-later AND NIST-PD | libfprint-devel (fedora) | [link](http://www.freedesktop.org/wiki/Software/fprint/libfprint) |
+| `Farstream-0.2` | LicenseRef-Callaway-LGPLv2+ AND GPL-2.0-or-later | farstream02-devel (fedora) | [link](https://www.freedesktop.org/wiki/Software/Farstream/) |
+| `Fcitx-1.0` | GPL-2.0-or-later | fcitx-devel (fedora) | [link](https://fcitx-im.org/wiki/Fcitx) |
+| `FcitxG-1.0` | LicenseRef-Callaway-LGPLv2+ | fcitx5-gtk-devel (fedora) | [link](https://github.com/fcitx/fcitx5-gtk) |
+| `Fep-1.0` | LicenseRef-Callaway-BSD AND GPL-3.0-or-later | libfep-devel (fedora) | [link](http://github.com/ueno/libfep) |
+| `Flatpak-1.0` | LGPL-2.1-or-later | flatpak-devel (fedora) | [link](https://flatpak.org/) |
+| `Folks-0.7` | LGPL-2.1-or-later | folks-devel (fedora) | [link](https://wiki.gnome.org/Projects/Folks) |
+| `FolksDummy-0.7` | LGPL-2.1-or-later | folks-devel (fedora) | [link](https://wiki.gnome.org/Projects/Folks) |
+| `FolksEds-0.7` | LGPL-2.1-or-later | folks-devel (fedora) | [link](https://wiki.gnome.org/Projects/Folks) |
+| `FolksTelepathy-0.7` | LGPL-2.1-or-later | folks-devel (fedora) | [link](https://wiki.gnome.org/Projects/Folks) |
+| `Foundry-1` | LGPL-2.1-or-later AND Apache-2.0 | libfoundry-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/foundry) |
+| `FoundryAdw-1` | LGPL-2.1-or-later AND Apache-2.0 | libfoundry-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/foundry) |
+| `FoundryGtk-1` | LGPL-2.1-or-later AND Apache-2.0 | libfoundry-gtk-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/foundry) |
+| `Fwupd-2.0` | LGPL-2.1-or-later | fwupd-devel (fedora) | [link](https://github.com/fwupd/fwupd) |
+| `GCab-1.0` | LGPL-2.1-or-later | libgcab1-devel (fedora) | [link](http://ftp.gnome.org/pub/GNOME/sources/gcab) |
+| `GCalc-2` | GPL-3.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0 | gnome-calculator-devel (fedora) | [link](https://wiki.gnome.org/Apps/Calculator) |
+| `GCi-1` | GPL-3.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0 | gnome-calculator-devel (fedora) | [link](https://wiki.gnome.org/Apps/Calculator) |
+| `GConf-2.0` | LGPL-2.0-or-later AND GPL-2.0-or-later | GConf2-devel (fedora) | [link](https://gitlab.gnome.org/Archive/gconf/) |
+| `GDesktopEnums-3.0` | LGPL-2.1-or-later | gsettings-desktop-schemas-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas) |
+| `GES-1.0` | GPL-2.0-or-later and LGPL-2.0-or-later | gst-editing-services-devel (fedora) | [link](http://cgit.freedesktop.org/gstreamer/gst-editing-services/) |
+| `GExiv2-0.10` | GPL-2.0-or-later | libgexiv2_0.14-devel (fedora) | [link](https://wiki.gnome.org/Projects/gexiv2) |
+| `GExiv2-0.16` | GPL-2.0-or-later | libgexiv2-devel (fedora) | [link](https://wiki.gnome.org/Projects/gexiv2) |
+| `GIRepository-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `GIRepository-3.0` | LGPL-2.1-or-later | glib2-devel (fedora) | [link](https://www.gtk.org) |
+| `GL-1.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `GLib-2.0` | LGPL-2.1-or-later | glib2-devel (fedora) | [link](https://www.gtk.org) |
+| `GLibUnix-2.0` | LGPL-2.1-or-later | glib2-devel (fedora) | [link](https://www.gtk.org) |
+| `GLibWin32-2.0` | LGPL-2.1-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/glib.git) |
+| `GMenu-3.0` | LGPL-2.0-or-later | gnome-menus-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-menus) |
+| `GMime-2.6` | LicenseRef-Callaway-LGPLv2+ AND GPL-2.0-or-later | gmime-devel (fedora) | [link](http://spruce.sourceforge.net/gmime/) |
+| `GMime-3.0` | LGPL-2.1-or-later | gmime30-devel (fedora) | [link](https://github.com/jstedfast/gmime) |
+| `GModule-2.0` | LGPL-2.1-or-later | glib2-devel (fedora) | [link](https://www.gtk.org) |
+| `GObject-2.0` | LGPL-2.1-or-later | glib2-devel (fedora) | [link](https://www.gtk.org) |
+| `GPaste-2` | BSD-2-Clause | gpaste-devel (fedora) | [link](https://github.com/Keruspe/GPaste/) |
+| `GPasteGtk-4` | BSD-2-Clause | gpaste-devel (fedora) | [link](https://github.com/Keruspe/GPaste/) |
+| `GPlugin-1.0` | LGPL-2.0-or-later | gplugin-devel (fedora) | [link](https://keep.imfreedom.org/gplugin/gplugin) |
+| `GPluginGtk4-1.0` | LGPL-2.0-or-later | gplugin-gtk4-devel (fedora) | [link](https://keep.imfreedom.org/gplugin/gplugin) |
+| `GSSDP-1.6` | LGPL-2.1-or-later AND CC0-1.0 | gssdp-devel (fedora) | [link](http://www.gupnp.org/) |
+| `GSound-1.0` | LGPL-2.1-or-later | gsound-devel (fedora) | [link](https://wiki.gnome.org/Projects/GSound) |
+| `GTop-2.0` | GPL-2.0-or-later | libgtop2-devel (fedora) | [link](https://download.gnome.org/sources/libgtop) |
+| `GUPnP-1.6` | LGPL-2.1-or-later | gupnp-devel (fedora) | [link](https://www.gupnp.org/) |
+| `GUPnPAV-1.0` | LGPL-2.1-or-later AND CC0-1.0 | gupnp-av-devel (fedora) | [link](http://www.gupnp.org/) |
+| `GUPnPDLNA-2.0` | LGPL-2.0-or-later | gupnp-dlna-devel (fedora) | [link](http://www.gupnp.org/) |
+| `GUPnPDLNAGst-2.0` | LGPL-2.0-or-later | gupnp-dlna-devel (fedora) | [link](http://www.gupnp.org/) |
+| `GUPnPIgd-1.6` | LGPL-2.1-or-later | gupnp-igd-devel (fedora) | [link](https://wiki.gnome.org/Projects/GUPnP) |
+| `GUdev-1.0` | LGPL-2.1-or-later | libgudev-devel (fedora) | [link](https://wiki.gnome.org/Projects/libgudev) |
+| `GUsb-1.0` | LGPL-2.1-or-later | libgusb-devel (fedora) | [link](https://github.com/hughsie/libgusb) |
+| `GVnc-1.0` | LGPL-2.1-or-later | gvnc-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gtk-vnc) |
+| `GVncPulse-1.0` | LGPL-2.1-or-later | gvncpulse-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gtk-vnc) |
+| `GWeather-4.0` | GPL-2.0-or-later AND BSD-3-Clause | libgweather-devel (fedora) | [link](https://wiki.gnome.org/Projects/LibGWeather) |
+| `GXPS-0.1` | LGPL-2.1-or-later | libgxps-devel (fedora) | [link](https://wiki.gnome.org/Projects/libgxps) |
+| `Gamerzilla-0.1` | zlib | gamerzillagobj-devel (fedora) | [link](https://github.com/dulsi/gamerzillagobj) |
+| `Garcon-1.0` | LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-GFDL | garcon (fedora) | [link](http://xfce.org/) |
+| `GarconGtk-1.0` | LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-GFDL | garcon (fedora) | [link](http://xfce.org/) |
+| `Gc-1.0` | BSD-3-Clause AND GPL-2.0-or-later | gnome-characters (fedora) | [link](https://wiki.gnome.org/Design/Apps/CharacterMap) |
+| `Gck-1` | LGPL-2.1-or-later AND LicenseRef-Fedora-Public-Domain AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs | gcr3-devel (fedora) | [link](https://wiki.gnome.org/Projects/CryptoGlue) |
+| `Gck-2` | LGPL-2.1-or-later AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs | gcr-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gcr) |
+| `Gcr-3` | LGPL-2.1-or-later AND LicenseRef-Fedora-Public-Domain AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs | gcr3-devel (fedora) | [link](https://wiki.gnome.org/Projects/CryptoGlue) |
+| `Gcr-4` | LGPL-2.1-or-later AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs | gcr-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gcr) |
+| `GcrUi-3` | LGPL-2.1-or-later AND LicenseRef-Fedora-Public-Domain AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs | gcr3-devel (fedora) | [link](https://wiki.gnome.org/Projects/CryptoGlue) |
+| `Gda-5.0` | LGPL-2.1-or-later | libgda5-devel (fedora) | [link](http://www.gnome-db.org/) |
+| `Gda-6.0` | LGPL-2.0-or-later | libgda-devel (fedora) | [link](http://www.gnome-db.org/) |
+| `Gdaui-5.0` | LGPL-2.1-or-later | libgda5-ui-devel (fedora) | [link](http://www.gnome-db.org/) |
+| `Gdaui-6.0` | LGPL-2.0-or-later | libgda-ui-devel (fedora) | [link](http://www.gnome-db.org/) |
+| `Gdk-2.0` | LicenseRef-Callaway-LGPLv2+ | gtk2-devel (fedora) | [link](http://www.gtk.org) |
+| `Gdk-3.0` | LGPL-2.0-or-later | gtk3-devel (fedora) | [link](https://gtk.org) |
+| `Gdk-4.0` | LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1 | gtk4-devel (fedora) | [link](https://www.gtk.org) |
+| `GdkMacos-4.0` | LGPL-2.1-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gtk.git) |
+| `GdkPixbuf-2.0` | LGPL-2.1-or-later | gdk-pixbuf2-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gdk-pixbuf) |
+| `GdkPixdata-2.0` | LGPL-2.1-or-later | gdk-pixbuf2-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gdk-pixbuf) |
+| `GdkWayland-4.0` | LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1 | gtk4-devel (fedora) | [link](https://www.gtk.org) |
+| `GdkWin32-4.0` | LGPL-2.1-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gtk.git) |
+| `GdkX11-2.0` | LicenseRef-Callaway-LGPLv2+ | gtk2-devel (fedora) | [link](http://www.gtk.org) |
+| `GdkX11-3.0` | LGPL-2.0-or-later | gtk3-devel (fedora) | [link](https://gtk.org) |
+| `GdkX11-4.0` | LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1 | gtk4-devel (fedora) | [link](https://www.gtk.org) |
+| `Gdl-3` | LGPL-2.1-or-later | libgdl-devel (fedora) | [link](https://gitlab.gnome.org/Archive/gdl) |
+| `Gdm-1.0` | GPL-2.0-or-later | gdm-devel (fedora) | [link](https://wiki.gnome.org/Projects/GDM) |
+| `Gedit-3.0` | GPL-3.0-or-later AND LGPL-3.0-or-later | gedit (fedora) | [link](https://gedit-text-editor.org/) |
+| `Gee-0.8` | LGPL-2.1-or-later | libgee-devel (fedora) | [link](https://wiki.gnome.org/Projects/Libgee) |
+| `Gegl-0.4` | GPL-3.0-or-later AND LGPL-3.0-or-later | gegl04-devel (fedora) | [link](https://www.gegl.org/) |
+| `Geoclue-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND GFDL-1.1-or-later | geoclue2-devel (fedora) | [link](http://www.freedesktop.org/wiki/Software/GeoClue/) |
+| `GeocodeGlib-2.0` | LGPL-2.0-or-later AND BSD-3-Clause | geocode-glib-devel (fedora) | [link](http://www.gnome.org/) |
+| `Gepub-0.7` | LGPL-2.1-or-later | libgepub-devel (fedora) | [link](https://git.gnome.org/browse/libgepub) |
+| `Gfls-1` | LGPL-3.0-or-later | libgedit-gfls-devel (fedora) | [link](https://gedit-text-editor.org/) |
+| `Ggit-1.0` | LGPL-2.1-or-later | libgit2-glib-devel (fedora) | [link](https://wiki.gnome.org/Projects/Libgit2-glib) |
+| `Gimp-3.0` | LGPL-3.0-or-later | gimp-devel (fedora) | [link](https://www.gimp.org) |
+| `GimpUi-3.0` | LGPL-3.0-or-later | gimp-devel (fedora) | [link](https://www.gimp.org) |
+| `Gio-2.0` | LGPL-2.1-or-later | glib2-devel (fedora) | [link](https://www.gtk.org) |
+| `GioUnix-2.0` | LGPL-2.1-or-later | glib2-devel (fedora) | [link](https://www.gtk.org) |
+| `GioWin32-2.0` | LGPL-2.1-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/glib.git) |
+| `Gitg-1.0` | GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND MIT | gitg-devel (fedora) | [link](https://wiki.gnome.org/Apps/Gitg) |
+| `GitgExt-1.0` | GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND MIT | gitg-devel (fedora) | [link](https://wiki.gnome.org/Apps/Gitg) |
+| `Gkbd-3.0` | LGPL-2.0-or-later | libgnomekbd-devel (fedora) | [link](http://gswitchit.sourceforge.net) |
+| `Gladeui-2.0` | GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ | glade-devel (fedora) | [link](https://glade.gnome.org/) |
+| `Gly-2` | (MPL-2.0 OR LGPL-2.1-or-later) AND Apache-2.0 WITH LLVM-exception AND BSD-3-Clause AND CC0-1.0 AND GPL-3.0-or-later AND IJG AND ISC AND MIT AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT) | glycin-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/glycin) |
+| `GlyGtk4-2` | (MPL-2.0 OR LGPL-2.1-or-later) AND Apache-2.0 WITH LLVM-exception AND BSD-3-Clause AND CC0-1.0 AND GPL-3.0-or-later AND IJG AND ISC AND MIT AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT) | glycin-gtk4-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/glycin) |
+| `Gm-0` | LGPL-2.1-or-later AND GPL-3.0-or-later | gmobile-devel (fedora) | [link](https://gitlab.gnome.org/World/Phosh/gmobile) |
+| `GnomeAutoar-0.1` | LGPL-2.1-or-later | gnome-autoar-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-autoar) |
+| `GnomeAutoarGtk-0.1` | LGPL-2.1-or-later | gnome-autoar-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-autoar) |
+| `GnomeBG-4.0` | LGPL-2.0-or-later | gnome-desktop4-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-desktop) |
+| `GnomeBluetooth-1.0` | LGPL-2.0-or-later AND LGPL-2.1-or-later AND GPL-2.0-or-later | gnome-bluetooth3.34-libs-devel (fedora) | [link](https://wiki.gnome.org/Projects/GnomeBluetooth) |
+| `GnomeBluetooth-3.0` | LGPL-2.1-or-later | gnome-bluetooth-libs-devel (fedora) | [link](https://wiki.gnome.org/Projects/GnomeBluetooth) |
+| `GnomeCmd-1.0` | GPL-3.0-or-later AND GFDL-1.3-or-later AND CC0-1.0 | gnome-commander (fedora) | [link](https://gnome.pages.gitlab.gnome.org/gnome-commander/) |
+| `GnomeDesktop-3.0` | LGPL-2.0-or-later | gnome-desktop3-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-desktop) |
+| `GnomeDesktop-4.0` | LGPL-2.0-or-later | gnome-desktop4-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-desktop) |
+| `GnomeKeyring-1.0` | LicenseRef-Callaway-LGPLv2+ | libgnome-keyring-devel (fedora) | [link](http://live.gnome.org/GnomeKeyring) |
+| `GnomeMaps-1.0` | GPL-2.0-or-later AND CC0-1.0 | gnome-maps (fedora) | [link](https://wiki.gnome.org/Apps/Maps) |
+| `GnomeQR-4.0` | LGPL-2.0-or-later | gnome-desktop4-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-desktop) |
+| `GnomeQRGtk-4.0` | LGPL-2.0-or-later | gnome-desktop4-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gnome-desktop) |
+| `GoVirt-1.0` | LGPL-2.1-or-later | libgovirt-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libgovirt) |
+| `Goa-1.0` | LGPL-2.0-or-later AND CC-BY-SA-4.0 | gnome-online-accounts-devel (fedora) | [link](https://wiki.gnome.org/Projects/GnomeOnlineAccounts) |
+| `Gom-1.0` | LGPL-2.1-or-later AND GFDL-1.1-or-later | gom-devel (fedora) | [link](https://wiki.gnome.org/Projects/Gom) |
+| `GooCanvas-2.0` | LGPL-2.0-or-later | goocanvas2-devel (fedora) | [link](https://wiki.gnome.org/Projects(2f)GooCanvas.html) |
+| `Gpiodglib-1.0` | LGPL-2.1-or-later | libgpiod-devel (fedora) | [link](https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/) |
+| `Granite-1.0` | LGPL-3.0-or-later | granite-devel (fedora) | [link](https://github.com/elementary/granite) |
+| `Graphene-1.0` | MIT | graphene-devel (fedora) | [link](https://github.com/ebassi/graphene) |
+| `Grl-0.3` | LGPL-2.1-or-later | grilo-devel (fedora) | [link](https://wiki.gnome.org/Projects/Grilo) |
+| `GrlNet-0.3` | LGPL-2.1-or-later | grilo-devel (fedora) | [link](https://wiki.gnome.org/Projects/Grilo) |
+| `GrlPls-0.3` | LGPL-2.1-or-later | grilo-devel (fedora) | [link](https://wiki.gnome.org/Projects/Grilo) |
+| `Grss-0.7` | LGPL-3.0-or-later | libgrss-devel (fedora) | [link](https://wiki.gnome.org/Projects/Libgrss) |
+| `Gsf-1` | LGPL-2.1-only | libgsf-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libgsf/) |
+| `Gsk-4.0` | LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1 | gtk4-devel (fedora) | [link](https://www.gtk.org) |
+| `Gspell-1` | LGPL-2.1-or-later | gspell-devel (fedora) | [link](https://wiki.gnome.org/Projects/gspell) |
+| `Gst-1.0` | LGPL-2.1-or-later | gstreamer1-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstAllocators-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstAnalytics-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstApp-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstAudio-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstBadAudio-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstBase-1.0` | LGPL-2.1-or-later | gstreamer1-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstCheck-1.0` | LGPL-2.1-or-later | gstreamer1-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstCodecParsers-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstCodecs-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstController-1.0` | LGPL-2.1-or-later | gstreamer1-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstCuda-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstDxva-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstGL-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstGLEGL-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstGLWayland-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstGLX11-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstHip-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstHipGL-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstInsertBin-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstMpegts-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstMse-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstNet-1.0` | LGPL-2.1-or-later | gstreamer1-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstPbutils-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstPlay-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstPlayer-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstRtp-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstRtsp-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstRtspServer-1.0` | LGPL-2.0-or-later AND LGPL-2.1-only | gstreamer1-rtsp-server-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstSdp-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstTag-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstTranscoder-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstVa-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstValidate-1.0` | LGPL-2.0-or-later | gst-devtools-devel (fedora) | [link](https://gstreamer.freedesktop.org/src/gst-devtools) |
+| `GstVideo-1.0` | LGPL-2.1-or-later | gstreamer1-plugins-base-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstVulkan-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstVulkanWayland-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `GstWebRTC-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note | gstreamer1-plugins-bad-free-devel (fedora) | [link](http://gstreamer.freedesktop.org/) |
+| `Gtd-1.0` | GPL-3.0-or-later | gnome-todo-devel (fedora) | [link](https://gitlab.gnome.org/World/Endeavour/) |
+| `Gtk-2.0` | LicenseRef-Callaway-LGPLv2+ | gtk2-devel (fedora) | [link](http://www.gtk.org) |
+| `Gtk-3.0` | LGPL-2.0-or-later | gtk3-devel (fedora) | [link](https://gtk.org) |
+| `Gtk-4.0` | LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1 | gtk4-devel (fedora) | [link](https://www.gtk.org) |
+| `Gtk4LayerShell-1.0` | MIT | gtk4-layer-shell-devel (fedora) | [link](https://github.com/wmww/gtk4-layer-shell) |
+| `Gtk4SessionLock-1.0` | MIT | gtk4-layer-shell-devel (fedora) | [link](https://github.com/wmww/gtk4-layer-shell) |
+| `GtkChamplain-0.12` | LicenseRef-Callaway-LGPLv2+ | libchamplain-devel (fedora) | [link](https://wiki.gnome.org/Projects/libchamplain) |
+| `GtkClutter-1.0` | LicenseRef-Callaway-LGPLv2+ | clutter-gtk-devel (fedora) | [link](http://www.clutter-project.org) |
+| `GtkLayerShell-0.1` | LGPL-3.0-or-later and MIT | gtk-layer-shell-devel (fedora) | [link](https://github.com/wmww/gtk-layer-shell) |
+| `GtkSessionLock-0.1` | GPL-3.0-or-later AND MIT | gtk-session-lock-devel (fedora) | [link](https://github.com/Cu3PO42/gtk-session-lock) |
+| `GtkSource-2.0` | LGPL-2.0-or-later AND GPL-2.0-or-later | gtksourceview2-devel (fedora) | [link](http://gtksourceview.sourceforge.net/) |
+| `GtkSource-3.0` | LicenseRef-Callaway-LGPLv2+ | gtksourceview3-devel (fedora) | [link](https://wiki.gnome.org/Projects/GtkSourceView) |
+| `GtkSource-300` | LGPL-2.1-or-later | libgedit-gtksourceview-devel (fedora) | [link](https://gedit-text-editor.org/) |
+| `GtkSource-4` | LicenseRef-Callaway-LGPLv2+ | gtksourceview4-devel (fedora) | [link](https://wiki.gnome.org/Projects/GtkSourceView) |
+| `GtkSource-5` | LGPL-2.1-or-later | gtksourceview5-devel (fedora) | [link](https://wiki.gnome.org/Projects/GtkSourceView) |
+| `GtkSpell-3.0` | GPL-2.0-or-later | gtkspell3-devel (fedora) | [link](https://gtkspell.sourceforge.net/) |
+| `GtkVnc-2.0` | LGPL-2.1-or-later | gtk-vnc2-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/gtk-vnc) |
+| `Gucharmap-2.90` | GPL-3.0-or-later AND GFDL-1.3-or-later AND Unicode-DFS-2016 | gucharmap-devel (fedora) | [link](https://wiki.gnome.org/Apps/Gucharmap) |
+| `Gvc-1.0` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Handy-1` | LGPL-2.1-or-later | libhandy-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libhandy) |
+| `HarfBuzz-0.0` | MIT-Modern-Variant | harfbuzz-devel (fedora) | [link](https://github.com/harfbuzz/harfbuzz/) |
+| `Hex-4` | GPL-2.0-or-later AND GFDL-1.1-no-invariants-or-later AND CC-BY-SA-4.0 | ghex-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/ghex) |
+| `IAnjuta-3.0` | GPL-2.0-or-later | anjuta-devel (fedora) | [link](http://www.anjuta.org/) |
+| `IBus-1.0` | LGPL-2.1-or-later | ibus-devel (fedora) | [link](https://github.com/ibus/ibus/wiki) |
+| `ICal-3.0` | LGPL-2.1-only OR MPL-2.0 | libical-devel (fedora) | [link](https://libical.github.io/libical/) |
+| `ICalGLib-3.0` | LGPL-2.1-only OR MPL-2.0 | libical-glib-devel (fedora) | [link](https://libical.github.io/libical/) |
+| `IMSettings-1.8` | LGPL-2.0-or-later | imsettings-devel (fedora) | [link](https://gitlab.com/tagoh/imsettings/) |
+| `Ide-50` | GPL-3.0-or-later AND GPL-2.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later AND LGPL-2.0-or-later AND MIT AND CC0-1.0 AND CC-BY-3.0 | gnome-builder-devel (fedora) | [link](https://wiki.gnome.org/Apps/Builder) |
+| `InputPad-1.1` | LGPL-2.1-or-later | input-pad-devel (fedora) | [link](https://github.com/fujiwarat/input-pad/wiki) |
+| `Ipuz-1.0` | (LGPL-2.1-or-later OR MIT) AND (Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND MIT AND (MIT OR Apache-2.0) AND (Unlicense OR MIT) | libipuz-devel (fedora) | [link](https://gitlab.gnome.org/jrb/libipuz) |
+| `JavaScriptCore-4.1` | LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0 | javascriptcoregtk4.1-devel (fedora) | [link](https://www.webkitgtk.org/) |
+| `JavaScriptCore-6.0` | LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0 | javascriptcoregtk6.0-devel (fedora) | [link](https://www.webkitgtk.org/) |
+| `Jcat-1.0` | LGPL-2.1-or-later | libjcat-devel (fedora) | [link](https://github.com/hughsie/libjcat) |
+| `Json-1.0` | LGPL-2.1-or-later | json-glib-devel (fedora) | [link](https://wiki.gnome.org/Projects/JsonGlib) |
+| `Jsonrpc-1.0` | LGPL-2.1-or-later | jsonrpc-glib-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/jsonrpc-glib) |
+| `Keybinder-0.0` | MIT | keybinder (fedora) | [link](https://github.com/engla/keybinder) |
+| `Keybinder-3.0` | MIT | keybinder3-devel (fedora) | [link](https://github.com/kupferlauncher/keybinder) |
+| `Kkc-1.0` | GPL-3.0-or-later | libkkc-devel (fedora) | [link](https://github.com/ueno/libkkc) |
+| `LangTag-0.6` | LGPL-3.0-or-later OR MPL-2.0 | liblangtag-devel (fedora) | [link](https://bitbucket.org/tagoh/liblangtag/) |
+| `Lasem-0.6` | LGPL-2.1-or-later | lasem-devel (fedora) | [link](https://lasemproject.github.io/lasem/) |
+| `Lfb-0.0` | GPL-3.0-or-later | feedbackd-devel (fedora) | [link](https://gitlab.freedesktop.org/feedbackd/feedbackd) |
+| `Libinsane-1.0` | LGPL-3.0-or-later | libinsane-gobject-devel (fedora) | [link](https://doc.openpaper.work/libinsane/latest/) |
+| `Libmsi-1.0` | LGPL-2.1-or-later | libmsi1-devel (fedora) | [link](http://ftp.gnome.org/pub/GNOME/sources/msitools) |
+| `Libosinfo-1.0` | LGPL-2.1-or-later | libosinfo-devel (fedora) | [link](https://libosinfo.org/) |
+| `Libproxy-1.0` | LGPL-2.1-or-later | libproxy-devel (fedora) | [link](https://libproxy.github.io/libproxy/) |
+| `LibvirtGConfig-1.0` | LGPL-2.1-or-later | libvirt-gconfig-devel (fedora) | [link](https://libvirt.org/) |
+| `LibvirtGLib-1.0` | LGPL-2.1-or-later | libvirt-glib-devel (fedora) | [link](https://libvirt.org/) |
+| `LibvirtGObject-1.0` | LGPL-2.1-or-later | libvirt-gobject-devel (fedora) | [link](https://libvirt.org/) |
+| `LibvirtSandbox-1.0` | LicenseRef-Callaway-LGPLv2+ | libvirt-sandbox-devel (fedora) | [link](http://libvirt.org/) |
+| `Libxfce4panel-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later | xfce4-panel-devel (fedora) | [link](http://www.xfce.org/) |
+| `Libxfce4ui-2.0` | LicenseRef-Callaway-LGPLv2+ | libxfce4ui (fedora) | [link](http://xfce.org/) |
+| `Libxfce4util-1.0` | LicenseRef-Callaway-LGPLv2+ | libxfce4util (fedora) | [link](http://www.xfce.org/) |
+| `Libxfce4windowing-0.0` | LGPL-2.1-or-later | libxfce4windowing-devel (fedora) | [link](https://docs.xfce.org/xfce/libxfce4windowing/start) |
+| `Libxfce4windowingui-0.0` | LGPL-2.1-or-later | libxfce4windowing-devel (fedora) | [link](https://docs.xfce.org/xfce/libxfce4windowing/start) |
+| `Liferea-3.0` | GPL-2.0-or-later | liferea (fedora) | [link](https://lzone.de/liferea/) |
+| `LightDM-1` | (LGPL-2.0-only OR LGPL-3.0-only) AND GPL-3.0-or-later | lightdm-gobject-devel (fedora) | [link](https://www.freedesktop.org/wiki/Software/LightDM/) |
+| `MPID-3.0` | GPL-2.0-or-later AND CC0-1.0 AND MIT | rhythmbox-devel (fedora) | [link](https://wiki.gnome.org/Apps/Rhythmbox) |
+| `Malcontent-0` | LGPL-2.1-only AND CC-BY-3.0 | malcontent-devel (fedora) | [link](https://gitlab.freedesktop.org/pwithnall/malcontent/) |
+| `MalcontentUi-1` | LGPL-2.1-only AND CC-BY-3.0 | malcontent-ui-devel (fedora) | [link](https://gitlab.freedesktop.org/pwithnall/malcontent/) |
+| `Manette-0.2` | LGPL-2.1-or-later | libmanette-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libmanette) |
+| `Mash-0.2` | LicenseRef-Callaway-LGPLv2+ | libmash-devel (fedora) | [link](http://clutter-project.github.com/mash/) |
+| `MateDesktop-2.0` | LicenseRef-Callaway-LGPLv2+ | mate-desktop-devel (fedora) | [link](http://mate-desktop.org) |
+| `MateMenu-2.0` | GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ | mate-menus-devel (fedora) | [link](http://mate-desktop.org) |
+| `MatePanelApplet-4.0` | GPL-2.0-or-later | mate-panel-devel (fedora) | [link](http://mate-desktop.org) |
+| `Matekbd-1.0` | LicenseRef-Callaway-LGPLv2+ | libmatekbd (fedora) | [link](http://mate-desktop.org) |
+| `Mbim-1.0` | LGPL-2.1-or-later | libmbim-devel (fedora) | [link](https://gitlab.freedesktop.org/mobile-broadband/libmbim/) |
+| `MediaArt-2.0` | LGPL-2.1-or-later | libmediaart-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libmediaart) |
+| `Meta-10` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-11` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-12` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-13` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-14` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-15` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-16` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-17` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-18` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-3` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-4` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-5` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-51` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-6` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-7` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-8` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Meta-9` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Mks-1` | LGPL-2.1-or-later | libmks-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libmks) |
+| `ModemManager-1.0` | LGPL-2.1-or-later | ModemManager-glib-devel (fedora) | [link](https://gitlab.freedesktop.org/mobile-broadband/ModemManager) |
+| `Modulemd-2.0` | MIT | libmodulemd-devel (fedora) | [link](https://github.com/fedora-modularity/libmodulemd) |
+| `Msg-1` | LGPL-3.0-or-later | msgraph-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/msgraph) |
+| `Mtk-13` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Mtk-14` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Mtk-15` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Mtk-16` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Mtk-17` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Mtk-18` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `Mtk-51` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/mutter.git) |
+| `MyPaint-1.6` | ISC | libmypaint-devel (fedora) | [link](https://github.com/mypaint/libmypaint) |
+| `NM-1.0` | LGPL-2.1-or-later | NetworkManager-libnm-devel (fedora) | [link](https://networkmanager.dev/) |
+| `NMA-1.0` | GPL-2.0-or-later AND LGPL-2.1-or-later | libnma-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libnma/) |
+| `NMA4-1.0` | GPL-2.0-or-later AND LGPL-2.1-or-later | libnma-gtk4-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libnma/) |
+| `Nautilus-4.1` | LGPL-2.1-or-later | nautilus-devel (fedora) | [link](https://apps.gnome.org/Nautilus/) |
+| `Nemo-3.0` | LGPL-2.0-or-later | nemo-devel (fedora) | [link](https://github.com/linuxmint/nemo) |
+| `NemoPreview-1.0` | GPL-2.0-or-later | nemo-preview (fedora) | [link](https://github.com/linuxmint/nemo-extensions) |
+| `Nice-0.1` | LGPL-2.1-or-later OR MPL-1.1 | libnice-devel (fedora) | [link](https://nice.freedesktop.org/) |
+| `Notify-0.7` | LGPL-2.1-or-later | libnotify-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libnotify) |
+| `OSTree-1.0` | LGPL-2.0-or-later | ostree-devel (fedora) | [link](https://ostreedev.github.io/ostree/) |
+| `OsmGpsMap-1.0` | GPL-2.0-or-later | osm-gps-map-devel (fedora) | [link](https://github.com/nzjrs/osm-gps-map/) |
+| `PackageKitGlib-1.0` | GPL-2.0-or-later AND LGPL-2.1-or-later AND FSFAP | PackageKit-glib-devel (fedora) | [link](http://www.freedesktop.org/software/PackageKit/) |
+| `Panel-1` | LGPL-3.0-or-later | libpanel-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libpanel) |
+| `Pango-1.0` | LGPL-2.0-or-later | pango-devel (fedora) | [link](https://pango.gnome.org/) |
+| `PangoCairo-1.0` | LGPL-2.0-or-later | pango-devel (fedora) | [link](https://pango.gnome.org/) |
+| `PangoFT2-1.0` | LGPL-2.0-or-later | pango-devel (fedora) | [link](https://pango.gnome.org/) |
+| `PangoFc-1.0` | LGPL-2.0-or-later | pango-devel (fedora) | [link](https://pango.gnome.org/) |
+| `PangoOT-1.0` | LGPL-2.0-or-later | pango-devel (fedora) | [link](https://pango.gnome.org/) |
+| `PangoXft-1.0` | LGPL-2.0-or-later | pango-devel (fedora) | [link](https://pango.gnome.org/) |
+| `PapersDocument-4.0` | GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT AND libtiff AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND LicenseRef-BSD-2-Clause-WITH-AdditionRef-AOMPL-1.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND Zlib AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause AND ISC) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT) | papers-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/papers) |
+| `PapersView-4.0` | GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT AND libtiff AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND LicenseRef-BSD-2-Clause-WITH-AdditionRef-AOMPL-1.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND Zlib AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause AND ISC) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT) | papers-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/papers) |
+| `Parquet-23.0` | Apache-2.0 | parquet-glib-devel (fedora) | [link](https://arrow.apache.org/) |
+| `Passim-1.0` | LGPL-2.1-or-later | passim-devel (fedora) | [link](https://github.com/hughsie/passim) |
+| `Peas-1.0` | LGPL-2.1-or-later | libpeas1-devel (fedora) | [link](https://wiki.gnome.org/Projects/Libpeas) |
+| `Peas-2` | LGPL-2.1-or-later | libpeas-devel (fedora) | [link](https://wiki.gnome.org/Projects/Libpeas) |
+| `PeasGtk-1.0` | LGPL-2.1-or-later | libpeas1-devel (fedora) | [link](https://wiki.gnome.org/Projects/Libpeas) |
+| `Phosh-0` | GPL-3.0-or-later | phosh-devel (fedora) | [link](https://gitlab.gnome.org/World/Phosh/phosh) |
+| `Playerctl-2.0` | LGPL-3.0-or-later | playerctl-devel (fedora) | [link](https://github.com/acrisci/playerctl) |
+| `Pluma-1.0` | GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ | pluma-devel (fedora) | [link](http://mate-desktop.org) |
+| `Pms-1.0` | LGPL-2.1-or-later | libphosh-mobile-settings-devel (fedora) | [link](https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings) |
+| `Polkit-1.0` | LGPL-2.0-or-later | polkit-devel (fedora) | [link](https://github.com/polkit-org/polkit) |
+| `PolkitAgent-1.0` | LGPL-2.0-or-later | polkit-devel (fedora) | [link](https://github.com/polkit-org/polkit) |
+| `Poppler-0.18` | (GPL-2.0-only OR GPL-3.0-only) AND GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT | poppler-glib-devel (fedora) | [link](https://poppler.freedesktop.org/) |
+| `Qmi-1.0` | LGPL-2.1-or-later | libqmi-devel (fedora) | [link](https://gitlab.freedesktop.org/mobile-broadband/libqmi/) |
+| `Qrtr-1.0` | LGPL-2.1-or-later | libqrtr-glib-devel (fedora) | [link](https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib) |
+| `RB-3.0` | GPL-2.0-or-later AND CC0-1.0 AND MIT | rhythmbox-devel (fedora) | [link](https://wiki.gnome.org/Apps/Rhythmbox) |
+| `Rest-0.7` | LicenseRef-Callaway-LGPLv2 | rest0.7-devel (fedora) | [link](http://www.gnome.org) |
+| `Rest-1.0` | LGPL-2.1-only | rest-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/librest) |
+| `RestExtras-0.7` | LicenseRef-Callaway-LGPLv2 | rest0.7-devel (fedora) | [link](http://www.gnome.org) |
+| `RestExtras-1.0` | LGPL-2.1-only | rest-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/librest) |
+| `RpmOstree-1.0` | LGPL-2.0-or-later | rpm-ostree-devel (fedora) | [link](https://github.com/coreos/rpm-ostree) |
+| `Rsvg-2.0` | LGPL-2.1-or-later AND Apache-2.0 AND BSD-3-Clause AND MIT AND MPL-2.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT) | librsvg2-devel (fedora) | [link](https://wiki.gnome.org/Projects/LibRsvg) |
+| `RygelCore-2.8` | LGPL-2.1-or-later AND CC-BY-SA-3.0 | rygel-devel (fedora) | [link](https://wiki.gnome.org/Projects/Rygel) |
+| `RygelRenderer-2.8` | LGPL-2.1-or-later AND CC-BY-SA-3.0 | rygel-devel (fedora) | [link](https://wiki.gnome.org/Projects/Rygel) |
+| `RygelRendererGst-2.8` | LGPL-2.1-or-later AND CC-BY-SA-3.0 | rygel-devel (fedora) | [link](https://wiki.gnome.org/Projects/Rygel) |
+| `RygelServer-2.8` | LGPL-2.1-or-later AND CC-BY-SA-3.0 | rygel-devel (fedora) | [link](https://wiki.gnome.org/Projects/Rygel) |
+| `Secret-1` | LGPL-2.1-or-later AND Apache-2.0 AND (GPL-2.0-or-later OR TGPPL-1.0) AND LicenseRef-Fedora-Public-Domain AND GCR-docs | libsecret-devel (fedora) | [link](https://wiki.gnome.org/Projects/Libsecret) |
+| `Shell-0.1` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-10` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-11` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-12` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-13` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-14` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-15` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-16` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-17` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-18` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-51` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shell-9` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shew-0` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `Shumate-1.0` | LGPL-2.1-or-later AND LGPL-2.0-or-later | libshumate-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libshumate) |
+| `Skk-1.0` | GPL-3.0-or-later | libskk-devel (fedora) | [link](https://github.com/ueno/libskk) |
+| `Snapd-2` | LGPL-2.0-only OR LGPL-3.0-only | snapd-glib-devel (fedora) | [link](https://github.com/canonical/snapd-glib) |
+| `Soup-2.4` | LGPL-2.0-only | libsoup-devel (fedora) | [link](https://wiki.gnome.org/Projects/libsoup) |
+| `Soup-3.0` | LGPL-2.0-or-later AND LGPL-2.1-or-later | libsoup3-devel (fedora) | [link](https://wiki.gnome.org/Projects/libsoup) |
+| `SoupGNOME-2.4` | LGPL-2.0-only | libsoup-devel (fedora) | [link](https://wiki.gnome.org/Projects/libsoup) |
+| `Spelling-1` | LGPL-2.1-or-later | libspelling-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/libspelling) |
+| `SpiceClientGLib-2.0` | LGPL-2.1-or-later AND MIT AND MIT-open-group and BSD-3-Clause | spice-glib-devel (fedora) | [link](https://www.spice-space.org/spice-gtk.html) |
+| `SpiceClientGtk-3.0` | LGPL-2.1-or-later AND MIT AND MIT-open-group and BSD-3-Clause | spice-gtk3-devel (fedora) | [link](https://www.spice-space.org/spice-gtk.html) |
+| `St-1.0` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-10` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-11` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-12` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-13` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-14` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-15` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-16` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-17` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-18` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-51` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `St-9` | GPL-2.0-or-later | gir-module-metadata | [link](https://gitlab.gnome.org/GNOME/gnome-shell.git) |
+| `SugarExt-1.0` | LicenseRef-Callaway-LGPLv2+ | sugar-toolkit-gtk3-devel (fedora) | [link](http://wiki.laptop.org/go/Sugar) |
+| `SugarGestures-1.0` | LicenseRef-Callaway-LGPLv2+ | sugar-toolkit-gtk3-devel (fedora) | [link](http://wiki.laptop.org/go/Sugar) |
+| `Sushi-1.0` | GPL-2.0-or-later WITH GStreamer-exception-2008 AND CC0-1.0 AND (LGPL-2.0-or-later AND LGPL-2.1-or-later WITH GStreamer-exception-2005) | sushi (fedora) | [link](https://gitlab.gnome.org/GNOME/sushi) |
+| `TelepathyGLib-0.12` | LGPL-2.1-or-later | telepathy-glib-devel (fedora) | [link](http://telepathy.freedesktop.org/wiki/FrontPage) |
+| `Template-1.0` | LGPL-2.1-or-later | template-glib-devel (fedora) | [link](https://gitlab.gnome.org/GNOME/template-glib/) |
+| `Tepl-6` | LGPL-3.0-or-later | libgedit-tepl-devel (fedora) | [link](https://gedit-text-editor.org/) |
+| `Thunarx-3.0` | GPL-2.0-or-later | Thunar-devel (fedora) | [link](http://thunar.xfce.org/) |
+| `TimezoneMap-1.0` | GPL-3.0-only | libtimezonemap-devel (fedora) | [link](https://launchpad.net/timezonemap) |
+| `Totem-1.0` | GPL-2.0-or-later AND (GPL-2.0-or-later WITH GStreamer-exception-2008) AND LGPL-2.0-or-later AND CC0-1.0 | totem-devel (fedora) | [link](https://wiki.gnome.org/Apps/Videos) |
+| `TotemPlParser-1.0` | LGPL-2.0-or-later AND (LGPL-2.1-or-later WITH GStreamer-exception-2005) | totem-pl-parser-devel (fedora) | [link](https://wiki.gnome.org/Apps/Videos) |
+| `Tracker-3.0` | LGPL-2.1-or-later | tinysparql-devel (fedora) | [link](https://gnome.pages.gitlab.gnome.org/tinysparql/) |
+| `Translit-1.0` | GPL-3.0-or-later | libtranslit-devel (fedora) | [link](http://github.com/ueno/libtranslit) |
+| `Tsparql-3.0` | LGPL-2.1-or-later | tinysparql-devel (fedora) | [link](https://gnome.pages.gitlab.gnome.org/tinysparql/) |
+| `UDisks-2.0` | LGPL-2.0-or-later | libudisks2-devel (fedora) | [link](https://github.com/storaged-project/udisks) |
+| `UMockdev-1.0` | LGPL-2.1-or-later | umockdev-devel (fedora) | [link](https://github.com/martinpitt/umockdev) |
+| `UPowerGlib-1.0` | GPL-2.0-or-later | upower-devel (fedora) | [link](https://upower.freedesktop.org/) |
+| `Uhm-1.0` | LGPL-2.1-or-later | uhttpmock-devel (fedora) | [link](https://gitlab.freedesktop.org/pwithnall/uhttpmock) |
+| `Unity-7.0` | GPL-3.0-only | libunity-devel (fedora) | [link](https://launchpad.net/libunity) |
+| `UnityExtras-7.0` | GPL-3.0-only | libunity-devel (fedora) | [link](https://launchpad.net/libunity) |
+| `Vips-8.0` | LGPL-2.1-or-later | vips-devel (fedora) | [link](https://www.libvips.org/) |
+| `Vte-0.0` | LGPL-2.0-or-later | vte-devel (fedora) | [link](http://developer.gnome.org/vte/) |
+| `Vte-2.91` | GPL-3.0-or-later AND LGPL-3.0-or-later | vte291-devel (fedora) | [link](https://wiki.gnome.org/Apps/Terminal/VTE) |
+| `Vte-3.91` | GPL-3.0-or-later AND LGPL-3.0-or-later | vte291-gtk4-devel (fedora) | [link](https://wiki.gnome.org/Apps/Terminal/VTE) |
+| `Vulkan-1.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `WebKit-6.0` | LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0 | webkitgtk6.0-devel (fedora) | [link](https://www.webkitgtk.org/) |
+| `WebKit2-4.1` | LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0 | webkit2gtk4.1-devel (fedora) | [link](https://www.webkitgtk.org/) |
+| `WebKit2WebExtension-4.1` | LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0 | webkit2gtk4.1-devel (fedora) | [link](https://www.webkitgtk.org/) |
+| `WebKitWebExtension-6.0` | LGPL-2.1-or-later | gir-module-metadata | [link](https://webkitgtk.org) |
+| `WebKitWebProcessExtension-6.0` | LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0 | webkitgtk6.0-devel (fedora) | [link](https://www.webkitgtk.org/) |
+| `Wnck-1.0` | LicenseRef-Callaway-LGPLv2+ | libwnck-devel (fedora) | [link](http://download.gnome.org/sources/libwnck/) |
+| `Wnck-3.0` | LGPL-2.0-or-later | libwnck3-devel (fedora) | [link](http://download.gnome.org/sources/libwnck/) |
+| `Wp-0.5` | MIT | wireplumber-devel (fedora) | [link](https://pipewire.pages.freedesktop.org/wireplumber/) |
+| `XApp-1.0` | LGPL-3.0-only | xapps-devel (fedora) | [link](https://github.com/linuxmint/xapps) |
+| `Xdp-1.0` | LGPL-3.0-only AND LGPL-2.1-or-later | libportal-devel (fedora) | [link](https://github.com/flatpak/libportal) |
+| `XdpGtk3-1.0` | LGPL-3.0-only AND LGPL-2.1-or-later | libportal-gtk3-devel (fedora) | [link](https://github.com/flatpak/libportal) |
+| `XdpGtk4-1.0` | LGPL-3.0-only AND LGPL-2.1-or-later | libportal-gtk4-devel (fedora) | [link](https://github.com/flatpak/libportal) |
+| `Xed-1.0` | GPL-2.0-or-later | xed-devel (fedora) | [link](https://github.com/linuxmint/xed) |
+| `Xfconf-0` | GPL-2.0-only | xfconf (fedora) | [link](http://www.xfce.org/) |
+| `Xkl-1.0` | LGPL-2.0-or-later | libxklavier-devel (fedora) | [link](http://www.freedesktop.org/wiki/Software/LibXklavier) |
+| `Xmlb-2.0` | LGPL-2.1-or-later | libxmlb-devel (fedora) | [link](https://github.com/hughsie/libxmlb) |
+| `XreaderDocument-1.5` | GPL-2.0-or-later | xreader-devel (fedora) | [link](https://github.com/linuxmint/xreader) |
+| `XreaderView-1.5` | GPL-2.0-or-later | xreader-devel (fedora) | [link](https://github.com/linuxmint/xreader) |
+| `ZBar-1.0` | LGPL-2.1-or-later | zbar-devel (fedora) | [link](http://zbar.sourceforge.net/) |
+| `Zeitgeist-2.0` | LGPL-2.0-or-later | zeitgeist-devel (fedora) | [link](https://launchpad.net/zeitgeist) |
+| `cairo-1.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `fontconfig-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `freetype2-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `libxml2-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `win32-1.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `xfixes-4.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `xft-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `xlib-2.0` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+| `xrandr-1.3` | GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause | gobject-introspection-devel (fedora) | [link](https://wiki.gnome.org/Projects/GObjectIntrospection) |
+
+---
+
+Regenerate this file with `node packages/gir-files/scripts/build-payload.mjs`.
+Provenance is re-queried with `scripts/build-gir-provenance.sh`.

--- a/packages/gir-files/README.md
+++ b/packages/gir-files/README.md
@@ -1,0 +1,125 @@
+# @ts-for-gir/gir-files
+
+The original **GIR XML** files that `@girs/*` is generated from, with a per-namespace
+provenance and licence record.
+
+```bash
+npm install @ts-for-gir/gir-files
+```
+
+```ts
+import { listGirFiles, readGirXml, getGirFile } from "@ts-for-gir/gir-files";
+
+const xml = readGirXml("Gtk-4.0");        // the full <repository> document
+const info = getGirFile("Gtk-4.0");       // provenance + sizes
+console.log(info?.license, info?.sourcePackage);
+
+for (const f of listGirFiles()) console.log(f.girId, f.bytes);
+```
+
+Need a directory of plain `.gir` files (for `ts-for-gir generate --girDirectories=…`, say)?
+
+```ts
+import { extractGirFiles } from "@ts-for-gir/gir-files";
+extractGirFiles("./girs");                       // all of them
+extractGirFiles("./girs", ["Gtk-4.0", "Adw-1"]); // or a few
+```
+
+## Why this exists
+
+GIR XML and the compiled typelib carry **different** data, and the generated `.d.ts` carries
+neither in full:
+
+| | GIR XML | typelib | generated `.d.ts` |
+|---|---|---|---|
+| enum nicks (`glib:nick`) | yes | yes | in `@girs/<ns>/surface` |
+| **documentation prose (`<doc>`)** | **yes** | no | no |
+| deprecation reasons, `<doc-deprecated>` | yes | no | no |
+| introspection annotations (`transfer-ownership`, `nullable`, …) | yes | partly | erased into types |
+
+A tool that wants to explain *why* — a property ledger with reasons and doc text, a
+conformance report, a documentation builder — has to read the XML. Until now the only way
+to get it was to install the distro `-devel` packages and hope the versions matched the
+types you were compiling against.
+
+## What this is NOT — please read
+
+**This package does not tell you what the host will load at runtime.**
+
+gjsify's [ADR 0019 § 2](https://github.com/gjsify/gjsify/blob/main/docs/adr/0019-ts-for-gir-as-library.md)
+decided that "the `.gir` travels with the RUNTIME package, never with the type package",
+and it is right: GIRepository matches only the *API* version, so a `Gtk-4.0` typelib built
+from GTK 4.12 and one built from 4.23 both satisfy `gi://Gtk?version=4.0`. A `.gir` with no
+binary next to it therefore proves nothing about the installed library. That is a real
+failure that was measured — `tsc` exit 0, `TypeError` at runtime.
+
+This package sits outside that decision because it answers a different question. It does not
+claim to describe your host; it describes **its own corpus**:
+
+- Its version tracks the ts-for-gir release train, so `@ts-for-gir/gir-files@X` carries the
+  XML that produced `@girs/*@X`. That is a *build-time* correspondence — which input made
+  which output — not a runtime one.
+- Every entry states where it came from (`sourcePackage`, `sourceRpm`, `upstreamUrl`), so a
+  consumer can see it is reading Fedora's `gtk4-devel` and not the GTK on this machine.
+
+The consumers this is for **never load the library at all**: generators, conformance
+checkers, documentation builders. ADR 0019 § 5 puts exactly that in ts-for-gir's domain —
+*"ts-for-gir knows GIR as XML, parsed headlessly, in CI, with no GTK installed and no typelib
+loaded"*.
+
+If you need to know what the running process will actually see, use the `.gir` that ships
+beside the binary (`@gjsify/gtk-runtime-*` via `gjsify.prebuilds`), not this package.
+
+## Licensing — read NOTICE.md
+
+The files in `payload/` are **not ours** and are **not permissively licensed**. They are
+verbatim copies of upstream artefacts, predominantly under **LGPL-2.1-or-later**, with
+**GPL-2.0-or-later**, **GPL-3.0-only**, **LGPL-2.1-only** and other expressions across the
+set. None of them carries a licence header of its own, so the terms are inherited from the
+project each was generated from.
+
+`package.json` therefore says `"license": "SEE LICENSE IN NOTICE.md"` — no single identifier
+is true of this package's contents. [`NOTICE.md`](./NOTICE.md) lists **every** file with the
+licence expression and the upstream package it came from.
+
+The packaging around them (`src/`, `scripts/`, `provenance.json`) is Apache-2.0, like the
+rest of ts-for-gir.
+
+**A namespace with no provenance record is not published.** `getProvenance().unattributed`
+names the ones held back; `readGirXml()` on one of those throws and says why. That refusal is
+deliberate: shipping a file we cannot name terms for would be worse than not shipping it.
+
+The provenance table is **evidence, not a legal determination** — a distribution's `License:`
+tag covers a whole package rather than one file, and nothing here is legal advice.
+
+## Size
+
+The payload ships **gzipped per file** and is decompressed on read.
+
+Measured over the 510 shipped namespaces (308.0 MB of raw XML), via `npm pack --dry-run`:
+
+| shape | tarball | installed |
+|---|---|---|
+| plain `.gir` files | 27.5 MB | 308.0 MB |
+| per-file `.gir.gz` (what this ships) | 27.6 MB | 27.9 MB |
+
+The tarball costs 0.1 MB more (+0.4 %) and the installed footprint is 11.0× smaller.
+
+That trade is nearly free because gzip's 32 KB window captures almost no redundancy
+*between* files. Over the full pool: one `tar.gz` of all 718 files is 32.4 MB, while gzipping
+each file separately and summing comes to 32.7 MB — a 0.9 % difference. Pooling into one
+stream buys essentially nothing, so pre-compressing gives up essentially nothing. (A format
+with a long window — `zstd --long`, `xz` — would do considerably better on this set, but npm
+tarballs are gzip.)
+
+Reproduce every number here with the commands in the PR that added this package.
+
+## Regenerating
+
+```bash
+scripts/build-gir-provenance.sh              # re-query provenance + licences (needs podman)
+node packages/gir-files/scripts/build-payload.mjs   # rebuild payload/ + NOTICE.md
+```
+
+`build:app` runs the second one, so a release cut picks it up. The payload is generated, not
+committed — `girs/` is already in the repo and a second copy would be 32.7 MB of duplication.

--- a/packages/gir-files/README.md
+++ b/packages/gir-files/README.md
@@ -122,4 +122,4 @@ node packages/gir-files/scripts/build-payload.mjs   # rebuild payload/ + NOTICE.
 ```
 
 `build:app` runs the second one, so a release cut picks it up. The payload is generated, not
-committed — `girs/` is already in the repo and a second copy would be 32.7 MB of duplication.
+committed — `girs/` is already in the repo and a second copy would be 27.6 MB of duplication.

--- a/packages/gir-files/package.json
+++ b/packages/gir-files/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@ts-for-gir/gir-files",
+  "version": "4.3.0",
+  "description": "The original GIR XML files behind @girs/*, with per-namespace provenance and upstream licence attribution",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./provenance.json": "./provenance.json",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "node scripts/build-payload.mjs",
+    "check": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gjsify/ts-for-gir.git"
+  },
+  "author": "Pascal Garber <pascal@mailfreun.de>",
+  "files": [
+    "src",
+    "payload",
+    "provenance.json",
+    "NOTICE.md"
+  ],
+  "license": "SEE LICENSE IN NOTICE.md",
+  "bugs": {
+    "url": "https://github.com/gjsify/ts-for-gir/issues"
+  },
+  "homepage": "https://github.com/gjsify/ts-for-gir/tree/main/packages/gir-files#readme",
+  "keywords": [
+    "gir",
+    "gobject-introspection",
+    "gnome",
+    "gtk",
+    "xml",
+    "introspection"
+  ],
+  "devDependencies": {
+    "@ts-for-gir/tsconfig": "workspace:^",
+    "@types/node": "^26.4.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/gir-files/provenance.json
+++ b/packages/gir-files/provenance.json
@@ -1,0 +1,4124 @@
+{
+  "$schema": "https://github.com/gjsify/ts-for-gir/blob/main/packages/gir-files/provenance.schema.json",
+  "schemaVersion": 1,
+  "generatedFrom": {
+    "distribution": "fedora",
+    "release": "rawhide"
+  },
+  "entries": {
+    "Abi-3.0": {
+      "file": "Abi-3.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libabiword-devel",
+      "sourceRpm": "abiword-3.0.8-5.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/World/AbiWord"
+    },
+    "Accounts-1.0": {
+      "file": "Accounts-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2",
+      "source": "fedora",
+      "sourcePackage": "libaccounts-glib-devel",
+      "sourceRpm": "libaccounts-glib-1.25-27.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.com/accounts-sso/libaccounts-glib"
+    },
+    "AccountsService-1.0": {
+      "file": "AccountsService-1.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "accountsservice-devel",
+      "sourceRpm": "accountsservice-26.27.3-2.fc45.src.rpm",
+      "upstreamUrl": "https://www.freedesktop.org/wiki/Software/AccountsService/"
+    },
+    "Adw-1": {
+      "file": "Adw-1.gir",
+      "license": "LGPL-2.1-or-later AND MIT",
+      "source": "fedora",
+      "sourcePackage": "libadwaita-devel",
+      "sourceRpm": "libadwaita-1.10~beta.1-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libadwaita"
+    },
+    "Ags-8.0": {
+      "file": "Ags-8.0.gir",
+      "license": "GPL-3.0-or-later AND AGPL-3.0-or-later AND LicenseRef-Callaway-GFDL",
+      "source": "fedora",
+      "sourcePackage": "gsequencer-devel",
+      "sourceRpm": "gsequencer-8.4.2-1.fc45.src.rpm",
+      "upstreamUrl": "http://nongnu.org/gsequencer"
+    },
+    "AgsAudio-8.0": {
+      "file": "AgsAudio-8.0.gir",
+      "license": "GPL-3.0-or-later AND AGPL-3.0-or-later AND LicenseRef-Callaway-GFDL",
+      "source": "fedora",
+      "sourcePackage": "gsequencer-devel",
+      "sourceRpm": "gsequencer-8.4.2-1.fc45.src.rpm",
+      "upstreamUrl": "http://nongnu.org/gsequencer"
+    },
+    "AgsGui-8.0": {
+      "file": "AgsGui-8.0.gir",
+      "license": "GPL-3.0-or-later AND AGPL-3.0-or-later AND LicenseRef-Callaway-GFDL",
+      "source": "fedora",
+      "sourcePackage": "gsequencer-devel",
+      "sourceRpm": "gsequencer-8.4.2-1.fc45.src.rpm",
+      "upstreamUrl": "http://nongnu.org/gsequencer"
+    },
+    "Amtk-5": {
+      "file": "Amtk-5.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgedit-amtk-devel",
+      "sourceRpm": "libgedit-amtk-5.10.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://gedit-text-editor.org/"
+    },
+    "Anjuta-3.0": {
+      "file": "Anjuta-3.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "anjuta-devel",
+      "sourceRpm": "anjuta-3.34.0-31.fc45.src.rpm",
+      "upstreamUrl": "http://www.anjuta.org/"
+    },
+    "Anthy-9000": {
+      "file": "Anthy-9000.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "ibus-anthy-devel",
+      "sourceRpm": "ibus-anthy-1.5.18-4.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/ibus/ibus/wiki"
+    },
+    "AppIndicator3-0.1": {
+      "file": "AppIndicator3-0.1.gir",
+      "license": "LicenseRef-Callaway-LGPLv2 AND LGPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "libappindicator-gtk3-devel",
+      "sourceRpm": "libappindicator-12.10.1-11.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/libappindicator"
+    },
+    "AppStream-1.0": {
+      "file": "AppStream-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "appstream-devel",
+      "sourceRpm": "appstream-1.1.3-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/ximion/appstream"
+    },
+    "AppStreamCompose-1.0": {
+      "file": "AppStreamCompose-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "appstream-compose-devel",
+      "sourceRpm": "appstream-1.1.3-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/ximion/appstream"
+    },
+    "AppStreamGlib-1.0": {
+      "file": "AppStreamGlib-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libappstream-glib-devel",
+      "sourceRpm": "libappstream-glib-0.8.4-1.fc45.src.rpm",
+      "upstreamUrl": "http://people.freedesktop.org/~hughsient/appstream-glib/"
+    },
+    "Arrow-23.0": {
+      "file": "Arrow-23.0.gir",
+      "license": "Apache-2.0",
+      "source": "fedora",
+      "sourcePackage": "libarrow-glib-devel",
+      "sourceRpm": "libarrow-23.0.1-11.fc46.src.rpm",
+      "upstreamUrl": "https://arrow.apache.org/"
+    },
+    "ArrowDataset-23.0": {
+      "file": "ArrowDataset-23.0.gir",
+      "license": "Apache-2.0",
+      "source": "fedora",
+      "sourcePackage": "libarrow-dataset-glib-devel",
+      "sourceRpm": "libarrow-23.0.1-11.fc46.src.rpm",
+      "upstreamUrl": "https://arrow.apache.org/"
+    },
+    "ArrowFlight-23.0": {
+      "file": "ArrowFlight-23.0.gir",
+      "license": "Apache-2.0",
+      "source": "fedora",
+      "sourcePackage": "libarrow-flight-devel",
+      "sourceRpm": "libarrow-23.0.1-11.fc46.src.rpm",
+      "upstreamUrl": "https://arrow.apache.org/"
+    },
+    "Atk-1.0": {
+      "file": "Atk-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "atk-devel",
+      "sourceRpm": "at-spi2-core-2.61.1-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/at-spi2-core/"
+    },
+    "AtrilDocument-1.5.0": {
+      "file": "AtrilDocument-1.5.0.gir",
+      "license": "GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-MIT",
+      "source": "fedora",
+      "sourcePackage": "atril-devel",
+      "sourceRpm": "atril-1.28.6-2.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "AtrilView-1.5.0": {
+      "file": "AtrilView-1.5.0.gir",
+      "license": "GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-MIT",
+      "source": "fedora",
+      "sourcePackage": "atril-devel",
+      "sourceRpm": "atril-1.28.6-2.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "Atspi-2.0": {
+      "file": "Atspi-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "at-spi2-core-devel",
+      "sourceRpm": "at-spi2-core-2.61.1-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/at-spi2-core/"
+    },
+    "AyatanaAppIndicator-0.1": {
+      "file": "AyatanaAppIndicator-0.1.gir",
+      "license": "GPL-3.0-only AND LGPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only)",
+      "source": "fedora",
+      "sourcePackage": "libayatana-appindicator-gtk2-devel",
+      "sourceRpm": "libayatana-appindicator-0.5.94-7.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/AyatanaIndicators/libayatana-appindicator"
+    },
+    "AyatanaAppIndicator3-0.1": {
+      "file": "AyatanaAppIndicator3-0.1.gir",
+      "license": "GPL-3.0-only AND LGPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only)",
+      "source": "fedora",
+      "sourcePackage": "libayatana-appindicator-gtk3-devel",
+      "sourceRpm": "libayatana-appindicator-0.5.94-7.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/AyatanaIndicators/libayatana-appindicator"
+    },
+    "AyatanaIdo3-0.4": {
+      "file": "AyatanaIdo3-0.4.gir",
+      "license": "LGPL-2.0-or-later AND GPL-3.0-only AND (LGPL-3.0-only OR LGPL-2.1-only)",
+      "source": "fedora",
+      "sourcePackage": "libayatana-ido-gtk3-devel",
+      "sourceRpm": "libayatana-ido-0.10.4-8.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/AyatanaIndicators/ayatana-ido"
+    },
+    "Babl-0.1": {
+      "file": "Babl-0.1.gir",
+      "license": "LGPL-3.0-or-later AND GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "babl-devel",
+      "sourceRpm": "babl-0.1.128-1.fc45.src.rpm",
+      "upstreamUrl": "https://www.gegl.org/babl/"
+    },
+    "Bamf-3": {
+      "file": "Bamf-3.gir",
+      "license": "GPL-2.0-only OR GPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "bamf-devel",
+      "sourceRpm": "bamf-0.5.6-7.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/bamf"
+    },
+    "BlockDev-3.0": {
+      "file": "BlockDev-3.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libblockdev-devel",
+      "sourceRpm": "libblockdev-3.5.0-4.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/storaged-project/libblockdev"
+    },
+    "BraseroBurn-3.1": {
+      "file": "BraseroBurn-3.1.gir",
+      "license": "GPL-3.0-or-later AND LGPL-2.0-or-later AND GPL-2.0-only AND CC-BY-SA-2.0 AND GPL-2.0-or-later WITH GStreamer-exception-2008",
+      "source": "fedora",
+      "sourcePackage": "brasero-devel",
+      "sourceRpm": "brasero-3.12.3-29.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Brasero"
+    },
+    "BraseroMedia-3.1": {
+      "file": "BraseroMedia-3.1.gir",
+      "license": "GPL-3.0-or-later AND LGPL-2.0-or-later AND GPL-2.0-only AND CC-BY-SA-2.0 AND GPL-2.0-or-later WITH GStreamer-exception-2008",
+      "source": "fedora",
+      "sourcePackage": "brasero-devel",
+      "sourceRpm": "brasero-3.12.3-29.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Brasero"
+    },
+    "Budgie-3.0": {
+      "file": "Budgie-3.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later AND CC0-1.0 AND CC-BY-SA-4.0",
+      "source": "fedora",
+      "sourcePackage": "budgie-desktop-devel",
+      "sourceRpm": "budgie-desktop-10.10.2-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/BuddiesOfBudgie/budgie-desktop"
+    },
+    "BudgieRaven-3.0": {
+      "file": "BudgieRaven-3.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-2.0-only AND LGPL-2.1-or-later AND CC0-1.0 AND CC-BY-SA-4.0",
+      "source": "fedora",
+      "sourcePackage": "budgie-desktop-devel",
+      "sourceRpm": "budgie-desktop-10.10.2-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/BuddiesOfBudgie/budgie-desktop"
+    },
+    "CDesktopEnums-3.0": {
+      "file": "CDesktopEnums-3.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cinnamon-desktop-devel",
+      "sourceRpm": "cinnamon-desktop-6.7.3^unstable-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/cinnamon-desktop"
+    },
+    "CMenu-3.0": {
+      "file": "CMenu-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cinnamon-menus-devel",
+      "sourceRpm": "cinnamon-menus-6.7.0^unstable-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/cinnamon-menus"
+    },
+    "Caja-2.0": {
+      "file": "Caja-2.0.gir",
+      "license": "GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "caja-devel",
+      "sourceRpm": "caja-1.28.0-12.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "Cally-1.0": {
+      "file": "Cally-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "clutter-devel",
+      "sourceRpm": "clutter-1.26.4-20.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "CambalachePrivate-3.0": {
+      "file": "CambalachePrivate-3.0.gir",
+      "license": "LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cambalache",
+      "sourceRpm": "cambalache-0.99.8-4.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/jpu/cambalache"
+    },
+    "CambalachePrivate-4.0": {
+      "file": "CambalachePrivate-4.0.gir",
+      "license": "LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cambalache",
+      "sourceRpm": "cambalache-0.99.8-4.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/jpu/cambalache"
+    },
+    "Camel-1.2": {
+      "file": "Camel-1.2.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "Caribou-1.0": {
+      "file": "Caribou-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "caribou-devel",
+      "sourceRpm": "caribou-0.4.21-53.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Caribou"
+    },
+    "Casilda-1.0": {
+      "file": "Casilda-1.0.gir",
+      "license": "LGPL-2.1-only AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "casilda-devel",
+      "sourceRpm": "casilda-1.0.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/jpu/casilda"
+    },
+    "Champlain-0.12": {
+      "file": "Champlain-0.12.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libchamplain-devel",
+      "sourceRpm": "libchamplain-0.12.21-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/libchamplain"
+    },
+    "CinnamonDesktop-3.0": {
+      "file": "CinnamonDesktop-3.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cinnamon-desktop-devel",
+      "sourceRpm": "cinnamon-desktop-6.7.3^unstable-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/cinnamon-desktop"
+    },
+    "Clapper-0.0": {
+      "file": "Clapper-0.0.gir",
+      "license": "GPL-3.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "clapper-devel",
+      "sourceRpm": "clapper-0.10.0-5.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/Rafostar/clapper"
+    },
+    "ClapperGtk-0.0": {
+      "file": "ClapperGtk-0.0.gir",
+      "license": "GPL-3.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "clapper-devel",
+      "sourceRpm": "clapper-0.10.0-5.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/Rafostar/clapper"
+    },
+    "CloudProviders-0.3": {
+      "file": "CloudProviders-0.3.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libcloudproviders-devel",
+      "sourceRpm": "libcloudproviders-0.4.0-8.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libcloudproviders"
+    },
+    "Clutter-1.0": {
+      "file": "Clutter-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "clutter-devel",
+      "sourceRpm": "clutter-1.26.4-20.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "Clutter-10": {
+      "file": "Clutter-10.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-11": {
+      "file": "Clutter-11.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-12": {
+      "file": "Clutter-12.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-13": {
+      "file": "Clutter-13.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-14": {
+      "file": "Clutter-14.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-15": {
+      "file": "Clutter-15.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-16": {
+      "file": "Clutter-16.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-17": {
+      "file": "Clutter-17.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-18": {
+      "file": "Clutter-18.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-3": {
+      "file": "Clutter-3.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-4": {
+      "file": "Clutter-4.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-5": {
+      "file": "Clutter-5.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-51": {
+      "file": "Clutter-51.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-6": {
+      "file": "Clutter-6.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-7": {
+      "file": "Clutter-7.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-8": {
+      "file": "Clutter-8.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Clutter-9": {
+      "file": "Clutter-9.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "ClutterGdk-1.0": {
+      "file": "ClutterGdk-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "clutter-devel",
+      "sourceRpm": "clutter-1.26.4-20.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "ClutterGst-3.0": {
+      "file": "ClutterGst-3.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "clutter-gst3-devel",
+      "sourceRpm": "clutter-gst3-3.0.27-25.fc45.src.rpm",
+      "upstreamUrl": "https://developer.gnome.org/clutter-gst/stable/"
+    },
+    "ClutterX11-1.0": {
+      "file": "ClutterX11-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "clutter-devel",
+      "sourceRpm": "clutter-1.26.4-20.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "CmbCatalogUtils-3.0": {
+      "file": "CmbCatalogUtils-3.0.gir",
+      "license": "LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cambalache",
+      "sourceRpm": "cambalache-0.99.8-4.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/jpu/cambalache"
+    },
+    "CmbCatalogUtils-4.0": {
+      "file": "CmbCatalogUtils-4.0.gir",
+      "license": "LGPL-2.1-only AND GPL-2.0-only AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cambalache",
+      "sourceRpm": "cambalache-0.99.8-4.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/jpu/cambalache"
+    },
+    "Cogl-1.0": {
+      "file": "Cogl-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "cogl-devel",
+      "sourceRpm": "cogl-1.22.8-18.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "Cogl-10": {
+      "file": "Cogl-10.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-11": {
+      "file": "Cogl-11.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-12": {
+      "file": "Cogl-12.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-13": {
+      "file": "Cogl-13.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-14": {
+      "file": "Cogl-14.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-15": {
+      "file": "Cogl-15.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-16": {
+      "file": "Cogl-16.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-17": {
+      "file": "Cogl-17.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-18": {
+      "file": "Cogl-18.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-2.0": {
+      "file": "Cogl-2.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "cogl-devel",
+      "sourceRpm": "cogl-1.22.8-18.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "Cogl-3": {
+      "file": "Cogl-3.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-4": {
+      "file": "Cogl-4.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-5": {
+      "file": "Cogl-5.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-51": {
+      "file": "Cogl-51.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-6": {
+      "file": "Cogl-6.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-7": {
+      "file": "Cogl-7.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-8": {
+      "file": "Cogl-8.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Cogl-9": {
+      "file": "Cogl-9.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "CoglPango-1.0": {
+      "file": "CoglPango-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "cogl-devel",
+      "sourceRpm": "cogl-1.22.8-18.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "CoglPango-2.0": {
+      "file": "CoglPango-2.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "cogl-devel",
+      "sourceRpm": "cogl-1.22.8-18.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org/"
+    },
+    "Colord-1.0": {
+      "file": "Colord-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "colord-devel",
+      "sourceRpm": "colord-1.4.8-5.fc45.src.rpm",
+      "upstreamUrl": "https://www.freedesktop.org/software/colord/"
+    },
+    "ColordGtk-1.0": {
+      "file": "ColordGtk-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "colord-gtk-devel",
+      "sourceRpm": "colord-gtk-0.3.1-9.fc45.src.rpm",
+      "upstreamUrl": "http://www.freedesktop.org/software/colord/"
+    },
+    "Colorhug-1.0": {
+      "file": "Colorhug-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "colord-devel",
+      "sourceRpm": "colord-1.4.8-5.fc45.src.rpm",
+      "upstreamUrl": "https://www.freedesktop.org/software/colord/"
+    },
+    "CryptUI-0.0": {
+      "file": "CryptUI-0.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libcryptui-devel",
+      "sourceRpm": "libcryptui-3.12.2-46.fc45.src.rpm",
+      "upstreamUrl": "http://projects.gnome.org/seahorse/"
+    },
+    "CudaGst-1.0": {
+      "file": "CudaGst-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "Cvc-1.0": {
+      "file": "Cvc-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "cinnamon-desktop-devel",
+      "sourceRpm": "cinnamon-desktop-6.7.3^unstable-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/cinnamon-desktop"
+    },
+    "DBus-1.0": {
+      "file": "DBus-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "DBusGLib-1.0": {
+      "file": "DBusGLib-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "Dazzle-1.0": {
+      "file": "Dazzle-1.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libdazzle-devel",
+      "sourceRpm": "libdazzle-3.44.0-12.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libdazzle"
+    },
+    "Dbusmenu-0.4": {
+      "file": "Dbusmenu-0.4.gir",
+      "license": "(LGPL-3.0-only OR LGPL-2.1-only) AND GPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "libdbusmenu-devel",
+      "sourceRpm": "libdbusmenu-16.04.0-32.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/libdbusmenu"
+    },
+    "DbusmenuGtk-0.4": {
+      "file": "DbusmenuGtk-0.4.gir",
+      "license": "(LGPL-3.0-only OR LGPL-2.1-only) AND GPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "libdbusmenu-gtk2-devel",
+      "sourceRpm": "libdbusmenu-16.04.0-32.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/libdbusmenu"
+    },
+    "DbusmenuGtk3-0.4": {
+      "file": "DbusmenuGtk3-0.4.gir",
+      "license": "(LGPL-3.0-only OR LGPL-2.1-only) AND GPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "libdbusmenu-gtk3-devel",
+      "sourceRpm": "libdbusmenu-16.04.0-32.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/libdbusmenu"
+    },
+    "Dee-1.0": {
+      "file": "Dee-1.0.gir",
+      "license": "LGPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "dee-devel",
+      "sourceRpm": "dee-1.2.7-69.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/dee"
+    },
+    "Devhelp-3.0": {
+      "file": "Devhelp-3.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "devhelp-devel",
+      "sourceRpm": "devhelp-43.0-19.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Devhelp"
+    },
+    "Dex-1": {
+      "file": "Dex-1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libdex-devel",
+      "sourceRpm": "libdex-1.2~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libdex"
+    },
+    "Dmap-4.0": {
+      "file": "Dmap-4.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libdmapsharing4-devel",
+      "sourceRpm": "libdmapsharing4-3.9.14-2.fc45.src.rpm",
+      "upstreamUrl": "https://www.flyn.org/projects/libdmapsharing/"
+    },
+    "EBackend-1.2": {
+      "file": "EBackend-1.2.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "EBook-1.2": {
+      "file": "EBook-1.2.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "EBookContacts-1.2": {
+      "file": "EBookContacts-1.2.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "ECal-2.0": {
+      "file": "ECal-2.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "EDataBook-1.2": {
+      "file": "EDataBook-1.2.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "EDataCal-2.0": {
+      "file": "EDataCal-2.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "EDataServer-1.2": {
+      "file": "EDataServer-1.2.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "EDataServerUI-1.2": {
+      "file": "EDataServerUI-1.2.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "EDataServerUI4-1.0": {
+      "file": "EDataServerUI4-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "evolution-data-server-devel",
+      "sourceRpm": "evolution-data-server-3.61.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/evolution/-/wikis/home"
+    },
+    "Easyfc-0.14": {
+      "file": "Easyfc-0.14.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libeasyfc-gobject-devel",
+      "sourceRpm": "libeasyfc-0.14.1-8.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.com/tagoh/libeasyfc/"
+    },
+    "Entangle-0.1": {
+      "file": "Entangle-0.1.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "entangle",
+      "sourceRpm": "entangle-3.0-18.fc45.src.rpm",
+      "upstreamUrl": "https://entangle-photo.org/"
+    },
+    "Eog-3.0": {
+      "file": "Eog-3.0.gir",
+      "license": "GPL-2.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "eog",
+      "sourceRpm": "eog-50.2-3.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/EyeOfGnome"
+    },
+    "Eom-1.0": {
+      "file": "Eom-1.0.gir",
+      "license": "GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "eom-devel",
+      "sourceRpm": "eom-1.28.1-3.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "EvinceDocument-3.0": {
+      "file": "EvinceDocument-3.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND X11 AND MIT AND Afmparse",
+      "source": "fedora",
+      "sourcePackage": "evince-devel",
+      "sourceRpm": "evince-48.1-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Evince"
+    },
+    "EvinceView-3.0": {
+      "file": "EvinceView-3.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND X11 AND MIT AND Afmparse",
+      "source": "fedora",
+      "sourcePackage": "evince-devel",
+      "sourceRpm": "evince-48.1-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Evince"
+    },
+    "FPrint-2.0": {
+      "file": "FPrint-2.0.gir",
+      "license": "LGPL-2.1-or-later AND NIST-PD",
+      "source": "fedora",
+      "sourcePackage": "libfprint-devel",
+      "sourceRpm": "libfprint-1.94.100-1.fc45.src.rpm",
+      "upstreamUrl": "http://www.freedesktop.org/wiki/Software/fprint/libfprint"
+    },
+    "Farstream-0.2": {
+      "file": "Farstream-0.2.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+ AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "farstream02-devel",
+      "sourceRpm": "farstream02-0.2.9-21.fc45.src.rpm",
+      "upstreamUrl": "https://www.freedesktop.org/wiki/Software/Farstream/"
+    },
+    "Fcitx-1.0": {
+      "file": "Fcitx-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "fcitx-devel",
+      "sourceRpm": "fcitx-4.2.9.9-14.fc45.src.rpm",
+      "upstreamUrl": "https://fcitx-im.org/wiki/Fcitx"
+    },
+    "FcitxG-1.0": {
+      "file": "FcitxG-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "fcitx5-gtk-devel",
+      "sourceRpm": "fcitx5-gtk-5.1.7-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/fcitx/fcitx5-gtk"
+    },
+    "Fep-1.0": {
+      "file": "Fep-1.0.gir",
+      "license": "LicenseRef-Callaway-BSD AND GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libfep-devel",
+      "sourceRpm": "libfep-0.1.0-31.fc45.src.rpm",
+      "upstreamUrl": "http://github.com/ueno/libfep"
+    },
+    "Flatpak-1.0": {
+      "file": "Flatpak-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "flatpak-devel",
+      "sourceRpm": "flatpak-1.19.0-2.fc46.src.rpm",
+      "upstreamUrl": "https://flatpak.org/"
+    },
+    "Folks-0.7": {
+      "file": "Folks-0.7.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "folks-devel",
+      "sourceRpm": "folks-0.15.12-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Folks"
+    },
+    "FolksDummy-0.7": {
+      "file": "FolksDummy-0.7.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "folks-devel",
+      "sourceRpm": "folks-0.15.12-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Folks"
+    },
+    "FolksEds-0.7": {
+      "file": "FolksEds-0.7.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "folks-devel",
+      "sourceRpm": "folks-0.15.12-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Folks"
+    },
+    "FolksTelepathy-0.7": {
+      "file": "FolksTelepathy-0.7.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "folks-devel",
+      "sourceRpm": "folks-0.15.12-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Folks"
+    },
+    "Foundry-1": {
+      "file": "Foundry-1.gir",
+      "license": "LGPL-2.1-or-later AND Apache-2.0",
+      "source": "fedora",
+      "sourcePackage": "libfoundry-devel",
+      "sourceRpm": "foundry-1.2~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/foundry"
+    },
+    "FoundryAdw-1": {
+      "file": "FoundryAdw-1.gir",
+      "license": "LGPL-2.1-or-later AND Apache-2.0",
+      "source": "fedora",
+      "sourcePackage": "libfoundry-devel",
+      "sourceRpm": "foundry-1.2~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/foundry"
+    },
+    "FoundryGtk-1": {
+      "file": "FoundryGtk-1.gir",
+      "license": "LGPL-2.1-or-later AND Apache-2.0",
+      "source": "fedora",
+      "sourcePackage": "libfoundry-gtk-devel",
+      "sourceRpm": "foundry-1.2~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/foundry"
+    },
+    "Fwupd-2.0": {
+      "file": "Fwupd-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "fwupd-devel",
+      "sourceRpm": "fwupd-2.1.7-1.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/fwupd/fwupd"
+    },
+    "GCab-1.0": {
+      "file": "GCab-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgcab1-devel",
+      "sourceRpm": "gcab-1.6-12.fc45.src.rpm",
+      "upstreamUrl": "http://ftp.gnome.org/pub/GNOME/sources/gcab"
+    },
+    "GCalc-2": {
+      "file": "GCalc-2.gir",
+      "license": "GPL-3.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "gnome-calculator-devel",
+      "sourceRpm": "gnome-calculator-51~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Calculator"
+    },
+    "GCi-1": {
+      "file": "GCi-1.gir",
+      "license": "GPL-3.0-or-later AND CC-BY-SA-3.0 AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "gnome-calculator-devel",
+      "sourceRpm": "gnome-calculator-51~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Calculator"
+    },
+    "GConf-2.0": {
+      "file": "GConf-2.0.gir",
+      "license": "LGPL-2.0-or-later AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "GConf2-devel",
+      "sourceRpm": "GConf2-3.2.6-50.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/Archive/gconf/"
+    },
+    "GDesktopEnums-3.0": {
+      "file": "GDesktopEnums-3.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gsettings-desktop-schemas-devel",
+      "sourceRpm": "gsettings-desktop-schemas-51~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas"
+    },
+    "GES-1.0": {
+      "file": "GES-1.0.gir",
+      "license": "GPL-2.0-or-later and LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gst-editing-services-devel",
+      "sourceRpm": "gst-editing-services-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://cgit.freedesktop.org/gstreamer/gst-editing-services/"
+    },
+    "GExiv2-0.10": {
+      "file": "GExiv2-0.10.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgexiv2_0.14-devel",
+      "sourceRpm": "libgexiv2_0.14-0.14.7-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/gexiv2"
+    },
+    "GExiv2-0.16": {
+      "file": "GExiv2-0.16.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgexiv2-devel",
+      "sourceRpm": "libgexiv2-0.16.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/gexiv2"
+    },
+    "GIRepository-2.0": {
+      "file": "GIRepository-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "GIRepository-3.0": {
+      "file": "GIRepository-3.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "glib2-devel",
+      "sourceRpm": "glib2-2.89.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GL-1.0": {
+      "file": "GL-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "GLib-2.0": {
+      "file": "GLib-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "glib2-devel",
+      "sourceRpm": "glib2-2.89.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GLibUnix-2.0": {
+      "file": "GLibUnix-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "glib2-devel",
+      "sourceRpm": "glib2-2.89.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GLibWin32-2.0": {
+      "file": "GLibWin32-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/glib.git"
+    },
+    "GMenu-3.0": {
+      "file": "GMenu-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-menus-devel",
+      "sourceRpm": "gnome-menus-3.38.1-9.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-menus"
+    },
+    "GMime-2.6": {
+      "file": "GMime-2.6.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+ AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gmime-devel",
+      "sourceRpm": "gmime-2.6.23-27.fc45.src.rpm",
+      "upstreamUrl": "http://spruce.sourceforge.net/gmime/"
+    },
+    "GMime-3.0": {
+      "file": "GMime-3.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gmime30-devel",
+      "sourceRpm": "gmime30-3.2.15-8.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/jstedfast/gmime"
+    },
+    "GModule-2.0": {
+      "file": "GModule-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "glib2-devel",
+      "sourceRpm": "glib2-2.89.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GObject-2.0": {
+      "file": "GObject-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "glib2-devel",
+      "sourceRpm": "glib2-2.89.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GPaste-2": {
+      "file": "GPaste-2.gir",
+      "license": "BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gpaste-devel",
+      "sourceRpm": "gpaste-50.6-1.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/Keruspe/GPaste/"
+    },
+    "GPasteGtk-4": {
+      "file": "GPasteGtk-4.gir",
+      "license": "BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gpaste-devel",
+      "sourceRpm": "gpaste-50.6-1.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/Keruspe/GPaste/"
+    },
+    "GPlugin-1.0": {
+      "file": "GPlugin-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gplugin-devel",
+      "sourceRpm": "gplugin-0.44.2-9.fc45.src.rpm",
+      "upstreamUrl": "https://keep.imfreedom.org/gplugin/gplugin"
+    },
+    "GPluginGtk4-1.0": {
+      "file": "GPluginGtk4-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gplugin-gtk4-devel",
+      "sourceRpm": "gplugin-0.44.2-9.fc45.src.rpm",
+      "upstreamUrl": "https://keep.imfreedom.org/gplugin/gplugin"
+    },
+    "GSSDP-1.6": {
+      "file": "GSSDP-1.6.gir",
+      "license": "LGPL-2.1-or-later AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "gssdp-devel",
+      "sourceRpm": "gssdp-1.6.6-3.fc45.src.rpm",
+      "upstreamUrl": "http://www.gupnp.org/"
+    },
+    "GSound-1.0": {
+      "file": "GSound-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gsound-devel",
+      "sourceRpm": "gsound-1.0.3-21.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GSound"
+    },
+    "GTop-2.0": {
+      "file": "GTop-2.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgtop2-devel",
+      "sourceRpm": "libgtop2-2.41.3-13.fc45.src.rpm",
+      "upstreamUrl": "https://download.gnome.org/sources/libgtop"
+    },
+    "GUPnP-1.6": {
+      "file": "GUPnP-1.6.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gupnp-devel",
+      "sourceRpm": "gupnp-1.6.10-3.fc45.src.rpm",
+      "upstreamUrl": "https://www.gupnp.org/"
+    },
+    "GUPnPAV-1.0": {
+      "file": "GUPnPAV-1.0.gir",
+      "license": "LGPL-2.1-or-later AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "gupnp-av-devel",
+      "sourceRpm": "gupnp-av-0.14.5-3.fc45.src.rpm",
+      "upstreamUrl": "http://www.gupnp.org/"
+    },
+    "GUPnPDLNA-2.0": {
+      "file": "GUPnPDLNA-2.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gupnp-dlna-devel",
+      "sourceRpm": "gupnp-dlna-0.12.0-21.fc45.src.rpm",
+      "upstreamUrl": "http://www.gupnp.org/"
+    },
+    "GUPnPDLNAGst-2.0": {
+      "file": "GUPnPDLNAGst-2.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gupnp-dlna-devel",
+      "sourceRpm": "gupnp-dlna-0.12.0-21.fc45.src.rpm",
+      "upstreamUrl": "http://www.gupnp.org/"
+    },
+    "GUPnPIgd-1.6": {
+      "file": "GUPnPIgd-1.6.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gupnp-igd-devel",
+      "sourceRpm": "gupnp-igd-1.6.0-15.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GUPnP"
+    },
+    "GUdev-1.0": {
+      "file": "GUdev-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgudev-devel",
+      "sourceRpm": "libgudev-238-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/libgudev"
+    },
+    "GUsb-1.0": {
+      "file": "GUsb-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgusb-devel",
+      "sourceRpm": "libgusb-0.4.9-6.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/hughsie/libgusb"
+    },
+    "GVnc-1.0": {
+      "file": "GVnc-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gvnc-devel",
+      "sourceRpm": "gtk-vnc-1.5.0-6.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gtk-vnc"
+    },
+    "GVncPulse-1.0": {
+      "file": "GVncPulse-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gvncpulse-devel",
+      "sourceRpm": "gtk-vnc-1.5.0-6.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gtk-vnc"
+    },
+    "GWeather-4.0": {
+      "file": "GWeather-4.0.gir",
+      "license": "GPL-2.0-or-later AND BSD-3-Clause",
+      "source": "fedora",
+      "sourcePackage": "libgweather-devel",
+      "sourceRpm": "libgweather-4.6.0-5.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/LibGWeather"
+    },
+    "GXPS-0.1": {
+      "file": "GXPS-0.1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgxps-devel",
+      "sourceRpm": "libgxps-0.3.2-13.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/libgxps"
+    },
+    "Gamerzilla-0.1": {
+      "file": "Gamerzilla-0.1.gir",
+      "license": "zlib",
+      "source": "fedora",
+      "sourcePackage": "gamerzillagobj-devel",
+      "sourceRpm": "gamerzillagobj-0.1.3-4.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/dulsi/gamerzillagobj"
+    },
+    "Garcon-1.0": {
+      "file": "Garcon-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-GFDL",
+      "source": "fedora",
+      "sourcePackage": "garcon",
+      "sourceRpm": "garcon-4.20.0-6.fc45.src.rpm",
+      "upstreamUrl": "http://xfce.org/"
+    },
+    "GarconGtk-1.0": {
+      "file": "GarconGtk-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+ AND LicenseRef-Callaway-GFDL",
+      "source": "fedora",
+      "sourcePackage": "garcon",
+      "sourceRpm": "garcon-4.20.0-6.fc45.src.rpm",
+      "upstreamUrl": "http://xfce.org/"
+    },
+    "Gc-1.0": {
+      "file": "Gc-1.0.gir",
+      "license": "BSD-3-Clause AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-characters",
+      "sourceRpm": "gnome-characters-50.0-6.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Design/Apps/CharacterMap"
+    },
+    "Gck-1": {
+      "file": "Gck-1.gir",
+      "license": "LGPL-2.1-or-later AND LicenseRef-Fedora-Public-Domain AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs",
+      "source": "fedora",
+      "sourcePackage": "gcr3-devel",
+      "sourceRpm": "gcr3-3.41.1-13.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/CryptoGlue"
+    },
+    "Gck-2": {
+      "file": "Gck-2.gir",
+      "license": "LGPL-2.1-or-later AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs",
+      "source": "fedora",
+      "sourcePackage": "gcr-devel",
+      "sourceRpm": "gcr-4.4.0.1-14.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gcr"
+    },
+    "Gcr-3": {
+      "file": "Gcr-3.gir",
+      "license": "LGPL-2.1-or-later AND LicenseRef-Fedora-Public-Domain AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs",
+      "source": "fedora",
+      "sourcePackage": "gcr3-devel",
+      "sourceRpm": "gcr3-3.41.1-13.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/CryptoGlue"
+    },
+    "Gcr-4": {
+      "file": "Gcr-4.gir",
+      "license": "LGPL-2.1-or-later AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs",
+      "source": "fedora",
+      "sourcePackage": "gcr-devel",
+      "sourceRpm": "gcr-4.4.0.1-14.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gcr"
+    },
+    "GcrUi-3": {
+      "file": "GcrUi-3.gir",
+      "license": "LGPL-2.1-or-later AND LicenseRef-Fedora-Public-Domain AND FSFULLRWD AND (LGPL-3.0-or-later OR CC-BY-SA-3.0) AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND GCR-docs",
+      "source": "fedora",
+      "sourcePackage": "gcr3-devel",
+      "sourceRpm": "gcr3-3.41.1-13.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/CryptoGlue"
+    },
+    "Gda-5.0": {
+      "file": "Gda-5.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgda5-devel",
+      "sourceRpm": "libgda5-5.2.10-29.fc46.src.rpm",
+      "upstreamUrl": "http://www.gnome-db.org/"
+    },
+    "Gda-6.0": {
+      "file": "Gda-6.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgda-devel",
+      "sourceRpm": "libgda-6.0.0-27.fc45.src.rpm",
+      "upstreamUrl": "http://www.gnome-db.org/"
+    },
+    "Gdaui-5.0": {
+      "file": "Gdaui-5.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgda5-ui-devel",
+      "sourceRpm": "libgda5-5.2.10-29.fc46.src.rpm",
+      "upstreamUrl": "http://www.gnome-db.org/"
+    },
+    "Gdaui-6.0": {
+      "file": "Gdaui-6.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgda-ui-devel",
+      "sourceRpm": "libgda-6.0.0-27.fc45.src.rpm",
+      "upstreamUrl": "http://www.gnome-db.org/"
+    },
+    "Gdk-2.0": {
+      "file": "Gdk-2.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "gtk2-devel",
+      "sourceRpm": "gtk2-2.24.33-28.fc45.src.rpm",
+      "upstreamUrl": "http://www.gtk.org"
+    },
+    "Gdk-3.0": {
+      "file": "Gdk-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gtk3-devel",
+      "sourceRpm": "gtk3-3.24.52-6.fc45.src.rpm",
+      "upstreamUrl": "https://gtk.org"
+    },
+    "Gdk-4.0": {
+      "file": "Gdk-4.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1",
+      "source": "fedora",
+      "sourcePackage": "gtk4-devel",
+      "sourceRpm": "gtk4-4.23.3-1.fc45.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GdkMacos-4.0": {
+      "file": "GdkMacos-4.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "docLicense": "GPL-2.1-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gtk.git"
+    },
+    "GdkPixbuf-2.0": {
+      "file": "GdkPixbuf-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gdk-pixbuf2-devel",
+      "sourceRpm": "gdk-pixbuf2-2.44.8-2.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gdk-pixbuf"
+    },
+    "GdkPixdata-2.0": {
+      "file": "GdkPixdata-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gdk-pixbuf2-devel",
+      "sourceRpm": "gdk-pixbuf2-2.44.8-2.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gdk-pixbuf"
+    },
+    "GdkWayland-4.0": {
+      "file": "GdkWayland-4.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1",
+      "source": "fedora",
+      "sourcePackage": "gtk4-devel",
+      "sourceRpm": "gtk4-4.23.3-1.fc45.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GdkWin32-4.0": {
+      "file": "GdkWin32-4.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "docLicense": "GPL-2.1-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gtk.git"
+    },
+    "GdkX11-2.0": {
+      "file": "GdkX11-2.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "gtk2-devel",
+      "sourceRpm": "gtk2-2.24.33-28.fc45.src.rpm",
+      "upstreamUrl": "http://www.gtk.org"
+    },
+    "GdkX11-3.0": {
+      "file": "GdkX11-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gtk3-devel",
+      "sourceRpm": "gtk3-3.24.52-6.fc45.src.rpm",
+      "upstreamUrl": "https://gtk.org"
+    },
+    "GdkX11-4.0": {
+      "file": "GdkX11-4.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1",
+      "source": "fedora",
+      "sourcePackage": "gtk4-devel",
+      "sourceRpm": "gtk4-4.23.3-1.fc45.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "Gdl-3": {
+      "file": "Gdl-3.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgdl-devel",
+      "sourceRpm": "libgdl-3.40.0-15.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/Archive/gdl"
+    },
+    "Gdm-1.0": {
+      "file": "Gdm-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gdm-devel",
+      "sourceRpm": "gdm-51~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GDM"
+    },
+    "Gedit-3.0": {
+      "file": "Gedit-3.0.gir",
+      "license": "GPL-3.0-or-later AND LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gedit",
+      "sourceRpm": "gedit-50.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://gedit-text-editor.org/"
+    },
+    "Gee-0.8": {
+      "file": "Gee-0.8.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgee-devel",
+      "sourceRpm": "libgee-0.20.8-4.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Libgee"
+    },
+    "Gegl-0.4": {
+      "file": "Gegl-0.4.gir",
+      "license": "GPL-3.0-or-later AND LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gegl04-devel",
+      "sourceRpm": "gegl04-0.4.70-4.fc45.src.rpm",
+      "upstreamUrl": "https://www.gegl.org/"
+    },
+    "Geoclue-2.0": {
+      "file": "Geoclue-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND GFDL-1.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "geoclue2-devel",
+      "sourceRpm": "geoclue2-2.8.2-2.fc45.src.rpm",
+      "upstreamUrl": "http://www.freedesktop.org/wiki/Software/GeoClue/"
+    },
+    "GeocodeGlib-2.0": {
+      "file": "GeocodeGlib-2.0.gir",
+      "license": "LGPL-2.0-or-later AND BSD-3-Clause",
+      "source": "fedora",
+      "sourcePackage": "geocode-glib-devel",
+      "sourceRpm": "geocode-glib-3.26.4-21.fc45.src.rpm",
+      "upstreamUrl": "http://www.gnome.org/"
+    },
+    "Gepub-0.7": {
+      "file": "Gepub-0.7.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgepub-devel",
+      "sourceRpm": "libgepub-0.7.3-13.fc45.src.rpm",
+      "upstreamUrl": "https://git.gnome.org/browse/libgepub"
+    },
+    "Gfls-1": {
+      "file": "Gfls-1.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgedit-gfls-devel",
+      "sourceRpm": "libgedit-gfls-0.4.1-2.fc45.src.rpm",
+      "upstreamUrl": "https://gedit-text-editor.org/"
+    },
+    "Ggit-1.0": {
+      "file": "Ggit-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgit2-glib-devel",
+      "sourceRpm": "libgit2-glib-1.2.1-18.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Libgit2-glib"
+    },
+    "Gimp-3.0": {
+      "file": "Gimp-3.0.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gimp-devel",
+      "sourceRpm": "gimp-3.2.4-4.fc46.src.rpm",
+      "upstreamUrl": "https://www.gimp.org"
+    },
+    "GimpUi-3.0": {
+      "file": "GimpUi-3.0.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gimp-devel",
+      "sourceRpm": "gimp-3.2.4-4.fc46.src.rpm",
+      "upstreamUrl": "https://www.gimp.org"
+    },
+    "Gio-2.0": {
+      "file": "Gio-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "glib2-devel",
+      "sourceRpm": "glib2-2.89.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GioUnix-2.0": {
+      "file": "GioUnix-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "glib2-devel",
+      "sourceRpm": "glib2-2.89.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "GioWin32-2.0": {
+      "file": "GioWin32-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/glib.git"
+    },
+    "Gitg-1.0": {
+      "file": "Gitg-1.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND MIT",
+      "source": "fedora",
+      "sourcePackage": "gitg-devel",
+      "sourceRpm": "gitg-50-4.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Gitg"
+    },
+    "GitgExt-1.0": {
+      "file": "GitgExt-1.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND MIT",
+      "source": "fedora",
+      "sourcePackage": "gitg-devel",
+      "sourceRpm": "gitg-50-4.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Gitg"
+    },
+    "Gkbd-3.0": {
+      "file": "Gkbd-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgnomekbd-devel",
+      "sourceRpm": "libgnomekbd-3.28.1-10.fc45.src.rpm",
+      "upstreamUrl": "http://gswitchit.sourceforge.net"
+    },
+    "Gladeui-2.0": {
+      "file": "Gladeui-2.0.gir",
+      "license": "GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "glade-devel",
+      "sourceRpm": "glade-3.40.0-17.fc45.src.rpm",
+      "upstreamUrl": "https://glade.gnome.org/"
+    },
+    "Gly-2": {
+      "file": "Gly-2.gir",
+      "license": "(MPL-2.0 OR LGPL-2.1-or-later) AND Apache-2.0 WITH LLVM-exception AND BSD-3-Clause AND CC0-1.0 AND GPL-3.0-or-later AND IJG AND ISC AND MIT AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)",
+      "source": "fedora",
+      "sourcePackage": "glycin-devel",
+      "sourceRpm": "glycin-2.2~beta-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/glycin"
+    },
+    "GlyGtk4-2": {
+      "file": "GlyGtk4-2.gir",
+      "license": "(MPL-2.0 OR LGPL-2.1-or-later) AND Apache-2.0 WITH LLVM-exception AND BSD-3-Clause AND CC0-1.0 AND GPL-3.0-or-later AND IJG AND ISC AND MIT AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)",
+      "source": "fedora",
+      "sourcePackage": "glycin-gtk4-devel",
+      "sourceRpm": "glycin-2.2~beta-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/glycin"
+    },
+    "Gm-0": {
+      "file": "Gm-0.gir",
+      "license": "LGPL-2.1-or-later AND GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gmobile-devel",
+      "sourceRpm": "gmobile-0.7.3-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/World/Phosh/gmobile"
+    },
+    "GnomeAutoar-0.1": {
+      "file": "GnomeAutoar-0.1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-autoar-devel",
+      "sourceRpm": "gnome-autoar-0.4.5-11.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-autoar"
+    },
+    "GnomeAutoarGtk-0.1": {
+      "file": "GnomeAutoarGtk-0.1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-autoar-devel",
+      "sourceRpm": "gnome-autoar-0.4.5-11.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-autoar"
+    },
+    "GnomeBG-4.0": {
+      "file": "GnomeBG-4.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-desktop4-devel",
+      "sourceRpm": "gnome-desktop3-51~alpha-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-desktop"
+    },
+    "GnomeBluetooth-1.0": {
+      "file": "GnomeBluetooth-1.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-or-later AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-bluetooth3.34-libs-devel",
+      "sourceRpm": "gnome-bluetooth3.34-3.34.5-12.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GnomeBluetooth"
+    },
+    "GnomeBluetooth-3.0": {
+      "file": "GnomeBluetooth-3.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-bluetooth-libs-devel",
+      "sourceRpm": "gnome-bluetooth-47.2-3.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GnomeBluetooth"
+    },
+    "GnomeCmd-1.0": {
+      "file": "GnomeCmd-1.0.gir",
+      "license": "GPL-3.0-or-later AND GFDL-1.3-or-later AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "gnome-commander",
+      "sourceRpm": "gnome-commander-2.0.3-2.fc45.src.rpm",
+      "upstreamUrl": "https://gnome.pages.gitlab.gnome.org/gnome-commander/"
+    },
+    "GnomeDesktop-3.0": {
+      "file": "GnomeDesktop-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-desktop3-devel",
+      "sourceRpm": "gnome-desktop3-51~alpha-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-desktop"
+    },
+    "GnomeDesktop-4.0": {
+      "file": "GnomeDesktop-4.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-desktop4-devel",
+      "sourceRpm": "gnome-desktop3-51~alpha-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-desktop"
+    },
+    "GnomeKeyring-1.0": {
+      "file": "GnomeKeyring-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libgnome-keyring-devel",
+      "sourceRpm": "libgnome-keyring-3.12.0-34.fc45.src.rpm",
+      "upstreamUrl": "http://live.gnome.org/GnomeKeyring"
+    },
+    "GnomeMaps-1.0": {
+      "file": "GnomeMaps-1.0.gir",
+      "license": "GPL-2.0-or-later AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "gnome-maps",
+      "sourceRpm": "gnome-maps-51~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Maps"
+    },
+    "GnomeQR-4.0": {
+      "file": "GnomeQR-4.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-desktop4-devel",
+      "sourceRpm": "gnome-desktop3-51~alpha-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-desktop"
+    },
+    "GnomeQRGtk-4.0": {
+      "file": "GnomeQRGtk-4.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-desktop4-devel",
+      "sourceRpm": "gnome-desktop3-51~alpha-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-desktop"
+    },
+    "GoVirt-1.0": {
+      "file": "GoVirt-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgovirt-devel",
+      "sourceRpm": "libgovirt-0.3.11-2.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libgovirt"
+    },
+    "Goa-1.0": {
+      "file": "Goa-1.0.gir",
+      "license": "LGPL-2.0-or-later AND CC-BY-SA-4.0",
+      "source": "fedora",
+      "sourcePackage": "gnome-online-accounts-devel",
+      "sourceRpm": "gnome-online-accounts-3.58.1-3.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GnomeOnlineAccounts"
+    },
+    "Gom-1.0": {
+      "file": "Gom-1.0.gir",
+      "license": "LGPL-2.1-or-later AND GFDL-1.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gom-devel",
+      "sourceRpm": "gom-0.5.6-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Gom"
+    },
+    "GooCanvas-2.0": {
+      "file": "GooCanvas-2.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "goocanvas2-devel",
+      "sourceRpm": "goocanvas2-2.0.4-23.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects(2f)GooCanvas.html"
+    },
+    "Gpiodglib-1.0": {
+      "file": "Gpiodglib-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgpiod-devel",
+      "sourceRpm": "libgpiod-2.3.1-3.fc45.src.rpm",
+      "upstreamUrl": "https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/"
+    },
+    "Granite-1.0": {
+      "file": "Granite-1.0.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "granite-devel",
+      "sourceRpm": "granite-6.2.0-13.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/elementary/granite"
+    },
+    "Graphene-1.0": {
+      "file": "Graphene-1.0.gir",
+      "license": "MIT",
+      "source": "fedora",
+      "sourcePackage": "graphene-devel",
+      "sourceRpm": "graphene-1.10.8-6.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/ebassi/graphene"
+    },
+    "Grl-0.3": {
+      "file": "Grl-0.3.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "grilo-devel",
+      "sourceRpm": "grilo-0.3.19-9.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Grilo"
+    },
+    "GrlNet-0.3": {
+      "file": "GrlNet-0.3.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "grilo-devel",
+      "sourceRpm": "grilo-0.3.19-9.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Grilo"
+    },
+    "GrlPls-0.3": {
+      "file": "GrlPls-0.3.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "grilo-devel",
+      "sourceRpm": "grilo-0.3.19-9.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Grilo"
+    },
+    "Grss-0.7": {
+      "file": "Grss-0.7.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgrss-devel",
+      "sourceRpm": "libgrss-0.7.0-25.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Libgrss"
+    },
+    "Gsf-1": {
+      "file": "Gsf-1.gir",
+      "license": "LGPL-2.1-only",
+      "source": "fedora",
+      "sourcePackage": "libgsf-devel",
+      "sourceRpm": "libgsf-1.14.58-3.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libgsf/"
+    },
+    "Gsk-4.0": {
+      "file": "Gsk-4.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1",
+      "source": "fedora",
+      "sourcePackage": "gtk4-devel",
+      "sourceRpm": "gtk4-4.23.3-1.fc45.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "Gspell-1": {
+      "file": "Gspell-1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gspell-devel",
+      "sourceRpm": "gspell-1.14.4-3.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/gspell"
+    },
+    "Gst-1.0": {
+      "file": "Gst-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-devel",
+      "sourceRpm": "gstreamer1-1.28.6-2.fc46.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstAllocators-1.0": {
+      "file": "GstAllocators-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstAnalytics-1.0": {
+      "file": "GstAnalytics-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstApp-1.0": {
+      "file": "GstApp-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstAudio-1.0": {
+      "file": "GstAudio-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstBadAudio-1.0": {
+      "file": "GstBadAudio-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstBase-1.0": {
+      "file": "GstBase-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-devel",
+      "sourceRpm": "gstreamer1-1.28.6-2.fc46.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstCheck-1.0": {
+      "file": "GstCheck-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-devel",
+      "sourceRpm": "gstreamer1-1.28.6-2.fc46.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstCodecParsers-1.0": {
+      "file": "GstCodecParsers-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstCodecs-1.0": {
+      "file": "GstCodecs-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstController-1.0": {
+      "file": "GstController-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-devel",
+      "sourceRpm": "gstreamer1-1.28.6-2.fc46.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstCuda-1.0": {
+      "file": "GstCuda-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstDxva-1.0": {
+      "file": "GstDxva-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstGL-1.0": {
+      "file": "GstGL-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstGLEGL-1.0": {
+      "file": "GstGLEGL-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstGLWayland-1.0": {
+      "file": "GstGLWayland-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstGLX11-1.0": {
+      "file": "GstGLX11-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstHip-1.0": {
+      "file": "GstHip-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstHipGL-1.0": {
+      "file": "GstHipGL-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstInsertBin-1.0": {
+      "file": "GstInsertBin-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstMpegts-1.0": {
+      "file": "GstMpegts-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstMse-1.0": {
+      "file": "GstMse-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstNet-1.0": {
+      "file": "GstNet-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-devel",
+      "sourceRpm": "gstreamer1-1.28.6-2.fc46.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstPbutils-1.0": {
+      "file": "GstPbutils-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstPlay-1.0": {
+      "file": "GstPlay-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstPlayer-1.0": {
+      "file": "GstPlayer-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstRtp-1.0": {
+      "file": "GstRtp-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstRtsp-1.0": {
+      "file": "GstRtsp-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstRtspServer-1.0": {
+      "file": "GstRtspServer-1.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-only",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-rtsp-server-devel",
+      "sourceRpm": "gstreamer1-rtsp-server-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstSdp-1.0": {
+      "file": "GstSdp-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstTag-1.0": {
+      "file": "GstTag-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstTranscoder-1.0": {
+      "file": "GstTranscoder-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstVa-1.0": {
+      "file": "GstVa-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstValidate-1.0": {
+      "file": "GstValidate-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gst-devtools-devel",
+      "sourceRpm": "gst-devtools-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "https://gstreamer.freedesktop.org/src/gst-devtools"
+    },
+    "GstVideo-1.0": {
+      "file": "GstVideo-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-base-devel",
+      "sourceRpm": "gstreamer1-plugins-base-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstVulkan-1.0": {
+      "file": "GstVulkan-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstVulkanWayland-1.0": {
+      "file": "GstVulkanWayland-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "GstWebRTC-1.0": {
+      "file": "GstWebRTC-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later AND (MIT OR LGPL-2.1-or-later) AND MPL-1.1 AND BSD-2-Clause AND BSD-3-Clause AND BSD-2-Clause-Views AND (BSD-2-Clause AND DOC) AND MIT-Festival AND (LGPL-2.0-or-later AND LicenseRef-Fedora-Public-Domain) AND (MPL-1.1 OR LGPL-2.0-or-later OR MIT) AND BSD-3-Clause WITH AdditionRef-Dart AND MIT AND GPL-2.0-only WITH Linux-syscall-note",
+      "source": "fedora",
+      "sourcePackage": "gstreamer1-plugins-bad-free-devel",
+      "sourceRpm": "gstreamer1-plugins-bad-free-1.28.6-1.fc45.src.rpm",
+      "upstreamUrl": "http://gstreamer.freedesktop.org/"
+    },
+    "Gtd-1.0": {
+      "file": "Gtd-1.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gnome-todo-devel",
+      "sourceRpm": "gnome-todo-43.0-9.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/World/Endeavour/"
+    },
+    "Gtk-2.0": {
+      "file": "Gtk-2.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "gtk2-devel",
+      "sourceRpm": "gtk2-2.24.33-28.fc45.src.rpm",
+      "upstreamUrl": "http://www.gtk.org"
+    },
+    "Gtk-3.0": {
+      "file": "Gtk-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gtk3-devel",
+      "sourceRpm": "gtk3-3.24.52-6.fc45.src.rpm",
+      "upstreamUrl": "https://gtk.org"
+    },
+    "Gtk-4.0": {
+      "file": "Gtk-4.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1",
+      "source": "fedora",
+      "sourcePackage": "gtk4-devel",
+      "sourceRpm": "gtk4-4.23.3-1.fc45.src.rpm",
+      "upstreamUrl": "https://www.gtk.org"
+    },
+    "Gtk4LayerShell-1.0": {
+      "file": "Gtk4LayerShell-1.0.gir",
+      "license": "MIT",
+      "source": "fedora",
+      "sourcePackage": "gtk4-layer-shell-devel",
+      "sourceRpm": "gtk4-layer-shell-1.3.0-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/wmww/gtk4-layer-shell"
+    },
+    "Gtk4SessionLock-1.0": {
+      "file": "Gtk4SessionLock-1.0.gir",
+      "license": "MIT",
+      "source": "fedora",
+      "sourcePackage": "gtk4-layer-shell-devel",
+      "sourceRpm": "gtk4-layer-shell-1.3.0-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/wmww/gtk4-layer-shell"
+    },
+    "GtkChamplain-0.12": {
+      "file": "GtkChamplain-0.12.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libchamplain-devel",
+      "sourceRpm": "libchamplain-0.12.21-10.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/libchamplain"
+    },
+    "GtkClutter-1.0": {
+      "file": "GtkClutter-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "clutter-gtk-devel",
+      "sourceRpm": "clutter-gtk-1.8.4-25.fc45.src.rpm",
+      "upstreamUrl": "http://www.clutter-project.org"
+    },
+    "GtkLayerShell-0.1": {
+      "file": "GtkLayerShell-0.1.gir",
+      "license": "LGPL-3.0-or-later and MIT",
+      "source": "fedora",
+      "sourcePackage": "gtk-layer-shell-devel",
+      "sourceRpm": "gtk-layer-shell-0.10.1-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/wmww/gtk-layer-shell"
+    },
+    "GtkSessionLock-0.1": {
+      "file": "GtkSessionLock-0.1.gir",
+      "license": "GPL-3.0-or-later AND MIT",
+      "source": "fedora",
+      "sourcePackage": "gtk-session-lock-devel",
+      "sourceRpm": "gtk-session-lock-0.2.0-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/Cu3PO42/gtk-session-lock"
+    },
+    "GtkSource-2.0": {
+      "file": "GtkSource-2.0.gir",
+      "license": "LGPL-2.0-or-later AND GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gtksourceview2-devel",
+      "sourceRpm": "gtksourceview2-2.11.2-47.fc45.src.rpm",
+      "upstreamUrl": "http://gtksourceview.sourceforge.net/"
+    },
+    "GtkSource-3.0": {
+      "file": "GtkSource-3.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "gtksourceview3-devel",
+      "sourceRpm": "gtksourceview3-3.24.11-18.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GtkSourceView"
+    },
+    "GtkSource-300": {
+      "file": "GtkSource-300.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgedit-gtksourceview-devel",
+      "sourceRpm": "libgedit-gtksourceview-299.7.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://gedit-text-editor.org/"
+    },
+    "GtkSource-4": {
+      "file": "GtkSource-4.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "gtksourceview4-devel",
+      "sourceRpm": "gtksourceview4-4.8.4-12.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GtkSourceView"
+    },
+    "GtkSource-5": {
+      "file": "GtkSource-5.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gtksourceview5-devel",
+      "sourceRpm": "gtksourceview5-5.21.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GtkSourceView"
+    },
+    "GtkSpell-3.0": {
+      "file": "GtkSpell-3.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "gtkspell3-devel",
+      "sourceRpm": "gtkspell3-3.0.10-26.fc45.src.rpm",
+      "upstreamUrl": "https://gtkspell.sourceforge.net/"
+    },
+    "GtkVnc-2.0": {
+      "file": "GtkVnc-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "gtk-vnc2-devel",
+      "sourceRpm": "gtk-vnc-1.5.0-6.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gtk-vnc"
+    },
+    "Gucharmap-2.90": {
+      "file": "Gucharmap-2.90.gir",
+      "license": "GPL-3.0-or-later AND GFDL-1.3-or-later AND Unicode-DFS-2016",
+      "source": "fedora",
+      "sourcePackage": "gucharmap-devel",
+      "sourceRpm": "gucharmap-17.0.2-2.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Gucharmap"
+    },
+    "Gvc-1.0": {
+      "file": "Gvc-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Handy-1": {
+      "file": "Handy-1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libhandy-devel",
+      "sourceRpm": "libhandy-1.8.3-16.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libhandy"
+    },
+    "HarfBuzz-0.0": {
+      "file": "HarfBuzz-0.0.gir",
+      "license": "MIT-Modern-Variant",
+      "source": "fedora",
+      "sourcePackage": "harfbuzz-devel",
+      "sourceRpm": "harfbuzz-14.4.0-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/harfbuzz/harfbuzz/"
+    },
+    "Hex-4": {
+      "file": "Hex-4.gir",
+      "license": "GPL-2.0-or-later AND GFDL-1.1-no-invariants-or-later AND CC-BY-SA-4.0",
+      "source": "fedora",
+      "sourcePackage": "ghex-devel",
+      "sourceRpm": "ghex-50.3-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/ghex"
+    },
+    "IAnjuta-3.0": {
+      "file": "IAnjuta-3.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "anjuta-devel",
+      "sourceRpm": "anjuta-3.34.0-31.fc45.src.rpm",
+      "upstreamUrl": "http://www.anjuta.org/"
+    },
+    "IBus-1.0": {
+      "file": "IBus-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "ibus-devel",
+      "sourceRpm": "ibus-1.5.35~beta2-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/ibus/ibus/wiki"
+    },
+    "ICal-3.0": {
+      "file": "ICal-3.0.gir",
+      "license": "LGPL-2.1-only OR MPL-2.0",
+      "source": "fedora",
+      "sourcePackage": "libical-devel",
+      "sourceRpm": "libical-3.0.20-9.fc45.src.rpm",
+      "upstreamUrl": "https://libical.github.io/libical/"
+    },
+    "ICalGLib-3.0": {
+      "file": "ICalGLib-3.0.gir",
+      "license": "LGPL-2.1-only OR MPL-2.0",
+      "source": "fedora",
+      "sourcePackage": "libical-glib-devel",
+      "sourceRpm": "libical-3.0.20-9.fc45.src.rpm",
+      "upstreamUrl": "https://libical.github.io/libical/"
+    },
+    "IMSettings-1.8": {
+      "file": "IMSettings-1.8.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "imsettings-devel",
+      "sourceRpm": "imsettings-1.8.11-3.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.com/tagoh/imsettings/"
+    },
+    "Ide-50": {
+      "file": "Ide-50.gir",
+      "license": "GPL-3.0-or-later AND GPL-2.0-or-later AND LGPL-3.0-or-later AND LGPL-2.1-or-later AND LGPL-2.0-or-later AND MIT AND CC0-1.0 AND CC-BY-3.0",
+      "source": "fedora",
+      "sourcePackage": "gnome-builder-devel",
+      "sourceRpm": "gnome-builder-50.0-4.fc46.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Builder"
+    },
+    "InputPad-1.1": {
+      "file": "InputPad-1.1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "input-pad-devel",
+      "sourceRpm": "input-pad-1.1.0-6.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/fujiwarat/input-pad/wiki"
+    },
+    "Ipuz-1.0": {
+      "file": "Ipuz-1.0.gir",
+      "license": "(LGPL-2.1-or-later OR MIT) AND (Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND MIT AND (MIT OR Apache-2.0) AND (Unlicense OR MIT)",
+      "source": "fedora",
+      "sourcePackage": "libipuz-devel",
+      "sourceRpm": "libipuz-0.5.4-5.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/jrb/libipuz"
+    },
+    "JavaScriptCore-4.1": {
+      "file": "JavaScriptCore-4.1.gir",
+      "license": "LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+      "source": "fedora",
+      "sourcePackage": "javascriptcoregtk4.1-devel",
+      "sourceRpm": "webkitgtk-2.53.91-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.webkitgtk.org/"
+    },
+    "JavaScriptCore-6.0": {
+      "file": "JavaScriptCore-6.0.gir",
+      "license": "LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+      "source": "fedora",
+      "sourcePackage": "javascriptcoregtk6.0-devel",
+      "sourceRpm": "webkitgtk-2.53.91-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.webkitgtk.org/"
+    },
+    "Jcat-1.0": {
+      "file": "Jcat-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libjcat-devel",
+      "sourceRpm": "libjcat-0.2.6-1.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/hughsie/libjcat"
+    },
+    "Json-1.0": {
+      "file": "Json-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "json-glib-devel",
+      "sourceRpm": "json-glib-1.10.8-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/JsonGlib"
+    },
+    "Jsonrpc-1.0": {
+      "file": "Jsonrpc-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "jsonrpc-glib-devel",
+      "sourceRpm": "jsonrpc-glib-3.44.2-12.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/jsonrpc-glib"
+    },
+    "Keybinder-0.0": {
+      "file": "Keybinder-0.0.gir",
+      "license": "MIT",
+      "source": "fedora",
+      "sourcePackage": "keybinder",
+      "sourceRpm": "keybinder-0.3.1-34.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/engla/keybinder"
+    },
+    "Keybinder-3.0": {
+      "file": "Keybinder-3.0.gir",
+      "license": "MIT",
+      "source": "fedora",
+      "sourcePackage": "keybinder3-devel",
+      "sourceRpm": "keybinder3-0.3.2-23.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/kupferlauncher/keybinder"
+    },
+    "Kkc-1.0": {
+      "file": "Kkc-1.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libkkc-devel",
+      "sourceRpm": "libkkc-0.3.5-36.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/ueno/libkkc"
+    },
+    "LangTag-0.6": {
+      "file": "LangTag-0.6.gir",
+      "license": "LGPL-3.0-or-later OR MPL-2.0",
+      "source": "fedora",
+      "sourcePackage": "liblangtag-devel",
+      "sourceRpm": "liblangtag-0.6.8-1.fc46.src.rpm",
+      "upstreamUrl": "https://bitbucket.org/tagoh/liblangtag/"
+    },
+    "Lasem-0.6": {
+      "file": "Lasem-0.6.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "lasem-devel",
+      "sourceRpm": "lasem-0.6.0-5.fc45.src.rpm",
+      "upstreamUrl": "https://lasemproject.github.io/lasem/"
+    },
+    "Lfb-0.0": {
+      "file": "Lfb-0.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "feedbackd-devel",
+      "sourceRpm": "feedbackd-0.8.9-4.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/feedbackd/feedbackd"
+    },
+    "Libinsane-1.0": {
+      "file": "Libinsane-1.0.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libinsane-gobject-devel",
+      "sourceRpm": "libinsane-1.0.10-10.fc45.src.rpm",
+      "upstreamUrl": "https://doc.openpaper.work/libinsane/latest/"
+    },
+    "Libmsi-1.0": {
+      "file": "Libmsi-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libmsi1-devel",
+      "sourceRpm": "msitools-0.106.73-1.fc45.src.rpm",
+      "upstreamUrl": "http://ftp.gnome.org/pub/GNOME/sources/msitools"
+    },
+    "Libosinfo-1.0": {
+      "file": "Libosinfo-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libosinfo-devel",
+      "sourceRpm": "libosinfo-1.12.0-10.fc45.src.rpm",
+      "upstreamUrl": "https://libosinfo.org/"
+    },
+    "Libproxy-1.0": {
+      "file": "Libproxy-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libproxy-devel",
+      "sourceRpm": "libproxy-0.5.12-3.fc45.src.rpm",
+      "upstreamUrl": "https://libproxy.github.io/libproxy/"
+    },
+    "LibvirtGConfig-1.0": {
+      "file": "LibvirtGConfig-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libvirt-gconfig-devel",
+      "sourceRpm": "libvirt-glib-5.0.0-10.fc45.src.rpm",
+      "upstreamUrl": "https://libvirt.org/"
+    },
+    "LibvirtGLib-1.0": {
+      "file": "LibvirtGLib-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libvirt-glib-devel",
+      "sourceRpm": "libvirt-glib-5.0.0-10.fc45.src.rpm",
+      "upstreamUrl": "https://libvirt.org/"
+    },
+    "LibvirtGObject-1.0": {
+      "file": "LibvirtGObject-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libvirt-gobject-devel",
+      "sourceRpm": "libvirt-glib-5.0.0-10.fc45.src.rpm",
+      "upstreamUrl": "https://libvirt.org/"
+    },
+    "LibvirtSandbox-1.0": {
+      "file": "LibvirtSandbox-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libvirt-sandbox-devel",
+      "sourceRpm": "libvirt-sandbox-0.8.0-21.fc45.src.rpm",
+      "upstreamUrl": "http://libvirt.org/"
+    },
+    "Libxfce4panel-2.0": {
+      "file": "Libxfce4panel-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "xfce4-panel-devel",
+      "sourceRpm": "xfce4-panel-4.20.8-4.fc45.src.rpm",
+      "upstreamUrl": "http://www.xfce.org/"
+    },
+    "Libxfce4ui-2.0": {
+      "file": "Libxfce4ui-2.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libxfce4ui",
+      "sourceRpm": "libxfce4ui-4.20.2-4.fc45.src.rpm",
+      "upstreamUrl": "http://xfce.org/"
+    },
+    "Libxfce4util-1.0": {
+      "file": "Libxfce4util-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libxfce4util",
+      "sourceRpm": "libxfce4util-4.20.1-4.fc45.src.rpm",
+      "upstreamUrl": "http://www.xfce.org/"
+    },
+    "Libxfce4windowing-0.0": {
+      "file": "Libxfce4windowing-0.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libxfce4windowing-devel",
+      "sourceRpm": "libxfce4windowing-4.20.7-1.fc46.src.rpm",
+      "upstreamUrl": "https://docs.xfce.org/xfce/libxfce4windowing/start"
+    },
+    "Libxfce4windowingui-0.0": {
+      "file": "Libxfce4windowingui-0.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libxfce4windowing-devel",
+      "sourceRpm": "libxfce4windowing-4.20.7-1.fc46.src.rpm",
+      "upstreamUrl": "https://docs.xfce.org/xfce/libxfce4windowing/start"
+    },
+    "Liferea-3.0": {
+      "file": "Liferea-3.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "liferea",
+      "sourceRpm": "liferea-2.0-1.fc46.src.rpm",
+      "upstreamUrl": "https://lzone.de/liferea/"
+    },
+    "LightDM-1": {
+      "file": "LightDM-1.gir",
+      "license": "(LGPL-2.0-only OR LGPL-3.0-only) AND GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "lightdm-gobject-devel",
+      "sourceRpm": "lightdm-1.33.1-2.fc46.src.rpm",
+      "upstreamUrl": "https://www.freedesktop.org/wiki/Software/LightDM/"
+    },
+    "MPID-3.0": {
+      "file": "MPID-3.0.gir",
+      "license": "GPL-2.0-or-later AND CC0-1.0 AND MIT",
+      "source": "fedora",
+      "sourcePackage": "rhythmbox-devel",
+      "sourceRpm": "rhythmbox-3.5.0-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Rhythmbox"
+    },
+    "Malcontent-0": {
+      "file": "Malcontent-0.gir",
+      "license": "LGPL-2.1-only AND CC-BY-3.0",
+      "source": "fedora",
+      "sourcePackage": "malcontent-devel",
+      "sourceRpm": "malcontent-0.14.0-7.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/pwithnall/malcontent/"
+    },
+    "MalcontentUi-1": {
+      "file": "MalcontentUi-1.gir",
+      "license": "LGPL-2.1-only AND CC-BY-3.0",
+      "source": "fedora",
+      "sourcePackage": "malcontent-ui-devel",
+      "sourceRpm": "malcontent-0.14.0-7.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/pwithnall/malcontent/"
+    },
+    "Manette-0.2": {
+      "file": "Manette-0.2.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libmanette-devel",
+      "sourceRpm": "libmanette-0.2.13-9.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libmanette"
+    },
+    "Mash-0.2": {
+      "file": "Mash-0.2.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libmash-devel",
+      "sourceRpm": "libmash-0.2.0-43.fc45.src.rpm",
+      "upstreamUrl": "http://clutter-project.github.com/mash/"
+    },
+    "MateDesktop-2.0": {
+      "file": "MateDesktop-2.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "mate-desktop-devel",
+      "sourceRpm": "mate-desktop-1.28.2-9.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "MateMenu-2.0": {
+      "file": "MateMenu-2.0.gir",
+      "license": "GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "mate-menus-devel",
+      "sourceRpm": "mate-menus-1.28.1-2.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "MatePanelApplet-4.0": {
+      "file": "MatePanelApplet-4.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "mate-panel-devel",
+      "sourceRpm": "mate-panel-1.28.4-5.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "Matekbd-1.0": {
+      "file": "Matekbd-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libmatekbd",
+      "sourceRpm": "libmatekbd-1.28.0-10.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "Mbim-1.0": {
+      "file": "Mbim-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libmbim-devel",
+      "sourceRpm": "libmbim-1.32.0-4.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/mobile-broadband/libmbim/"
+    },
+    "MediaArt-2.0": {
+      "file": "MediaArt-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libmediaart-devel",
+      "sourceRpm": "libmediaart-1.9.7-12.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libmediaart"
+    },
+    "Meta-10": {
+      "file": "Meta-10.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-11": {
+      "file": "Meta-11.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-12": {
+      "file": "Meta-12.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-13": {
+      "file": "Meta-13.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-14": {
+      "file": "Meta-14.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-15": {
+      "file": "Meta-15.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-16": {
+      "file": "Meta-16.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-17": {
+      "file": "Meta-17.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-18": {
+      "file": "Meta-18.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-3": {
+      "file": "Meta-3.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-4": {
+      "file": "Meta-4.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-5": {
+      "file": "Meta-5.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-51": {
+      "file": "Meta-51.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-6": {
+      "file": "Meta-6.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-7": {
+      "file": "Meta-7.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-8": {
+      "file": "Meta-8.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Meta-9": {
+      "file": "Meta-9.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Mks-1": {
+      "file": "Mks-1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libmks-devel",
+      "sourceRpm": "libmks-0.1.5-12.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libmks"
+    },
+    "ModemManager-1.0": {
+      "file": "ModemManager-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "ModemManager-glib-devel",
+      "sourceRpm": "ModemManager-1.24.2-5.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/mobile-broadband/ModemManager"
+    },
+    "Modulemd-2.0": {
+      "file": "Modulemd-2.0.gir",
+      "license": "MIT",
+      "source": "fedora",
+      "sourcePackage": "libmodulemd-devel",
+      "sourceRpm": "libmodulemd-2.15.3-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/fedora-modularity/libmodulemd"
+    },
+    "Msg-1": {
+      "file": "Msg-1.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "msgraph-devel",
+      "sourceRpm": "msgraph-0.3.5-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/msgraph"
+    },
+    "Mtk-13": {
+      "file": "Mtk-13.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Mtk-14": {
+      "file": "Mtk-14.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Mtk-15": {
+      "file": "Mtk-15.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Mtk-16": {
+      "file": "Mtk-16.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Mtk-17": {
+      "file": "Mtk-17.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Mtk-18": {
+      "file": "Mtk-18.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "Mtk-51": {
+      "file": "Mtk-51.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/mutter.git"
+    },
+    "MyPaint-1.6": {
+      "file": "MyPaint-1.6.gir",
+      "license": "ISC",
+      "source": "fedora",
+      "sourcePackage": "libmypaint-devel",
+      "sourceRpm": "libmypaint-1.6.1-22.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/mypaint/libmypaint"
+    },
+    "NM-1.0": {
+      "file": "NM-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "NetworkManager-libnm-devel",
+      "sourceRpm": "NetworkManager-1.58.1-1.fc46.src.rpm",
+      "upstreamUrl": "https://networkmanager.dev/"
+    },
+    "NMA-1.0": {
+      "file": "NMA-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libnma-devel",
+      "sourceRpm": "libnma-1.10.6-12.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libnma/"
+    },
+    "NMA4-1.0": {
+      "file": "NMA4-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libnma-gtk4-devel",
+      "sourceRpm": "libnma-1.10.6-12.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libnma/"
+    },
+    "Nautilus-4.1": {
+      "file": "Nautilus-4.1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "nautilus-devel",
+      "sourceRpm": "nautilus-51~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://apps.gnome.org/Nautilus/"
+    },
+    "Nemo-3.0": {
+      "file": "Nemo-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "nemo-devel",
+      "sourceRpm": "nemo-6.7.5^unstable-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/nemo"
+    },
+    "NemoPreview-1.0": {
+      "file": "NemoPreview-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "nemo-preview",
+      "sourceRpm": "nemo-extensions-6.7.1^unstable-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/nemo-extensions"
+    },
+    "Nice-0.1": {
+      "file": "Nice-0.1.gir",
+      "license": "LGPL-2.1-or-later OR MPL-1.1",
+      "source": "fedora",
+      "sourcePackage": "libnice-devel",
+      "sourceRpm": "libnice-0.1.23-3.fc45.src.rpm",
+      "upstreamUrl": "https://nice.freedesktop.org/"
+    },
+    "Notify-0.7": {
+      "file": "Notify-0.7.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libnotify-devel",
+      "sourceRpm": "libnotify-0.8.8-8.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libnotify"
+    },
+    "OSTree-1.0": {
+      "file": "OSTree-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "ostree-devel",
+      "sourceRpm": "ostree-2026.4-1.fc46.src.rpm",
+      "upstreamUrl": "https://ostreedev.github.io/ostree/"
+    },
+    "OsmGpsMap-1.0": {
+      "file": "OsmGpsMap-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "osm-gps-map-devel",
+      "sourceRpm": "osm-gps-map-1.2.1-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/nzjrs/osm-gps-map/"
+    },
+    "PackageKitGlib-1.0": {
+      "file": "PackageKitGlib-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.1-or-later AND FSFAP",
+      "source": "fedora",
+      "sourcePackage": "PackageKit-glib-devel",
+      "sourceRpm": "PackageKit-1.3.6-3.fc45.src.rpm",
+      "upstreamUrl": "http://www.freedesktop.org/software/PackageKit/"
+    },
+    "Panel-1": {
+      "file": "Panel-1.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libpanel-devel",
+      "sourceRpm": "libpanel-1.10.4-8.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libpanel"
+    },
+    "Pango-1.0": {
+      "file": "Pango-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "pango-devel",
+      "sourceRpm": "pango-1.58.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://pango.gnome.org/"
+    },
+    "PangoCairo-1.0": {
+      "file": "PangoCairo-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "pango-devel",
+      "sourceRpm": "pango-1.58.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://pango.gnome.org/"
+    },
+    "PangoFT2-1.0": {
+      "file": "PangoFT2-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "pango-devel",
+      "sourceRpm": "pango-1.58.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://pango.gnome.org/"
+    },
+    "PangoFc-1.0": {
+      "file": "PangoFc-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "pango-devel",
+      "sourceRpm": "pango-1.58.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://pango.gnome.org/"
+    },
+    "PangoOT-1.0": {
+      "file": "PangoOT-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "pango-devel",
+      "sourceRpm": "pango-1.58.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://pango.gnome.org/"
+    },
+    "PangoXft-1.0": {
+      "file": "PangoXft-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "pango-devel",
+      "sourceRpm": "pango-1.58.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://pango.gnome.org/"
+    },
+    "PapersDocument-4.0": {
+      "file": "PapersDocument-4.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT AND libtiff AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND LicenseRef-BSD-2-Clause-WITH-AdditionRef-AOMPL-1.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND Zlib AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause AND ISC) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)",
+      "source": "fedora",
+      "sourcePackage": "papers-devel",
+      "sourceRpm": "papers-51~beta-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/papers"
+    },
+    "PapersView-4.0": {
+      "file": "PapersView-4.0.gir",
+      "license": "GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT AND libtiff AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND ISC AND LicenseRef-BSD-2-Clause-WITH-AdditionRef-AOMPL-1.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND Zlib AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT) AND (BSD-2-Clause OR Apache-2.0 OR MIT) AND (BSD-2-Clause AND ISC) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)",
+      "source": "fedora",
+      "sourcePackage": "papers-devel",
+      "sourceRpm": "papers-51~beta-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/papers"
+    },
+    "Parquet-23.0": {
+      "file": "Parquet-23.0.gir",
+      "license": "Apache-2.0",
+      "source": "fedora",
+      "sourcePackage": "parquet-glib-devel",
+      "sourceRpm": "libarrow-23.0.1-11.fc46.src.rpm",
+      "upstreamUrl": "https://arrow.apache.org/"
+    },
+    "Passim-1.0": {
+      "file": "Passim-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "passim-devel",
+      "sourceRpm": "passim-0.1.12-1.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/hughsie/passim"
+    },
+    "Peas-1.0": {
+      "file": "Peas-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libpeas1-devel",
+      "sourceRpm": "libpeas1-1.36.0-16.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Libpeas"
+    },
+    "Peas-2": {
+      "file": "Peas-2.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libpeas-devel",
+      "sourceRpm": "libpeas-2.2.1-8.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Libpeas"
+    },
+    "PeasGtk-1.0": {
+      "file": "PeasGtk-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libpeas1-devel",
+      "sourceRpm": "libpeas1-1.36.0-16.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Libpeas"
+    },
+    "Phosh-0": {
+      "file": "Phosh-0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "phosh-devel",
+      "sourceRpm": "phosh-0.57.0-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/World/Phosh/phosh"
+    },
+    "Playerctl-2.0": {
+      "file": "Playerctl-2.0.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "playerctl-devel",
+      "sourceRpm": "playerctl-2.4.1-13.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/acrisci/playerctl"
+    },
+    "Pluma-1.0": {
+      "file": "Pluma-1.0.gir",
+      "license": "GPL-2.0-or-later AND LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "pluma-devel",
+      "sourceRpm": "pluma-1.28.1-3.fc45.src.rpm",
+      "upstreamUrl": "http://mate-desktop.org"
+    },
+    "Pms-1.0": {
+      "file": "Pms-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libphosh-mobile-settings-devel",
+      "sourceRpm": "phosh-mobile-settings-0.57.0-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings"
+    },
+    "Polkit-1.0": {
+      "file": "Polkit-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "polkit-devel",
+      "sourceRpm": "polkit-127-5.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/polkit-org/polkit"
+    },
+    "PolkitAgent-1.0": {
+      "file": "PolkitAgent-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "polkit-devel",
+      "sourceRpm": "polkit-127-5.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/polkit-org/polkit"
+    },
+    "Poppler-0.18": {
+      "file": "Poppler-0.18.gir",
+      "license": "(GPL-2.0-only OR GPL-3.0-only) AND GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND MIT",
+      "source": "fedora",
+      "sourcePackage": "poppler-glib-devel",
+      "sourceRpm": "poppler-26.08.0-1.fc45.src.rpm",
+      "upstreamUrl": "https://poppler.freedesktop.org/"
+    },
+    "Qmi-1.0": {
+      "file": "Qmi-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libqmi-devel",
+      "sourceRpm": "libqmi-1.36.0-4.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/mobile-broadband/libqmi/"
+    },
+    "Qrtr-1.0": {
+      "file": "Qrtr-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libqrtr-glib-devel",
+      "sourceRpm": "libqrtr-glib-1.2.2-10.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib"
+    },
+    "RB-3.0": {
+      "file": "RB-3.0.gir",
+      "license": "GPL-2.0-or-later AND CC0-1.0 AND MIT",
+      "source": "fedora",
+      "sourcePackage": "rhythmbox-devel",
+      "sourceRpm": "rhythmbox-3.5.0-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Rhythmbox"
+    },
+    "Rest-0.7": {
+      "file": "Rest-0.7.gir",
+      "license": "LicenseRef-Callaway-LGPLv2",
+      "source": "fedora",
+      "sourcePackage": "rest0.7-devel",
+      "sourceRpm": "rest0.7-0.8.1-12.fc45.src.rpm",
+      "upstreamUrl": "http://www.gnome.org"
+    },
+    "Rest-1.0": {
+      "file": "Rest-1.0.gir",
+      "license": "LGPL-2.1-only",
+      "source": "fedora",
+      "sourcePackage": "rest-devel",
+      "sourceRpm": "rest-0.10.2-12.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/librest"
+    },
+    "RestExtras-0.7": {
+      "file": "RestExtras-0.7.gir",
+      "license": "LicenseRef-Callaway-LGPLv2",
+      "source": "fedora",
+      "sourcePackage": "rest0.7-devel",
+      "sourceRpm": "rest0.7-0.8.1-12.fc45.src.rpm",
+      "upstreamUrl": "http://www.gnome.org"
+    },
+    "RestExtras-1.0": {
+      "file": "RestExtras-1.0.gir",
+      "license": "LGPL-2.1-only",
+      "source": "fedora",
+      "sourcePackage": "rest-devel",
+      "sourceRpm": "rest-0.10.2-12.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/librest"
+    },
+    "RpmOstree-1.0": {
+      "file": "RpmOstree-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "rpm-ostree-devel",
+      "sourceRpm": "rpm-ostree-2026.2-4.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/coreos/rpm-ostree"
+    },
+    "Rsvg-2.0": {
+      "file": "Rsvg-2.0.gir",
+      "license": "LGPL-2.1-or-later AND Apache-2.0 AND BSD-3-Clause AND MIT AND MPL-2.0 AND Unicode-3.0 AND Unicode-DFS-2016 AND (0BSD OR MIT OR Apache-2.0) AND (Apache-2.0 OR MIT) AND (BSD-3-Clause OR Apache-2.0) AND (MIT OR Apache-2.0 OR Zlib) AND (Unlicense OR MIT)",
+      "source": "fedora",
+      "sourcePackage": "librsvg2-devel",
+      "sourceRpm": "librsvg2-2.62.3-3.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/LibRsvg"
+    },
+    "RygelCore-2.8": {
+      "file": "RygelCore-2.8.gir",
+      "license": "LGPL-2.1-or-later AND CC-BY-SA-3.0",
+      "source": "fedora",
+      "sourcePackage": "rygel-devel",
+      "sourceRpm": "rygel-46~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Rygel"
+    },
+    "RygelRenderer-2.8": {
+      "file": "RygelRenderer-2.8.gir",
+      "license": "LGPL-2.1-or-later AND CC-BY-SA-3.0",
+      "source": "fedora",
+      "sourcePackage": "rygel-devel",
+      "sourceRpm": "rygel-46~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Rygel"
+    },
+    "RygelRendererGst-2.8": {
+      "file": "RygelRendererGst-2.8.gir",
+      "license": "LGPL-2.1-or-later AND CC-BY-SA-3.0",
+      "source": "fedora",
+      "sourcePackage": "rygel-devel",
+      "sourceRpm": "rygel-46~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Rygel"
+    },
+    "RygelServer-2.8": {
+      "file": "RygelServer-2.8.gir",
+      "license": "LGPL-2.1-or-later AND CC-BY-SA-3.0",
+      "source": "fedora",
+      "sourcePackage": "rygel-devel",
+      "sourceRpm": "rygel-46~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Rygel"
+    },
+    "Secret-1": {
+      "file": "Secret-1.gir",
+      "license": "LGPL-2.1-or-later AND Apache-2.0 AND (GPL-2.0-or-later OR TGPPL-1.0) AND LicenseRef-Fedora-Public-Domain AND GCR-docs",
+      "source": "fedora",
+      "sourcePackage": "libsecret-devel",
+      "sourceRpm": "libsecret-0.21.7-16.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/Libsecret"
+    },
+    "Shell-0.1": {
+      "file": "Shell-0.1.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-10": {
+      "file": "Shell-10.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-11": {
+      "file": "Shell-11.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-12": {
+      "file": "Shell-12.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-13": {
+      "file": "Shell-13.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-14": {
+      "file": "Shell-14.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-15": {
+      "file": "Shell-15.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-16": {
+      "file": "Shell-16.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-17": {
+      "file": "Shell-17.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-18": {
+      "file": "Shell-18.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-51": {
+      "file": "Shell-51.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shell-9": {
+      "file": "Shell-9.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shew-0": {
+      "file": "Shew-0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "Shumate-1.0": {
+      "file": "Shumate-1.0.gir",
+      "license": "LGPL-2.1-or-later AND LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libshumate-devel",
+      "sourceRpm": "libshumate-1.7~beta-1.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libshumate"
+    },
+    "Skk-1.0": {
+      "file": "Skk-1.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libskk-devel",
+      "sourceRpm": "libskk-1.1.1-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/ueno/libskk"
+    },
+    "Snapd-2": {
+      "file": "Snapd-2.gir",
+      "license": "LGPL-2.0-only OR LGPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "snapd-glib-devel",
+      "sourceRpm": "snapd-glib-1.72-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/canonical/snapd-glib"
+    },
+    "Soup-2.4": {
+      "file": "Soup-2.4.gir",
+      "license": "LGPL-2.0-only",
+      "source": "fedora",
+      "sourcePackage": "libsoup-devel",
+      "sourceRpm": "libsoup-2.74.3-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/libsoup"
+    },
+    "Soup-3.0": {
+      "file": "Soup-3.0.gir",
+      "license": "LGPL-2.0-or-later AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libsoup3-devel",
+      "sourceRpm": "libsoup3-3.7.2-1.fc46.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/libsoup"
+    },
+    "SoupGNOME-2.4": {
+      "file": "SoupGNOME-2.4.gir",
+      "license": "LGPL-2.0-only",
+      "source": "fedora",
+      "sourcePackage": "libsoup-devel",
+      "sourceRpm": "libsoup-2.74.3-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/libsoup"
+    },
+    "Spelling-1": {
+      "file": "Spelling-1.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libspelling-devel",
+      "sourceRpm": "libspelling-0.4.10-3.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/libspelling"
+    },
+    "SpiceClientGLib-2.0": {
+      "file": "SpiceClientGLib-2.0.gir",
+      "license": "LGPL-2.1-or-later AND MIT AND MIT-open-group and BSD-3-Clause",
+      "source": "fedora",
+      "sourcePackage": "spice-glib-devel",
+      "sourceRpm": "spice-gtk-0.43-4.fc45.src.rpm",
+      "upstreamUrl": "https://www.spice-space.org/spice-gtk.html"
+    },
+    "SpiceClientGtk-3.0": {
+      "file": "SpiceClientGtk-3.0.gir",
+      "license": "LGPL-2.1-or-later AND MIT AND MIT-open-group and BSD-3-Clause",
+      "source": "fedora",
+      "sourcePackage": "spice-gtk3-devel",
+      "sourceRpm": "spice-gtk-0.43-4.fc45.src.rpm",
+      "upstreamUrl": "https://www.spice-space.org/spice-gtk.html"
+    },
+    "St-1.0": {
+      "file": "St-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-10": {
+      "file": "St-10.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-11": {
+      "file": "St-11.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-12": {
+      "file": "St-12.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-13": {
+      "file": "St-13.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-14": {
+      "file": "St-14.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-15": {
+      "file": "St-15.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-16": {
+      "file": "St-16.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-17": {
+      "file": "St-17.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-18": {
+      "file": "St-18.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-51": {
+      "file": "St-51.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "St-9": {
+      "file": "St-9.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/gnome-shell.git"
+    },
+    "SugarExt-1.0": {
+      "file": "SugarExt-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "sugar-toolkit-gtk3-devel",
+      "sourceRpm": "sugar-toolkit-gtk3-0.121-15.fc45.src.rpm",
+      "upstreamUrl": "http://wiki.laptop.org/go/Sugar"
+    },
+    "SugarGestures-1.0": {
+      "file": "SugarGestures-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "sugar-toolkit-gtk3-devel",
+      "sourceRpm": "sugar-toolkit-gtk3-0.121-15.fc45.src.rpm",
+      "upstreamUrl": "http://wiki.laptop.org/go/Sugar"
+    },
+    "Sushi-1.0": {
+      "file": "Sushi-1.0.gir",
+      "license": "GPL-2.0-or-later WITH GStreamer-exception-2008 AND CC0-1.0 AND (LGPL-2.0-or-later AND LGPL-2.1-or-later WITH GStreamer-exception-2005)",
+      "source": "fedora",
+      "sourcePackage": "sushi",
+      "sourceRpm": "sushi-51~beta-1.fc46.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/sushi"
+    },
+    "TelepathyGLib-0.12": {
+      "file": "TelepathyGLib-0.12.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "telepathy-glib-devel",
+      "sourceRpm": "telepathy-glib-0.24.2-16.fc45.src.rpm",
+      "upstreamUrl": "http://telepathy.freedesktop.org/wiki/FrontPage"
+    },
+    "Template-1.0": {
+      "file": "Template-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "template-glib-devel",
+      "sourceRpm": "template-glib-3.40.0-5.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.gnome.org/GNOME/template-glib/"
+    },
+    "Tepl-6": {
+      "file": "Tepl-6.gir",
+      "license": "LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libgedit-tepl-devel",
+      "sourceRpm": "libgedit-tepl-6.14.0-5.fc45.src.rpm",
+      "upstreamUrl": "https://gedit-text-editor.org/"
+    },
+    "Thunarx-3.0": {
+      "file": "Thunarx-3.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "Thunar-devel",
+      "sourceRpm": "Thunar-4.20.9-1.fc45.src.rpm",
+      "upstreamUrl": "http://thunar.xfce.org/"
+    },
+    "TimezoneMap-1.0": {
+      "file": "TimezoneMap-1.0.gir",
+      "license": "GPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "libtimezonemap-devel",
+      "sourceRpm": "libtimezonemap-0.4.5.4-3.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/timezonemap"
+    },
+    "Totem-1.0": {
+      "file": "Totem-1.0.gir",
+      "license": "GPL-2.0-or-later AND (GPL-2.0-or-later WITH GStreamer-exception-2008) AND LGPL-2.0-or-later AND CC0-1.0",
+      "source": "fedora",
+      "sourcePackage": "totem-devel",
+      "sourceRpm": "totem-43.2-16.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Videos"
+    },
+    "TotemPlParser-1.0": {
+      "file": "TotemPlParser-1.0.gir",
+      "license": "LGPL-2.0-or-later AND (LGPL-2.1-or-later WITH GStreamer-exception-2005)",
+      "source": "fedora",
+      "sourcePackage": "totem-pl-parser-devel",
+      "sourceRpm": "totem-pl-parser-3.26.7-3.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Videos"
+    },
+    "Tracker-3.0": {
+      "file": "Tracker-3.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "tinysparql-devel",
+      "sourceRpm": "tinysparql-3.12~alpha-2.fc45.src.rpm",
+      "upstreamUrl": "https://gnome.pages.gitlab.gnome.org/tinysparql/"
+    },
+    "Translit-1.0": {
+      "file": "Translit-1.0.gir",
+      "license": "GPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libtranslit-devel",
+      "sourceRpm": "libtranslit-0.0.3-53.fc45.src.rpm",
+      "upstreamUrl": "http://github.com/ueno/libtranslit"
+    },
+    "Tsparql-3.0": {
+      "file": "Tsparql-3.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "tinysparql-devel",
+      "sourceRpm": "tinysparql-3.12~alpha-2.fc45.src.rpm",
+      "upstreamUrl": "https://gnome.pages.gitlab.gnome.org/tinysparql/"
+    },
+    "UDisks-2.0": {
+      "file": "UDisks-2.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libudisks2-devel",
+      "sourceRpm": "udisks2-2.11.2-1.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/storaged-project/udisks"
+    },
+    "UMockdev-1.0": {
+      "file": "UMockdev-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "umockdev-devel",
+      "sourceRpm": "umockdev-0.19.8-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/martinpitt/umockdev"
+    },
+    "UPowerGlib-1.0": {
+      "file": "UPowerGlib-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "upower-devel",
+      "sourceRpm": "upower-1.91.3-2.fc45.src.rpm",
+      "upstreamUrl": "https://upower.freedesktop.org/"
+    },
+    "Uhm-1.0": {
+      "file": "Uhm-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "uhttpmock-devel",
+      "sourceRpm": "uhttpmock-0.11.0-6.fc45.src.rpm",
+      "upstreamUrl": "https://gitlab.freedesktop.org/pwithnall/uhttpmock"
+    },
+    "Unity-7.0": {
+      "file": "Unity-7.0.gir",
+      "license": "GPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "libunity-devel",
+      "sourceRpm": "libunity-7.1.4-47.20190319.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/libunity"
+    },
+    "UnityExtras-7.0": {
+      "file": "UnityExtras-7.0.gir",
+      "license": "GPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "libunity-devel",
+      "sourceRpm": "libunity-7.1.4-47.20190319.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/libunity"
+    },
+    "Vips-8.0": {
+      "file": "Vips-8.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "vips-devel",
+      "sourceRpm": "vips-8.18.3-4.fc46.src.rpm",
+      "upstreamUrl": "https://www.libvips.org/"
+    },
+    "Vte-0.0": {
+      "file": "Vte-0.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "vte-devel",
+      "sourceRpm": "vte-0.28.2-47.fc45.src.rpm",
+      "upstreamUrl": "http://developer.gnome.org/vte/"
+    },
+    "Vte-2.91": {
+      "file": "Vte-2.91.gir",
+      "license": "GPL-3.0-or-later AND LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "vte291-devel",
+      "sourceRpm": "vte291-0.84.1-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Terminal/VTE"
+    },
+    "Vte-3.91": {
+      "file": "Vte-3.91.gir",
+      "license": "GPL-3.0-or-later AND LGPL-3.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "vte291-gtk4-devel",
+      "sourceRpm": "vte291-0.84.1-1.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Apps/Terminal/VTE"
+    },
+    "Vulkan-1.0": {
+      "file": "Vulkan-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "WebKit-6.0": {
+      "file": "WebKit-6.0.gir",
+      "license": "LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+      "source": "fedora",
+      "sourcePackage": "webkitgtk6.0-devel",
+      "sourceRpm": "webkitgtk-2.53.91-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.webkitgtk.org/"
+    },
+    "WebKit2-4.1": {
+      "file": "WebKit2-4.1.gir",
+      "license": "LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+      "source": "fedora",
+      "sourcePackage": "webkit2gtk4.1-devel",
+      "sourceRpm": "webkitgtk-2.53.91-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.webkitgtk.org/"
+    },
+    "WebKit2WebExtension-4.1": {
+      "file": "WebKit2WebExtension-4.1.gir",
+      "license": "LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+      "source": "fedora",
+      "sourcePackage": "webkit2gtk4.1-devel",
+      "sourceRpm": "webkitgtk-2.53.91-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.webkitgtk.org/"
+    },
+    "WebKitWebExtension-6.0": {
+      "file": "WebKitWebExtension-6.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "gir-module-metadata",
+      "upstreamUrl": "https://webkitgtk.org"
+    },
+    "WebKitWebProcessExtension-6.0": {
+      "file": "WebKitWebProcessExtension-6.0.gir",
+      "license": "LGPL-2.1-only AND BSD-2-Clause AND BSD-3-Clause AND ISC AND bzip2-1.0.6 AND NCSA AND MIT AND GPL-2.0-only AND MPL-1.1 AND SunPro AND Apache-2.0 AND GPL-3.0-or-later WITH Bison-exception-2.2 AND MPL-2.0 AND OFL-1.1 AND (AFL-2.0 OR GPL-2.0-or-later) AND BSD-Source-Code AND BSD-2-Clause-Views AND LGPL-2.1-or-later AND (NCSA OR MIT) AND Apache-2.0 WITH LLVM-exception AND BSL-1.0",
+      "source": "fedora",
+      "sourcePackage": "webkitgtk6.0-devel",
+      "sourceRpm": "webkitgtk-2.53.91-1.fc46.src.rpm",
+      "upstreamUrl": "https://www.webkitgtk.org/"
+    },
+    "Wnck-1.0": {
+      "file": "Wnck-1.0.gir",
+      "license": "LicenseRef-Callaway-LGPLv2+",
+      "source": "fedora",
+      "sourcePackage": "libwnck-devel",
+      "sourceRpm": "libwnck-2.31.0-30.fc45.src.rpm",
+      "upstreamUrl": "http://download.gnome.org/sources/libwnck/"
+    },
+    "Wnck-3.0": {
+      "file": "Wnck-3.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libwnck3-devel",
+      "sourceRpm": "libwnck3-43.3-8.fc45.src.rpm",
+      "upstreamUrl": "http://download.gnome.org/sources/libwnck/"
+    },
+    "Wp-0.5": {
+      "file": "Wp-0.5.gir",
+      "license": "MIT",
+      "source": "fedora",
+      "sourcePackage": "wireplumber-devel",
+      "sourceRpm": "wireplumber-0.5.14-2.fc45.src.rpm",
+      "upstreamUrl": "https://pipewire.pages.freedesktop.org/wireplumber/"
+    },
+    "XApp-1.0": {
+      "file": "XApp-1.0.gir",
+      "license": "LGPL-3.0-only",
+      "source": "fedora",
+      "sourcePackage": "xapps-devel",
+      "sourceRpm": "xapps-3.3.4^unstable-1.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/xapps"
+    },
+    "Xdp-1.0": {
+      "file": "Xdp-1.0.gir",
+      "license": "LGPL-3.0-only AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libportal-devel",
+      "sourceRpm": "libportal-0.10.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/flatpak/libportal"
+    },
+    "XdpGtk3-1.0": {
+      "file": "XdpGtk3-1.0.gir",
+      "license": "LGPL-3.0-only AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libportal-gtk3-devel",
+      "sourceRpm": "libportal-0.10.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/flatpak/libportal"
+    },
+    "XdpGtk4-1.0": {
+      "file": "XdpGtk4-1.0.gir",
+      "license": "LGPL-3.0-only AND LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libportal-gtk4-devel",
+      "sourceRpm": "libportal-0.10.0-2.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/flatpak/libportal"
+    },
+    "Xed-1.0": {
+      "file": "Xed-1.0.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "xed-devel",
+      "sourceRpm": "xed-3.8.9-4.fc46.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/xed"
+    },
+    "Xfconf-0": {
+      "file": "Xfconf-0.gir",
+      "license": "GPL-2.0-only",
+      "source": "fedora",
+      "sourcePackage": "xfconf",
+      "sourceRpm": "xfconf-4.20.0-5.fc45.src.rpm",
+      "upstreamUrl": "http://www.xfce.org/"
+    },
+    "Xkl-1.0": {
+      "file": "Xkl-1.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "libxklavier-devel",
+      "sourceRpm": "libxklavier-5.4-31.fc45.src.rpm",
+      "upstreamUrl": "http://www.freedesktop.org/wiki/Software/LibXklavier"
+    },
+    "Xmlb-2.0": {
+      "file": "Xmlb-2.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "libxmlb-devel",
+      "sourceRpm": "libxmlb-0.3.29-1.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/hughsie/libxmlb"
+    },
+    "XreaderDocument-1.5": {
+      "file": "XreaderDocument-1.5.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "xreader-devel",
+      "sourceRpm": "xreader-4.6.4-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/xreader"
+    },
+    "XreaderView-1.5": {
+      "file": "XreaderView-1.5.gir",
+      "license": "GPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "xreader-devel",
+      "sourceRpm": "xreader-4.6.4-3.fc45.src.rpm",
+      "upstreamUrl": "https://github.com/linuxmint/xreader"
+    },
+    "ZBar-1.0": {
+      "file": "ZBar-1.0.gir",
+      "license": "LGPL-2.1-or-later",
+      "source": "fedora",
+      "sourcePackage": "zbar-devel",
+      "sourceRpm": "zbar-0.23.93-13.fc45.src.rpm",
+      "upstreamUrl": "http://zbar.sourceforge.net/"
+    },
+    "Zeitgeist-2.0": {
+      "file": "Zeitgeist-2.0.gir",
+      "license": "LGPL-2.0-or-later",
+      "source": "fedora",
+      "sourcePackage": "zeitgeist-devel",
+      "sourceRpm": "zeitgeist-1.0.4-25.fc45.src.rpm",
+      "upstreamUrl": "https://launchpad.net/zeitgeist"
+    },
+    "cairo-1.0": {
+      "file": "cairo-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "fontconfig-2.0": {
+      "file": "fontconfig-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "freetype2-2.0": {
+      "file": "freetype2-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "libxml2-2.0": {
+      "file": "libxml2-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "win32-1.0": {
+      "file": "win32-1.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "xfixes-4.0": {
+      "file": "xfixes-4.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "xft-2.0": {
+      "file": "xft-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "xlib-2.0": {
+      "file": "xlib-2.0.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    },
+    "xrandr-1.3": {
+      "file": "xrandr-1.3.gir",
+      "license": "GPL-2.0-or-later AND LGPL-2.0-or-later AND LGPL-2.1-or-later AND BSD-2-Clause",
+      "source": "fedora",
+      "sourcePackage": "gobject-introspection-devel",
+      "sourceRpm": "gobject-introspection-1.86.0-11.fc45.src.rpm",
+      "upstreamUrl": "https://wiki.gnome.org/Projects/GObjectIntrospection"
+    }
+  },
+  "unattributed": [
+    "Ags-6.0",
+    "AgsAudio-6.0",
+    "AgsGui-6.0",
+    "Amtk-4",
+    "AnacondaWidgets-3.4",
+    "AppStreamBuilder-1.0",
+    "Arrow-1.0",
+    "ArrowCUDA-1.0",
+    "ArrowDataset-1.0",
+    "ArrowFlight-1.0",
+    "Avahi-0.6",
+    "AvahiCore-0.6",
+    "Budgie-1.0",
+    "BudgieRaven-1.0",
+    "Builder-1.0",
+    "Bump-0.1",
+    "Cally-10",
+    "Cally-11",
+    "Cally-12",
+    "Cally-13",
+    "Cally-14",
+    "Cally-15",
+    "Cally-3",
+    "Cally-4",
+    "Cally-5",
+    "Cally-6",
+    "Cally-7",
+    "Cally-8",
+    "Cally-9",
+    "Casilda-0.1",
+    "Cheese-3.0",
+    "ClutterGst-1.0",
+    "ClutterGst-2.0",
+    "ClutterX11-3",
+    "ClutterX11-4",
+    "ClutterX11-5",
+    "ClutterX11-6",
+    "ClutterX11-7",
+    "ClutterX11-8",
+    "CoglGst-2.0",
+    "CoglPango-10",
+    "CoglPango-11",
+    "CoglPango-12",
+    "CoglPango-13",
+    "CoglPango-14",
+    "CoglPango-15",
+    "CoglPango-3",
+    "CoglPango-4",
+    "CoglPango-5",
+    "CoglPango-6",
+    "CoglPango-7",
+    "CoglPango-8",
+    "CoglPango-9",
+    "ColorHug-1.0",
+    "DMAP-3.0",
+    "Deviced-1.0",
+    "ECalendar-1.2",
+    "Egg-1.0",
+    "Epc-1.0",
+    "EpcUi-1.0",
+    "Farstream-0.1",
+    "Folks-0.6",
+    "FolksDummy-0.6",
+    "FolksEds-0.6",
+    "FolksLibsocialweb-0.6",
+    "FolksTelepathy-0.6",
+    "GCalc-1",
+    "GData-0.0",
+    "GFBGraph-0.2",
+    "GFBGraph-0.3",
+    "GPasteGtk-3",
+    "GSSDP-1.0",
+    "GSSDP-1.2",
+    "GSignond-1.0",
+    "GSystem-1.0",
+    "GUPnP-1.0",
+    "GUPnP-1.2",
+    "GUPnPDLNA-1.0",
+    "GUPnPIgd-1.0",
+    "GWeather-3.0",
+    "GXml-0.14",
+    "GXml-0.16",
+    "GXml-0.18",
+    "GXml-0.20",
+    "Gandiva-1.0",
+    "GcrGtk3-4",
+    "GcrGtk4-4",
+    "Gd-1.0",
+    "Gee-1.0",
+    "Gegl-0.3",
+    "GeglGtk3-0.1",
+    "GeocodeGlib-1.0",
+    "Gepub-0.5",
+    "GjsDBus-1.0",
+    "GjsPrivate-1.0",
+    "Gly-1",
+    "GlyGtk4-1",
+    "GnomeRR-4.0",
+    "GooCanvas-3.0",
+    "Govf-0.1",
+    "Gpseq-1.0",
+    "Granite-7.0",
+    "Grl-0.1",
+    "Grl-0.2",
+    "GrlNet-0.1",
+    "GrlNet-0.2",
+    "GrlPls-0.2",
+    "Gst-0.10",
+    "GstAudio-0.10",
+    "GstBadAllocators-1.0",
+    "GstBase-0.10",
+    "GstClapper-1.0",
+    "GstFft-1.0",
+    "GstInterfaces-0.10",
+    "GstPbutils-0.10",
+    "GstRiff-1.0",
+    "GstTag-0.10",
+    "GstVideo-0.10",
+    "GstVulkanXCB-1.0",
+    "Gtef-2",
+    "Gthree-1.0",
+    "GthreeGtk3-1.0",
+    "GtkFrdp-0.2",
+    "GtkosxApplication-1.0",
+    "Guestfs-1.0",
+    "Gxps-1.0",
+    "Handy-0.0",
+    "Hs-1",
+    "Ide-1.0",
+    "Ide-45",
+    "Ide-46",
+    "Ide-47",
+    "Ide-49",
+    "JSCore-3.0",
+    "JavaScriptCore-4.0",
+    "JavaScriptCore-5.0",
+    "Lasem-0.4",
+    "Libsitra-0.1",
+    "Manette-1",
+    "MediaArt-1.0",
+    "MetaTest-12",
+    "MetaTest-13",
+    "MetaTest-14",
+    "MetaTest-15",
+    "MetaTest-16",
+    "MetaTest-17",
+    "MetaTest-18",
+    "MetaTest-51",
+    "Midori-0.6",
+    "Ministream-1",
+    "Mirage-3.2",
+    "Msg-0",
+    "Mx-1.0",
+    "Mx-2.0",
+    "MxGtk-1.0",
+    "MyPaintGegl-1.6",
+    "NMClient-1.0",
+    "NMGtk-1.0",
+    "Nautilus-3.0",
+    "Nautilus-4.0",
+    "NetworkManager-1.0",
+    "P11Kit-1.0",
+    "PQMarble-2",
+    "PackageKitPlugin-1.0",
+    "PanelApplet-4.0",
+    "PantheonWayland-1",
+    "Parquet-1.0",
+    "Plasma-1.0",
+    "Pnl-1.0",
+    "Retro-0.14",
+    "Retro-1",
+    "Retro-2",
+    "RygelCore-2.6",
+    "RygelRenderer-2.6",
+    "RygelRendererGst-2.6",
+    "RygelServer-2.6",
+    "SecretUnstable-0",
+    "Signon-2.0",
+    "Snapd-1",
+    "SocialWebClient-0.25",
+    "TelepathyFarstream-0.6",
+    "TelepathyLogger-0.2",
+    "Tepl-4",
+    "Tepl-5",
+    "Tracker-1.0",
+    "Tracker-2.0",
+    "TrackerControl-1.0",
+    "TrackerControl-2.0",
+    "TrackerMiner-1.0",
+    "TrackerMiner-2.0",
+    "Uhm-0.0",
+    "Unique-3.0",
+    "Unity-6.0",
+    "Vda-1",
+    "Vgda-1",
+    "Vgpg-1",
+    "Vgsl-1",
+    "Vpg-1",
+    "Vsqlite-1",
+    "Vte-4-2.91",
+    "WebKit2-4.0",
+    "WebKit2-5.0",
+    "WebKit2WebExtension-4.0",
+    "WebKit2WebExtension-5.0",
+    "Workbench-0",
+    "Wp-0.4",
+    "Zpj-0.0",
+    "gSignon-1.0"
+  ]
+}

--- a/packages/gir-files/provenance.json
+++ b/packages/gir-files/provenance.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://github.com/gjsify/ts-for-gir/blob/main/packages/gir-files/provenance.schema.json",
   "schemaVersion": 1,
   "generatedFrom": {
     "distribution": "fedora",

--- a/packages/gir-files/scripts/build-payload.mjs
+++ b/packages/gir-files/scripts/build-payload.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Builds the shipped payload of @ts-for-gir/gir-files from the repo's `girs/` pool.
+//
+// Runs from `build:app`, NOT from a `prepack` hook: the production packer does not run
+// npm lifecycle scripts (tests/e2e/cli-tarball-shape/run.mjs states this outright), so an
+// artefact that only a lifecycle hook produces ships as an empty directory. `packages/cli`
+// chains `dist-templates` the same way.
+//
+// TWO THINGS THIS DOES THAT LOOK OPTIONAL AND ARE NOT
+//
+// 1. It gzips each file individually instead of copying the XML in.
+//    Measured over the 510 shipped namespaces (308.0 MB raw), via `npm pack --dry-run`:
+//      plain .gir files ...................... 27.5 MB tarball / 308.0 MB unpacked
+//      per-file .gir.gz (what this writes) ... 27.6 MB tarball /  27.9 MB unpacked
+//    The tarball costs 0.1 MB (+0.4 %) and the installed footprint drops 11.0x. That is
+//    almost free ONLY because gzip's 32 KB window captures essentially no redundancy
+//    ACROSS files: over the full 718-file pool, one tar.gz of everything is 32.4 MB while
+//    the sum of the files gzipped separately is 32.7 MB -- 0.9 % apart. Pooling into one
+//    stream buys nothing, so pre-compressing gives up nothing. Do not "simplify" this
+//    back to plain files: 308 MB unpacked is 2.5x the largest widely-installed npm
+//    package (aws-cdk-lib, 124.3 MB).
+//
+// 2. It ships a file only if `provenance.json` attributes it.
+//    `girs/` is third-party content under real copyleft and carries no licence headers.
+//    An unattributed file is one we cannot name terms for, so it does not go in the
+//    tarball and does not go in NOTICE.md. See scripts/build-gir-provenance.sh.
+
+import { createRequire } from "node:module";
+import { gzipSync } from "node:zlib";
+import { mkdirSync, readFileSync, rmSync, writeFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, "..");
+const repoRoot = join(pkgRoot, "..", "..");
+const girDir = join(repoRoot, "girs");
+const payloadDir = join(pkgRoot, "payload");
+
+const require = createRequire(import.meta.url);
+const pkg = require(join(pkgRoot, "package.json"));
+
+const manifest = JSON.parse(readFileSync(join(pkgRoot, "provenance.json"), "utf8"));
+const entries = Object.entries(manifest.entries ?? {});
+
+if (entries.length === 0) {
+  console.error(
+    "error: provenance.json attributes no files, so there is nothing publishable.\n" +
+      "       Regenerate it with scripts/build-gir-provenance.sh.",
+  );
+  process.exit(1);
+}
+
+rmSync(payloadDir, { recursive: true, force: true });
+mkdirSync(payloadDir, { recursive: true });
+
+const index = {};
+let rawBytes = 0;
+let gzBytes = 0;
+const missing = [];
+
+for (const [girId, entry] of entries) {
+  const src = join(girDir, entry.file);
+  let xml;
+  try {
+    xml = readFileSync(src);
+  } catch {
+    missing.push(entry.file);
+    continue;
+  }
+  const gz = gzipSync(xml, { level: 6 });
+  writeFileSync(join(payloadDir, `${entry.file}.gz`), gz);
+  rawBytes += xml.length;
+  gzBytes += gz.length;
+  index[girId] = { file: entry.file, bytes: xml.length, gzipBytes: gz.length };
+}
+
+// The manifest is generated from a listing of `girs/`, so a name in it that is not on
+// disk means the two have drifted -- refusing here beats shipping a NOTICE entry for a
+// file the tarball does not contain.
+if (missing.length > 0) {
+  console.error(`error: provenance.json names ${missing.length} file(s) absent from ${girDir}:`);
+  for (const f of missing.slice(0, 10)) console.error(`         ${f}`);
+  process.exit(1);
+}
+
+writeFileSync(join(payloadDir, "index.json"), `${JSON.stringify(index, null, 2)}\n`);
+
+// NOTICE.md is the attribution artefact, not documentation. Every file in the tarball is
+// listed with the upstream package it came from and the terms that package declares.
+const licences = new Map();
+for (const [, e] of entries) {
+  licences.set(e.license, (licences.get(e.license) ?? 0) + 1);
+}
+
+const rows = entries
+  .map(([girId, e]) => {
+    const origin = e.sourcePackage
+      ? `${e.sourcePackage} (${manifest.generatedFrom?.distribution ?? "distro"})`
+      : e.source;
+    const url = e.upstreamUrl ? `[link](${e.upstreamUrl})` : "";
+    return `| \`${girId}\` | ${e.license} | ${origin} | ${url} |`;
+  })
+  .join("\n");
+
+const notice = `# NOTICE — third-party content in \`${pkg.name}\`
+
+This package redistributes **GObject Introspection (GIR) XML files that this project did
+not author**. They are verbatim copies of files shipped by upstream projects and by the
+Fedora packages built from them.
+
+## Licensing
+
+The packaging around them — \`src/\`, \`scripts/\`, \`provenance.json\` — is **Apache-2.0**,
+like the rest of ts-for-gir.
+
+The \`payload/\` files are **not**. Each carries the licence of the project it was generated
+from, and those are predominantly copyleft. The table below records, for every file in this
+package, the licence expression declared by the upstream source it came from. That is why
+\`package.json\` says \`"license": "SEE LICENSE IN NOTICE.md"\` rather than naming one licence:
+no single identifier is true of this package's contents.
+
+**This table is evidence, not a legal determination.** A distribution's \`License:\` tag is an
+expression covering everything in that package, not a per-file finding, and nothing here is
+legal advice. If you redistribute these files onward, satisfy the terms below yourself.
+
+Files that no source could attribute are **not included** in this package. See
+\`provenance.json\` → \`unattributed\` for what was left out and why.
+
+## Licence expressions present (${licences.size} distinct, over ${entries.length} files)
+
+${[...licences.entries()]
+  .sort((a, b) => b[1] - a[1])
+  .map(([lic, n]) => `- \`${lic}\` — ${n} file(s)`)
+  .join("\n")}
+
+## Per-file attribution
+
+| Namespace | Declared licence | Origin | Upstream |
+|---|---|---|---|
+${rows}
+
+---
+
+Regenerate this file with \`node packages/gir-files/scripts/build-payload.mjs\`.
+Provenance is re-queried with \`scripts/build-gir-provenance.sh\`.
+`;
+
+writeFileSync(join(pkgRoot, "NOTICE.md"), notice);
+
+const mb = (n) => (n / 1048576).toFixed(1);
+console.error(`==> payload: ${entries.length} files`);
+console.error(
+  `    raw  ${mb(rawBytes)} MB -> gzip ${mb(gzBytes)} MB (${(rawBytes / gzBytes).toFixed(1)}x)`,
+);
+console.error(`    NOTICE.md: ${licences.size} distinct licence expressions`);
+console.error(`    payload/index.json: ${statSync(join(payloadDir, "index.json")).size} bytes`);

--- a/packages/gir-files/src/index.ts
+++ b/packages/gir-files/src/index.ts
@@ -1,0 +1,181 @@
+/**
+ * Access to the original GIR XML files that `@girs/*` is generated from.
+ *
+ * SCOPE — read this before using the package. It is narrow on purpose, and the narrowness
+ * is what makes it compatible with gjsify's ADR 0019 § 2 ("the `.gir` travels with the
+ * RUNTIME package, never with the type package").
+ *
+ * This package answers exactly one question: **what did the corpus that generated
+ * `@girs/*` at this version say?** Its version tracks the ts-for-gir release train, so
+ * `@ts-for-gir/gir-files@X` carries the XML that produced `@girs/*@X`.
+ *
+ * It does NOT answer "what library will the host load". It cannot: a `.gir` with no
+ * binary beside it says nothing about the installed library, which is the whole point of
+ * ADR 0019 — GIRepository matches only the API version, so a `Gtk-4.0` typelib from 4.12
+ * and one from 4.23 both satisfy `gi://Gtk?version=4.0`. Do not use this package to
+ * decide what is available at runtime; for that the `.gir` must travel next to the binary,
+ * which is what `@gjsify/gtk-runtime-*` does via `gjsify.prebuilds`.
+ *
+ * The consumers this is for never load the library at all: generators, conformance
+ * checkers and documentation builders, which ADR 0019 § 5 places squarely in ts-for-gir's
+ * domain — "ts-for-gir knows GIR as XML, parsed headlessly, in CI, with no GTK installed
+ * and no typelib loaded".
+ *
+ * Why it exists: GIR XML and the compiled typelib carry different data. Enum nicks live
+ * in the typelib; the documentation strings live only in the XML. Neither the generated
+ * `.d.ts` nor the typelib carries the `<doc>` prose, so a tool that needs reasons and doc
+ * text has to read the XML.
+ */
+
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gunzipSync } from "node:zlib";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const payloadDir = join(packageRoot, "payload");
+
+/** Where a file's licence and origin were established. */
+export type GirProvenanceSource = "fedora" | "gir-module-metadata";
+
+/** The provenance record for one namespace, as committed in `provenance.json`. */
+export interface GirProvenanceEntry {
+  /** Filename inside the pool, e.g. `Gtk-4.0.gir`. */
+  file: string;
+  /**
+   * SPDX expression declared by the upstream source this file came from.
+   *
+   * Evidence, not a legal determination: a distribution's `License:` tag covers everything
+   * in that package rather than this one file. See NOTICE.md.
+   */
+  license: string;
+  /** SPDX expression for the documentation prose, where the curated records state one. */
+  docLicense?: string;
+  source: GirProvenanceSource;
+  /** Distribution package that ships the file, when the origin is a distro. */
+  sourcePackage?: string;
+  /** Source RPM the distribution package was built from, when known. */
+  sourceRpm?: string;
+  upstreamUrl?: string;
+}
+
+/** A namespace present in this package, with its provenance and sizes. */
+export interface GirFileInfo extends GirProvenanceEntry {
+  /** `Gtk-4.0` */
+  girId: string;
+  /** `Gtk` */
+  namespace: string;
+  /** `4.0` */
+  version: string;
+  /** Uncompressed size of the XML in bytes. */
+  bytes: number;
+  /** Size of the shipped gzip in bytes. */
+  gzipBytes: number;
+}
+
+interface ProvenanceManifest {
+  schemaVersion: number;
+  generatedFrom: { distribution: string; release: string };
+  entries: Record<string, GirProvenanceEntry>;
+  /** Namespaces in the pool that no source could attribute — deliberately NOT shipped. */
+  unattributed: string[];
+}
+
+interface PayloadIndex {
+  [girId: string]: { file: string; bytes: number; gzipBytes: number };
+}
+
+const readJson = <T>(path: string): T => JSON.parse(readFileSync(path, "utf8")) as T;
+
+let manifestCache: ProvenanceManifest | undefined;
+let indexCache: PayloadIndex | undefined;
+
+const manifest = (): ProvenanceManifest => {
+  manifestCache ??= readJson<ProvenanceManifest>(join(packageRoot, "provenance.json"));
+  return manifestCache;
+};
+
+const payloadIndex = (): PayloadIndex => {
+  indexCache ??= readJson<PayloadIndex>(join(payloadDir, "index.json"));
+  return indexCache;
+};
+
+/** The committed provenance manifest, including the list of namespaces left out. */
+export const getProvenance = (): ProvenanceManifest => manifest();
+
+const splitGirId = (girId: string): { namespace: string; version: string } => {
+  const at = girId.lastIndexOf("-");
+  return at === -1
+    ? { namespace: girId, version: "" }
+    : { namespace: girId.slice(0, at), version: girId.slice(at + 1) };
+};
+
+/** Every namespace shipped by this package. */
+export const listGirFiles = (): GirFileInfo[] => {
+  const { entries } = manifest();
+  const index = payloadIndex();
+  return Object.keys(index)
+    .sort()
+    .map((girId) => {
+      const entry = entries[girId];
+      const sizes = index[girId];
+      if (!entry || !sizes) {
+        // Unreachable while build-payload.mjs writes both from the same manifest; the
+        // gate in tests/gir-files asserts it stays that way.
+        throw new Error(`gir-files: payload and provenance disagree about ${girId}`);
+      }
+      return { girId, ...splitGirId(girId), ...entry, ...sizes };
+    });
+};
+
+/** One namespace's record, or `undefined` if this package does not ship it. */
+export const getGirFile = (girId: string): GirFileInfo | undefined => {
+  const entry = manifest().entries[girId];
+  const sizes = payloadIndex()[girId];
+  if (!entry || !sizes) return undefined;
+  return { girId, ...splitGirId(girId), ...entry, ...sizes };
+};
+
+/**
+ * The GIR XML for one namespace.
+ *
+ * @throws if the namespace is not shipped — check {@link getGirFile} first, and consult
+ * `getProvenance().unattributed` for namespaces the pool has but this package withholds.
+ */
+export const readGirXml = (girId: string): string => {
+  const info = getGirFile(girId);
+  if (!info) {
+    const withheld = manifest().unattributed.includes(girId);
+    throw new Error(
+      withheld
+        ? `gir-files: ${girId} is in the pool but has no provenance record, so it is not published. See NOTICE.md.`
+        : `gir-files: unknown namespace ${girId}`,
+    );
+  }
+  return gunzipSync(readFileSync(join(payloadDir, `${info.file}.gz`))).toString("utf8");
+};
+
+/**
+ * Write the shipped namespaces out as plain `.gir` files.
+ *
+ * For tools that want a directory of XML rather than an API — `ts-for-gir generate
+ * --girDirectories=<dir>` being the obvious one. The payload ships gzipped (32.7 MB
+ * installed instead of 376.0 MB), so this trades disk for that convenience at the moment
+ * a caller actually needs it.
+ *
+ * @param destDir directory to write into; created if absent.
+ * @param girIds namespaces to write, defaulting to all of them.
+ * @returns the number of files written.
+ */
+export const extractGirFiles = (destDir: string, girIds?: readonly string[]): number => {
+  mkdirSync(destDir, { recursive: true });
+  const wanted = girIds ?? listGirFiles().map((f) => f.girId);
+  let written = 0;
+  for (const girId of wanted) {
+    const info = getGirFile(girId);
+    if (!info) throw new Error(`gir-files: unknown namespace ${girId}`);
+    writeFileSync(join(destDir, info.file), readGirXml(girId));
+    written++;
+  }
+  return written;
+};

--- a/packages/gir-files/tsconfig.json
+++ b/packages/gir-files/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@ts-for-gir/tsconfig/tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "lib"
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["lib", "node_modules"]
+}

--- a/scripts/build-gir-provenance.mjs
+++ b/scripts/build-gir-provenance.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+// Merges the provenance sources for `girs/` into one committed manifest.
+// Driven by scripts/build-gir-provenance.sh, which supplies the Fedora rows; see that
+// file's header for why this manifest has to exist at all.
+//
+// Two authorities, in priority order, because they answer different questions:
+//
+//   1. Fedora repository metadata (`%{license}`) -- authoritative for the bulk of the
+//      pool, which fetch-fedora-girs.sh harvested out of Fedora RPMs. It maps a .gir
+//      FILENAME to the package that ships it, so it answers per file.
+//   2. `@ts-for-gir/gir-module-metadata` -- this repo's own curated records. It covers
+//      the namespaces Fedora cannot: gnome-shell's Shell/St/Gvc/Shew are built from
+//      source by build-gnome-shell-girs.sh and ship in no RPM, and its `versionAgnostic`
+//      entries answer for the historical namespace versions (Cally-3 ... Cally-15) that
+//      current Fedora has long since dropped.
+//
+// A file no authority places gets NO entry. That is deliberate: `packages/gir-files`
+// publishes exactly the entries in this manifest, so an unattributable file is an
+// unpublished file rather than a silent licence claim.
+
+import { readFileSync, writeFileSync, readdirSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+const args = process.argv.slice(2);
+const argOf = (name) => {
+  const i = args.indexOf(`--${name}`);
+  return i === -1 ? undefined : args[i + 1];
+};
+
+const tsvPath = argOf("tsv");
+const girDir = argOf("gir-dir");
+const outPath = argOf("out");
+const release = argOf("release") ?? "unknown";
+
+if (!tsvPath || !girDir || !outPath) {
+  console.error(
+    "usage: build-gir-provenance.mjs --tsv <f> --gir-dir <d> --out <f> [--release <r>]",
+  );
+  process.exit(2);
+}
+
+/** Fedora rows: girFile -> { package, license, url, sourceRpm }. */
+const fedora = new Map();
+for (const line of readFileSync(tsvPath, "utf8").split("\n")) {
+  if (!line || line.startsWith("#")) continue;
+  const [girFile, pkg, license, url, sourceRpm] = line.split("\t");
+  if (!girFile || !license) continue;
+  // A .gir can be provided by more than one package (e.g. a -devel and a compat split).
+  // First wins, and the set is sorted upstream, so the choice is stable across runs.
+  if (!fedora.has(girFile)) {
+    fedora.set(girFile, {
+      package: pkg,
+      license: license.trim(),
+      url: url?.trim() || undefined,
+      sourceRpm: sourceRpm?.trim() || undefined,
+    });
+  }
+}
+
+/** Curated in-repo records, keyed by girId, with versionAgnostic entries expanded on lookup. */
+const { getModuleMetadata } = await import(
+  new URL("../packages/gir-module-metadata/src/index.ts", import.meta.url).href
+);
+
+const girFiles = readdirSync(girDir)
+  .filter((f) => f.endsWith(".gir"))
+  .sort();
+
+const entries = {};
+const unattributed = [];
+
+for (const file of girFiles) {
+  const girId = file.replace(/\.gir$/, "");
+  const fromFedora = fedora.get(file);
+  if (fromFedora) {
+    entries[girId] = {
+      file,
+      license: fromFedora.license,
+      source: "fedora",
+      sourcePackage: fromFedora.package,
+      sourceRpm: fromFedora.sourceRpm,
+      upstreamUrl: fromFedora.url,
+    };
+    continue;
+  }
+
+  const curated = getModuleMetadata?.(girId);
+  if (curated?.license) {
+    entries[girId] = {
+      file,
+      license: curated.license,
+      docLicense: curated.docLicense,
+      source: "gir-module-metadata",
+      upstreamUrl: curated.repositoryUrl ?? curated.websiteUrl,
+    };
+    continue;
+  }
+
+  unattributed.push(girId);
+}
+
+const manifest = {
+  $schema:
+    "https://github.com/gjsify/ts-for-gir/blob/main/packages/gir-files/provenance.schema.json",
+  schemaVersion: 1,
+  // Regenerate with scripts/build-gir-provenance.sh. Do not hand-edit: the licence
+  // column is a claim about third-party terms and must stay traceable to a query.
+  generatedFrom: { distribution: "fedora", release },
+  entries: Object.fromEntries(Object.entries(entries).sort(([a], [b]) => (a < b ? -1 : 1))),
+  unattributed: unattributed.sort(),
+};
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+const byLicence = new Map();
+for (const e of Object.values(entries))
+  byLicence.set(e.license, (byLicence.get(e.license) ?? 0) + 1);
+
+console.error(`==> ${girFiles.length} .gir files in ${girDir}`);
+console.error(`    attributed:   ${Object.keys(entries).length}`);
+console.error(
+  `      via fedora: ${Object.values(entries).filter((e) => e.source === "fedora").length}`,
+);
+console.error(
+  `      via curated:${Object.values(entries).filter((e) => e.source !== "fedora").length}`,
+);
+console.error(`    unattributed: ${unattributed.length}  (these will NOT be published)`);
+console.error(`    distinct licence expressions: ${byLicence.size}`);
+console.error(`==> wrote ${outPath}`);

--- a/scripts/build-gir-provenance.mjs
+++ b/scripts/build-gir-provenance.mjs
@@ -100,8 +100,6 @@ for (const file of girFiles) {
 }
 
 const manifest = {
-  $schema:
-    "https://github.com/gjsify/ts-for-gir/blob/main/packages/gir-files/provenance.schema.json",
   schemaVersion: 1,
   // Regenerate with scripts/build-gir-provenance.sh. Do not hand-edit: the licence
   // column is a claim about third-party terms and must stay traceable to a query.

--- a/scripts/build-gir-provenance.sh
+++ b/scripts/build-gir-provenance.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Build the provenance + licence manifest for the .gir files in `girs/`.
+#
+# WHY THIS EXISTS
+#
+# `girs/` is not our work. Every file in it is a verbatim copy of a distro-packaged
+# artefact (see fetch-fedora-girs.sh) or a build output of an upstream project, and not
+# one of them carries a licence header -- `grep -lE 'SPDX-License|Copyright' girs/*.gir`
+# matches zero files. The licence is therefore inherited from the project each file was
+# generated from, and nothing in this repository recorded which project that was.
+#
+# That gap is fine while the pool is only ever READ (the generator emits TypeScript, and
+# a type signature is not the XML). It stops being fine the moment we redistribute the
+# XML itself, because the upstream licences are real copyleft -- LGPL-2.1-or-later is the
+# common case, but the pool also draws on GPL-3.0-only, LGPL-2.1-only and AGPL-3.0-or-later
+# packages, and the documentation prose embedded in the `<doc>` elements is separately
+# licensed again (packages/gir-module-metadata/src/data/gtk4.ts records GTK's as
+# GPL-2.1-or-later against library code that is LGPL-2.1-or-later).
+#
+# So: a file may only be redistributed if we can say where it came from and under what
+# terms. This script establishes that, from the same authority the pool was harvested
+# from -- Fedora's repository metadata, whose `%{license}` tag is a maintained SPDX
+# expression. It installs nothing; it is a metadata query only, which is why it takes
+# a couple of minutes rather than the harvester's hour.
+#
+# WHAT IT CANNOT DO, stated plainly because a manifest that overclaims is worse than none:
+# `%{license}` is the licence of the whole RPM, an AND-expression over everything the
+# package ships. It is evidence of the terms the file arrives under, not a per-file
+# determination, and it is not legal advice. Files the query cannot place get NO entry,
+# and a file with no entry is not published -- that refusal is the point.
+#
+# Usage: scripts/build-gir-provenance.sh [--fedora <release>] [--gir-dir <dir>] [--out <file>]
+
+set -euo pipefail
+
+FEDORA_VERSION="rawhide"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GIR_DIR="$PROJECT_DIR/girs"
+OUT_FILE="$PROJECT_DIR/packages/gir-files/provenance.json"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fedora)  FEDORA_VERSION="$2"; shift 2 ;;
+        --gir-dir) GIR_DIR="$2"; shift 2 ;;
+        --out)     OUT_FILE="$2"; shift 2 ;;
+        -h|--help) sed -n '2,32p' "${BASH_SOURCE[0]}"; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+command -v "$CONTAINER_RUNTIME" >/dev/null || {
+    echo "error: $CONTAINER_RUNTIME not found" >&2; exit 1
+}
+
+TSV="$(mktemp "${TMPDIR:-/tmp}/gir-provenance.XXXXXX.tsv")"
+trap 'rm -f "$TSV"' EXIT
+
+echo "==> Querying Fedora $FEDORA_VERSION metadata for .gir provenance (no installs) ..." >&2
+
+# One container, one metadata download. For every package that provides a file under a
+# gir-1.0 directory we emit one row per .gir file it owns, carrying the package's SPDX
+# licence expression and upstream URL. `--file` matches on file-provides, so this finds
+# the owning package without installing it.
+#
+# `run -i` is load-bearing: without it the container gets no stdin, `bash -s` reads an
+# empty script, and podman exits 0 having done nothing. That produced a complete-looking
+# manifest with zero Fedora rows on the first run of this script.
+# dnf's `--qf` interprets `\n` but NOT `\t`, and terminates no record on its own, so fields
+# come back `|`-joined with an explicit newline and are re-split here -- an SPDX expression
+# uses the words AND/OR and never a pipe. Omitting the `\n` returns all 288 packages as one
+# line, which `sort -u` then reports as a single package: the second silent near-miss here.
+"$CONTAINER_RUNTIME" run --rm -i "registry.fedoraproject.org/fedora:${FEDORA_VERSION}" bash -s > "$TSV" <<'INNER'
+set -uo pipefail
+ARCH="$(rpm --eval '%{_arch}'),noarch"
+
+declare -A LICENSE URL SRPM
+while IFS='|' read -r name lic url srpm; do
+    [ -n "$name" ] || continue
+    [ -n "${LICENSE[$name]:-}" ] && continue
+    LICENSE[$name]="$lic"; URL[$name]="$url"; SRPM[$name]="$srpm"
+done < <(dnf repoquery -q --file '*/gir-1.0/*.gir' --arch="$ARCH" \
+             --qf '%{name}|%{license}|%{url}|%{sourcerpm}\n' 2>/dev/null | sort -u)
+
+echo "# packages providing a .gir: ${#LICENSE[@]}" >&2
+
+# A smoke floor, not a target: Fedora has carried ~288 packages providing a .gir for years,
+# and every way this query has broken so far collapsed it to 1. Anything under 100 means the
+# query shape is wrong, not that the distro shrank.
+if [ "${#LICENSE[@]}" -lt 100 ]; then
+    echo "# error: only ${#LICENSE[@]} packages matched -- query shape is broken" >&2
+    exit 1
+fi
+
+for p in "${!LICENSE[@]}"; do
+    dnf repoquery -q --list "$p" --arch="$ARCH" 2>/dev/null \
+      | grep -E '/gir-1\.0/[^/]+\.gir$' \
+      | sed 's#.*/##' \
+      | sort -u \
+      | while IFS= read -r girfile; do
+            [ -n "$girfile" ] || continue
+            printf '%s\t%s\t%s\t%s\t%s\n' \
+                "$girfile" "$p" "${LICENSE[$p]}" "${URL[$p]}" "${SRPM[$p]}"
+        done
+done
+INNER
+
+rows=$(grep -cv '^#' "$TSV" || true)
+echo "==> $rows (gir file, package) rows returned" >&2
+
+# A metadata query that returns nothing is a broken query, not an empty distro. Exiting 0
+# here is what let the first run write a manifest attributing nothing via Fedora at all.
+if [ "$rows" -eq 0 ]; then
+    echo "error: the Fedora metadata query returned no rows -- refusing to write a manifest" >&2
+    echo "       (check container stdin, network, and that fedora:${FEDORA_VERSION} exists)" >&2
+    exit 1
+fi
+
+node "$PROJECT_DIR/scripts/build-gir-provenance.mjs" \
+    --tsv "$TSV" --gir-dir "$GIR_DIR" --out "$OUT_FILE" --release "$FEDORA_VERSION"

--- a/tests/gir-files/package.json
+++ b/tests/gir-files/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ts-for-gir-test/gir-files",
+  "type": "module",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "node ../../packages/gir-files/scripts/build-payload.mjs && vitest run",
+    "test:watch": "vitest"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@ts-for-gir/gir-files": "workspace:^",
+    "vitest": "^4.1.11"
+  },
+  "devDependencies": {
+    "@types/node": "^26.4.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/tests/gir-files/src/gir-files.test.ts
+++ b/tests/gir-files/src/gir-files.test.ts
@@ -1,0 +1,161 @@
+// WHY THIS EXISTS
+//
+// `@ts-for-gir/gir-files` is a package whose entire value is its payload, and whose payload
+// is GENERATED at build time rather than committed. That combination has one dominant
+// failure mode: the builder does not run, or runs against an empty manifest, and a tarball
+// ships with zero `.gir` files while every script in the chain exits 0. Nothing else in the
+// repo would notice -- there is no type to compile, no import to resolve, no example to run.
+// This file is the thing that notices.
+//
+// It also guards the licensing invariant, which is not a nice-to-have here. `girs/` is
+// third-party content under real copyleft with no licence headers, so the package ships a
+// file ONLY if `provenance.json` attributes it. A file that leaks into the payload without a
+// record is an undeclared redistribution, and that is the assertion in
+// "no unattributed namespace is shipped".
+//
+// Every count below is DERIVED from the manifest. The pool grows (GNOME 51 added 13
+// namespaces in one commit), so a hard-coded 718 would be a gate that fails for the wrong
+// reason on the next corpus refresh.
+
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  extractGirFiles,
+  getGirFile,
+  getProvenance,
+  listGirFiles,
+  readGirXml,
+} from "@ts-for-gir/gir-files";
+
+const require = createRequire(import.meta.url);
+const pkgJsonPath = require.resolve("@ts-for-gir/gir-files/package.json");
+const pkgRoot = dirname(pkgJsonPath);
+const payloadDir = join(pkgRoot, "payload");
+const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+  files: string[];
+  license: string;
+};
+
+const provenance = getProvenance();
+const shipped = listGirFiles();
+const payloadFiles = readdirSync(payloadDir).filter((f) => f.endsWith(".gir.gz"));
+
+describe("payload", () => {
+  it("is not empty", () => {
+    // The failure this package would otherwise ship silently.
+    expect(payloadFiles.length).toBeGreaterThan(0);
+    expect(shipped.length).toBeGreaterThan(0);
+  });
+
+  it("contains exactly the namespaces the manifest attributes", () => {
+    const claimed = Object.keys(provenance.entries).sort();
+    const onDisk = payloadFiles.map((f) => f.replace(/\.gir\.gz$/, "")).sort();
+    expect(onDisk).toEqual(claimed);
+    expect(shipped.map((f) => f.girId).sort()).toEqual(claimed);
+  });
+
+  it("holds real bytes for every namespace it lists", () => {
+    for (const file of shipped) {
+      expect(file.gzipBytes, `${file.girId} gzip is empty`).toBeGreaterThan(0);
+      expect(file.bytes, `${file.girId} raw size is zero`).toBeGreaterThan(0);
+      expect(file.bytes, `${file.girId} did not compress`).toBeGreaterThan(file.gzipBytes);
+    }
+  });
+});
+
+describe("licensing", () => {
+  it("attributes every shipped namespace with a non-empty licence", () => {
+    const unlicensed = shipped.filter((f) => !f.license || f.license.trim() === "");
+    expect(unlicensed.map((f) => f.girId)).toEqual([]);
+  });
+
+  it("records where every licence came from", () => {
+    const badSource = shipped.filter(
+      (f) => f.source !== "fedora" && f.source !== "gir-module-metadata",
+    );
+    expect(badSource.map((f) => f.girId)).toEqual([]);
+  });
+
+  it("ships no unattributed namespace", () => {
+    // The invariant that makes redistribution defensible at all.
+    const leaked = provenance.unattributed.filter((girId) =>
+      payloadFiles.includes(`${girId}.gir.gz`),
+    );
+    expect(leaked).toEqual([]);
+  });
+
+  it("declares itself as not single-licensed", () => {
+    // A blanket "MIT" here would be a false claim about LGPL/GPL content.
+    expect(pkg.license).toBe("SEE LICENSE IN NOTICE.md");
+  });
+
+  it("names every shipped namespace and licence expression in NOTICE.md", () => {
+    const notice = readFileSync(join(pkgRoot, "NOTICE.md"), "utf8");
+    const missingIds = shipped.filter((f) => !notice.includes(`\`${f.girId}\``));
+    expect(missingIds.map((f) => f.girId)).toEqual([]);
+
+    const expressions = new Set(shipped.map((f) => f.license));
+    const missingLicences = [...expressions].filter((lic) => !notice.includes(lic));
+    expect(missingLicences).toEqual([]);
+  });
+
+  it("refuses to serve a namespace it cannot attribute", () => {
+    const withheld = provenance.unattributed[0];
+    if (withheld === undefined) return; // nothing held back in this corpus
+    expect(getGirFile(withheld)).toBeUndefined();
+    expect(() => readGirXml(withheld)).toThrow(/no provenance record/);
+  });
+});
+
+describe("tarball shape", () => {
+  it("ships the payload, the manifest and the NOTICE", () => {
+    for (const entry of ["payload", "provenance.json", "NOTICE.md", "src"]) {
+      expect(pkg.files, `package.json "files" omits ${entry}`).toContain(entry);
+    }
+  });
+});
+
+describe("reading", () => {
+  // Derived, not hard-coded: the three largest namespaces in whatever corpus is present.
+  const samples = [...shipped].sort((a, b) => b.bytes - a.bytes).slice(0, 3);
+
+  it("has samples to read", () => {
+    expect(samples.length).toBeGreaterThan(0);
+  });
+
+  for (const sample of samples) {
+    it(`round-trips ${sample.girId} to GIR XML`, () => {
+      const xml = readGirXml(sample.girId);
+      expect(xml.startsWith("<?xml")).toBe(true);
+      expect(xml).toContain("<repository");
+      expect(xml).toContain(`name="${sample.namespace}"`);
+      expect(Buffer.byteLength(xml, "utf8")).toBe(sample.bytes);
+    });
+
+    it(`carries documentation prose for ${sample.girId}`, () => {
+      // The reason this package exists: <doc> survives only in the XML.
+      expect(readGirXml(sample.girId)).toContain("<doc ");
+    });
+  }
+
+  it("throws a named error for an unknown namespace", () => {
+    expect(() => readGirXml("NotANamespace-9.9")).toThrow(/unknown namespace/);
+  });
+
+  it("extracts plain .gir files on request", () => {
+    const first = samples[0];
+    if (!first) return;
+    const dir = mkdtempSync(join(tmpdir(), "gir-files-extract-"));
+    try {
+      expect(extractGirFiles(dir, [first.girId])).toBe(1);
+      const onDisk = readFileSync(join(dir, first.file), "utf8");
+      expect(Buffer.byteLength(onDisk, "utf8")).toBe(first.bytes);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/gir-files/tsconfig.json
+++ b/tests/gir-files/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@ts-for-gir/tsconfig/tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["node", "vitest/globals"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What this adds

`@ts-for-gir/gir-files` — one pooled package carrying the original **GIR XML** that
`@girs/*` is generated from, with a per-namespace provenance and licence record.

```ts
import { readGirXml, getGirFile, listGirFiles, extractGirFiles } from "@ts-for-gir/gir-files";

const xml  = readGirXml("Gtk-4.0");   // the full <repository> document
const info = getGirFile("Gtk-4.0");   // license, sourcePackage, sourceRpm, sizes
extractGirFiles("./girs");            // plain .gir files, for --girDirectories consumers
```

## Why

GIR XML and the compiled typelib carry **different** data, and the generated `.d.ts`
carries neither in full:

| | GIR XML | typelib | generated `.d.ts` |
|---|---|---|---|
| enum nicks (`glib:nick`) | yes | yes | in `@girs/<ns>/surface` |
| **documentation prose (`<doc>`)** | **yes** | no | no |
| deprecation reasons (`<doc-deprecated>`) | yes | no | no |

`Gtk-4.0.gir` holds **18,386 `<doc>` elements**. A tool that wants to explain *why* — a
property ledger with reasons and doc text, a conformance checker, a docs builder — has to
read the XML, and until now the only way to get it was to install the distro `-devel`
packages and hope their versions matched the types being compiled against.

## Scoping against ADR 0019 § 2

gjsify's [ADR 0019 § 2](https://github.com/gjsify/gjsify/blob/main/docs/adr/0019-ts-for-gir-as-library.md)
decided *"the `.gir` travels with the RUNTIME package, never with the type package"*, and
rejects shipping `.gir` inside `@girs/*` because **"a `.gir` in a type package proves
nothing about the library the host will load"**.

That argument is correct and this package does not contradict it. What § 2 rejects is a
`.gir` used to answer *"what will the host load?"* — the drift it was written about, where
`tsc` exits 0 and the runtime throws `TypeError`. This package answers a different
question: **what did the corpus that generated `@girs/*` at this version say?** That is a
build-time correspondence between input and output, not a claim about any host.

Three things keep it on the right side of the line:

- It is neither a type package nor a runtime package, so it adds no `.gir` to any `@girs/*`
  tarball and duplicates nothing across ~705 packages — the ADR's other objection.
- Every entry names its own origin (`sourcePackage: "gtk4-devel"`,
  `sourceRpm: "gtk4-4.23.3-1.fc45.src.rpm"`), so a consumer can see it is reading Fedora's
  package and not the GTK on this machine.
- The README says outright that it must not be used to decide what is available at
  runtime, and points at `@gjsify/gtk-runtime-*` for that.

ADR 0019 § 5 draws the same boundary in this package's favour: *"ts-for-gir knows GIR as
XML — parsed headlessly, in CI, with no GTK installed and no typelib loaded."* The
consumers here are generators, conformance checkers and documentation builders, which never
load the library at all. § 4 also states explicitly that the boundary *"does not restrict
where GIR-derived DATA may flow"*.

**Venue**: `gjsify/types` has issues disabled (`has_issues: false`) and is generator output;
`ts-for-gir` owns `girs/` and the release train, so it is the right repo. No existing issue
or PR covers this.

## Licensing — please read this part

**`girs/` is not our work.** Every file is a verbatim copy of a Fedora RPM's contents
(`scripts/fetch-fedora-girs.sh` harvests them with `dnf repoquery -f '*.gir'`), a
`g-ir-generate` decompile, or a gnome-shell build artefact. **Not one of the 718 files
carries a licence header** — `grep -lE 'SPDX-License|Copyright \(c\)' girs/*.gir` matches
zero files — so the terms are inherited from the project each was generated from.

Before this PR the repository recorded **nothing** about that: no NOTICE, no carve-out in
`LICENSE`, and `git log -i --grep=licen --oneline origin/main` over the whole history returns zero commits. The
generated `@girs/*` packages stamp a blanket `"license": "MIT"`
(`packages/templates/templates/package.json:107`) regardless of the source namespace.

The terms are real copyleft. Over the 510 attributed files, **93 distinct licence
expressions**, the top of the distribution being:

| expression | files |
|---|---|
| `LGPL-2.1-or-later` | 114 |
| `GPL-2.0-or-later` | 103 |
| `LGPL-2.0-or-later` | 46 |
| `LicenseRef-Callaway-LGPLv2+` | 30 |
| `LGPL-3.0-or-later` | 13 |
| `GPL-3.0-or-later` | 10 |

So this PR builds the mechanism that makes attribution possible rather than assuming an
answer:

- **`scripts/build-gir-provenance.sh`** queries Fedora's repository metadata for the
  `%{license}`, `%{url}` and `%{sourcerpm}` of the package owning each `.gir`. It installs
  nothing — metadata only. Namespaces Fedora cannot place fall back to this repo's own
  curated `@ts-for-gir/gir-module-metadata` records, which cover gnome-shell (built from
  source, in no RPM) and, via `versionAgnostic`, the historical namespace versions.
- **A file ships only if the manifest attributes it.** 510 of 718 today; the 208 held back
  are listed in `provenance.json` → `unattributed` (108 are older versions of namespaces
  that *are* attributed, 100 are namespaces current Fedora no longer ships). `readGirXml()`
  on a withheld namespace throws and says why.
- **`NOTICE.md`** is generated from the manifest and lists every shipped file with its
  licence and origin. `package.json` says `"license": "SEE LICENSE IN NOTICE.md"` — no
  single identifier is true of these contents, and claiming MIT would be false.

### What still needs a human, before this is published

**I did not, and could not, make the licensing determination — only the evidence for one.**
Two limits are stated in the code and repeated here:

1. A distribution's `License:` tag is an expression over **everything in that RPM**, not a
   per-file finding. `gtk4-devel` declares ten licences AND-ed together; which of them
   governs `Gtk-4.0.gir` specifically is not something the tag answers.
2. Some values are Fedora-internal legacy identifiers (`LicenseRef-Callaway-LGPLv2+`,
   30 files) rather than real SPDX, and will not resolve in an SPDX tool.

LGPL and GPL do permit verbatim redistribution of source with notices preserved, which is
what distros and `gtk-rs/gir-files` rely on, and the NOTICE is built to satisfy that. But
**the decision to publish is yours, not mine.** Nothing here has been published; the
package would ship only on a future release cut, and it would be reasonable to hold it
until that review happens. There is also a separate, pre-existing question this surfaces
but does not touch: whether the blanket `MIT` on the generated `@girs/*` packages is right.

## Shape and size

One pooled package, not one per namespace. Per-namespace would mean **718 new npm names**;
in `packages/*` — the home chosen below — each would need its own manual first-publish plus
Trusted Publisher bootstrap, since that train publishes over OIDC. (To be precise: a
per-namespace set placed in `gjsify/types` instead would avoid the bootstrap, because that
train authenticates with a token and its publisher treats a 404 as "new package". It would
still be 718 names to version and 718 tarballs, and it would inherit that repo's problem
that nothing bumps versions there.) And GIR consumers are tools — generators, conformance
checkers, docs builders — which usually want many namespaces at once.

The payload ships **gzipped per file**. Measured over the 510 shipped namespaces via
`npm pack --dry-run --json`:

| shape | tarball | installed |
|---|---|---|
| plain `.gir` | 27.5 MB | 308.0 MB |
| per-file `.gir.gz` (shipped) | **27.6 MB** | **27.9 MB** |

The tarball costs 0.1 MB (+0.4 %) and the installed footprint is **11.0× smaller**. This
matters: 308 MB unpacked would be ~2.5× `aws-cdk-lib` (124.3 MB), one of the largest
widely-installed packages, and npmjs.com publishes no clear hard limit to bet against.
27.9 MB is ordinary — `@swc/core-linux-x64-gnu` is 30.5 MB.

**Do not read the compression ratio as files sharing structure.** They do not: gzip's 32 KB
window captures almost nothing across a 376 MB set. Over the full pool, one `tar.gz` of all
718 files is **32.4 MB** while gzipping each separately and summing is **32.7 MB** — 0.9 %
apart. Pooling into one stream buys essentially nothing, which is exactly *why*
pre-compressing per file gives up essentially nothing. (`zstd --long` or `xz` would do
considerably better here, but npm tarballs are gzip.)

## Versioning

The package lives in `packages/*`, so `@release-it/bumper` versions it with the train and
`@ts-for-gir/gir-files@X` carries the XML that produced `@girs/*@X`. No hand-maintained
range can drift out of step — the failure that has reddened installs on this project twice.

The cost of that home is that `release-app.yml` publishes via OIDC, where a new name needs
a bootstrap. Hence the third commit.

## Release-path fix included

`publish:app` passed `--trusted` without `--tolerate-untrusted-new`. Trusted Publishing
requires the package to already exist, so the **first** release carrying any new
`@ts-for-gir/*` name would 404 on the OIDC exchange, hard-fail, and take every
alphabetically later package down with it — gjsify's docs record exactly this as the
v0.4.20 incident (60+ packages stuck a version behind). The flag is the documented remedy
and pairs with the `--tolerate-republish` already present.

**Before the release that ships this**, a maintainer still has to do the manual bootstrap:

```bash
gjsify workspace @ts-for-gir/gir-files build
cd packages/gir-files && gjsify publish --access public --otp <code>
gjsify trust @ts-for-gir/gir-files --workflow release-app.yml   # NOT the default release.yml
```

## The gate, watched red first

`tests/gir-files` (Vitest, picked up automatically by `test:tests`). The failure it exists
for is a tarball with **zero `.gir` files at exit 0** — nothing else in the repo would
notice, since there is no type to compile and no import to resolve.

**Red 1 — payload built empty** (builder skipped / empty manifest):

```
REAL vitest exit=1
     × is not empty 3ms
     × contains exactly the namespaces the manifest attributes 6ms
     × has samples to read 0ms
 Test Files  1 failed (1)
      Tests  3 failed | 10 passed (13)
```

**Red 2 — one unattributed `.gir` dropped into the payload** (the licensing invariant):

```
injecting unattributed namespace: Ags-6.0
REAL vitest exit=1
 FAIL  src/gir-files.test.ts > licensing > ships no unattributed namespace
AssertionError: expected [ 'Ags-6.0' ] to deeply equal []
 Test Files  1 failed (1)
      Tests  2 failed | 17 passed (19)
```

**Green — payload rebuilt from scratch:**

```
REAL exit=0
==> payload: 510 files
    raw  308.0 MB -> gzip 27.6 MB (11.2x)
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

Every count in the gate is **derived from the manifest**, never written down: the pool
grows (GNOME 51 added 13 namespaces in one commit — 705 → 718), so a hard-coded number
would go red for the wrong reason on the next refresh.

The harvester itself has the same discipline, learned the hard way — its first two runs
exited 0 having attributed nothing via Fedora, because `podman run` without `-i` gives the
container no stdin, and because dnf's `--qf` interprets `\n` but not `\t` (without the
newline all 288 packages come back as one line, which `sort -u` reports as one package). It
now refuses to write a manifest on an empty or implausibly small result.

## Verification

```
check:lint    exit=0      check:app     exit=0 (tsc over @ts-for-gir/gir-files)
check:pm      exit=0      check:prereqs exit=0
check:girs    exit=0      check:docs    exit=0
gjsify install --immutable exit=0       (lockfile unchanged; no new registry deps)
gjsify run test:tests      exit=0       (gir-files 19/19, plus the existing suites)
gjsify run build:app       exit=0       (chains the payload; tree stays clean)
```

## Reproducing every number

Measured on `origin/main` @ `7e97f3f3` (`git rev-list --count HEAD..origin/main` = 0).
Note the pool grew in `575ec30d` (GNOME 51): figures taken before it say 705 files /
361.8 MB, and `Gtk-4.0.gir` is now 8.04 MB, not 6.20 MB.

```bash
# pool size and count
find girs -name '*.gir' -printf '%s\n' | awk '{s+=$1;n++} END {printf "%d files, %.1f MB\n", n, s/1048576}'
#=> 718 files, 376.0 MB

# one tar.gz over the whole pool vs. the sum of the files gzipped separately
tar cf - --sort=name $(find girs -name '*.gir' | sort) | gzip -6 | wc -c      #=> 33987103  (32.4 MB)
find girs -name '*.gir' -print0 | xargs -0 -P8 -I{} sh -c 'gzip -6 -c "{}" | wc -c' \
  | awk '{s+=$1} END {printf "%.1f MB\n", s/1048576}'                         #=> 32.7 MB   (0.9 % apart)

# the shipped set, both shapes
scripts/build-gir-provenance.sh                       #=> 718 files, 510 attributed, 208 not, 93 licences
node packages/gir-files/scripts/build-payload.mjs     #=> 510 files, 308.0 MB -> 27.6 MB (11.2x)
cd packages/gir-files && npm pack --dry-run --json    #=> size 27.6 MB, unpackedSize 27.9 MB, 510 .gir.gz

# comparison packages
curl -s https://registry.npmjs.org/aws-cdk-lib/latest | jq '.dist.unpackedSize'   #=> 124.3 MB (vs 27.9 MB here)
curl -s https://registry.npmjs.org/@swc/core-linux-x64-gnu/latest | jq '.dist.unpackedSize'
```

## Not done

- Nothing published to npm; no bootstrap performed.
- `girs/` is untouched, and no submodule was modified.
