### PR TITLE
feat: emit child holders on the widget surface

### DIFF
--- a/packages/generator-typescript/src/surface/emit-data.ts
+++ b/packages/generator-typescript/src/surface/emit-data.ts
@@ -31,17 +31,24 @@ export function emitSurfaceData(surface: WidgetSurface): string {
     ownProps.push(`    ${decl.gtype}: ${list(decl.props.map((prop) => prop.girName))},`);
   }
 
-  const ownSignals = surface.widgets
+  // The runtime data describes EVERYTHING the surface knows, widgets and holders alike:
+  // a holder a consumer cannot look up is a holder it has to re-read the GIR for.
+  // `CHILD_HOLDERS` is the line between the two kinds, not a second data set.
+  const all = [...surface.widgets, ...surface.childHolders].sort((a, b) =>
+    a.gtype < b.gtype ? -1 : 1,
+  );
+
+  const ownSignals = all
     .filter((widget) => widget.signals.length > 0)
     .map((widget) => `    ${widget.gtype}: ${list(widget.signals)},`);
 
-  const decls = surface.widgets.map((widget) => `    ${widget.gtype}: ${list(widget.chain)},`);
+  const decls = all.map((widget) => `    ${widget.gtype}: ${list(widget.chain)},`);
 
   const nicks = [...surface.enums.values()]
     .sort((a, b) => (a.gtype < b.gtype ? -1 : 1))
     .map((entry) => `    ${entry.gtype}: ${list(entry.nicks)},`);
 
-  const slots = surface.widgets
+  const slots = all
     .filter((widget) => widget.slotCandidates.size > 0)
     .map((widget) => {
       const rows = [...widget.slotCandidates]
@@ -69,6 +76,12 @@ export const OWN_PROPS = ${record(ownProps)};
 export const OWN_SIGNALS = ${record(ownSignals)};
 
 export const DECLS = ${record(decls)};
+
+// The GTypes above that are NOT widgets: they hold one through \`set_child\`/\`get_child\`
+// and descend from \`GObject.Object\`. A renderer places them like a container; a check
+// asking "is this a widget" must not count them. Derived from the accessor pair, never
+// from a list — the count is in the provenance line above.
+export const CHILD_HOLDERS = ${list(surface.childHolders.map((holder) => holder.gtype))};
 
 export const ENUM_NICKS = ${record(nicks)};
 

--- a/packages/generator-typescript/src/surface/emit-types.ts
+++ b/packages/generator-typescript/src/surface/emit-types.ts
@@ -18,6 +18,7 @@ import {
   nickAliasOf,
   propsInterfaceOf,
   type SurfaceDecl,
+  type SurfaceWidget,
   type WidgetSurface,
 } from "./model.ts";
 
@@ -117,29 +118,36 @@ export function emitSurfaceTypes(surface: WidgetSurface): string {
       return `export type ${nickAliasOf(entry.gtype)} = ${union};`;
     });
 
-  const rows = surface.widgets.map((widget) => {
-    const slots = [...widget.slotCandidates]
-      .sort(([a], [b]) => (a < b ? -1 : 1))
-      .map(([slot, method]) => `        '${slot}': '${method}';`);
-    return (
-      `    ${widget.gtype}: {\n` +
-      `        class: ${widget.namespace}.${widget.local};\n` +
-      `        props: ${propsInterfaceOf(widget.gtype)};\n` +
-      `        signals: ${widget.namespace}.${widget.local}.SignalSignatures;\n` +
-      `        constructOnly: ${constructOnlyAliasOf(widget.gtype)};\n` +
-      `        slotCandidates: ${slots.length > 0 ? `{\n${slots.join("\n")}\n        }` : "{}"};\n` +
-      `    };`
-    );
-  });
+  const rowsOf = (entries: readonly SurfaceWidget[]): string[] =>
+    entries.map((widget) => {
+      const slots = [...widget.slotCandidates]
+        .sort(([a], [b]) => (a < b ? -1 : 1))
+        .map(([slot, method]) => `        '${slot}': '${method}';`);
+      return (
+        `    ${widget.gtype}: {\n` +
+        `        class: ${widget.namespace}.${widget.local};\n` +
+        `        props: ${propsInterfaceOf(widget.gtype)};\n` +
+        `        signals: ${widget.namespace}.${widget.local}.SignalSignatures;\n` +
+        `        constructOnly: ${constructOnlyAliasOf(widget.gtype)};\n` +
+        `        slotCandidates: ${slots.length > 0 ? `{\n${slots.join("\n")}\n        }` : "{}"};\n` +
+        `    };`
+      );
+    });
 
-  const slotTotal = surface.widgets.reduce((n, widget) => n + widget.slotCandidates.size, 0);
+  const rows = rowsOf(surface.widgets);
+  const holderRows = rowsOf(surface.childHolders);
+
+  const slotTotal = [...surface.widgets, ...surface.childHolders].reduce(
+    (n, widget) => n + widget.slotCandidates.size,
+    0,
+  );
 
   return `/**
  * The GIR-derived widget VOCABULARY for ${surface.namespace}-${surface.version}.
  *
  * GENERATED — do not edit. Provenance: ${surface.provenance}
  *
- * ${surface.widgets.length} concrete widgets, ${emitted.length} declarations${inlined.length > 0 ? ` (${inlined.length} inlined from a namespace with no surface)` : ""}, ${surface.enums.size} enum nick unions, ${slotTotal} slot candidates.
+ * ${surface.widgets.length} concrete widgets${surface.childHolders.length > 0 ? `, ${surface.childHolders.length} child holders` : ""}, ${emitted.length} declarations${inlined.length > 0 ? ` (${inlined.length} inlined from a namespace with no surface)` : ""}, ${surface.enums.size} enum nick unions, ${slotTotal} slot candidates.
  *
  * Module-scoped exports only. There is no \`JSX\` namespace here, no tag spelling and
  * no \`on<Signal>\` prop name: those are DIALECT, and every framework answers them
@@ -207,6 +215,23 @@ ${rows.join("\n")}
 /** Every GType this namespace can create. A consumer derives its own tag map. */
 export type WidgetGType = keyof Widgets;
 
+// ---------------------------------------------------------------------------
+// Child holders — the same shape, for objects that CARRY a widget without being one.
+//
+// \`GtkListItem\`, \`GtkListHeader\`, \`GtkColumnViewCell\` and \`AdwToggle\` descend from
+// \`GObject.Object\` and hold a widget through \`set_child\`/\`get_child\`. A renderer places
+// them exactly like a container, so they belong in the vocabulary; a check asking "is
+// this a widget" must still be able to say no. Hence a sibling table rather than four
+// more rows in \`Widgets\`: concatenate them when you mean both.
+// ---------------------------------------------------------------------------
+
+export interface ChildHolders {
+${holderRows.join("\n")}
+}
+
+/** Every GType this namespace holds a child in without it being a widget. */
+export type ChildHolderGType = keyof ChildHolders;
+
 /** The writable, optional, GObject-keyed property surface of one GType. */
 export type PropsOf<G extends WidgetGType> = Widgets[G]['props'];
 
@@ -233,6 +258,9 @@ export const OWN_SIGNALS: Readonly<Record<string, readonly string[]>>;
 
 /** Widget GType -> every declaration its members come from, self first. */
 export const DECLS: Readonly<Record<string, readonly string[]>>;
+
+/** The GTypes in \`DECLS\` that hold a widget without being one — see \`ChildHolders\`. */
+export const CHILD_HOLDERS: readonly string[];
 
 /** Enum GType -> the nicks this surface offers. */
 export const ENUM_NICKS: Readonly<Record<string, readonly string[]>>;

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -139,6 +139,12 @@ export interface WidgetSurface {
   readonly importName: string;
   readonly provenance: string;
   readonly widgets: readonly SurfaceWidget[];
+  /**
+   * Objects that hold a widget without being one — see `childHoldersOf`. Same shape as
+   * `widgets` and deliberately a SEPARATE list: a consumer wanting both concatenates
+   * them, and one that means "is a widget" is not quietly handed four that are not.
+   */
+  readonly childHolders: readonly SurfaceWidget[];
   /** Key -> declaration, own and foreign, in emit order. */
   readonly declarations: ReadonlyMap<string, SurfaceDecl>;
   /** Nick unions this surface must emit itself, by enum GType. */
@@ -258,6 +264,45 @@ function concreteWidgetsOf(module: GirModule): IntrospectedClass[] {
       typeof cls.glibTypeName === "string" &&
       isWidgetClass(module, cls),
   );
+}
+
+/**
+ * The CHILD HOLDERS of one namespace — objects that carry a widget without being one.
+ *
+ * `GtkListItem`, `GtkListHeader`, `GtkColumnViewCell` and `AdwToggle` hold a widget
+ * through `set_child`/`get_child` and descend from `GObject.Object`, not from
+ * `GtkWidget`. A renderer that places children addresses them exactly like a container,
+ * so leaving them out leaves the consumer re-reading the GIR for four types — which is
+ * the second reader this subpath exists to remove.
+ *
+ * The rule is the accessor PAIR, not a hand-written list, and that distinction is
+ * load-bearing: measured across Gtk-4.0 and Adw-1 it selects exactly those four, and
+ * `AdwToggle` is the argument for having a rule at all — it was absent from the
+ * hand-written list this replaces, has the identical shape, and would have been an
+ * arbitrary gap.
+ *
+ * Names, not types, because that is what was measured. A type-directed version ("holds
+ * anything descending from the root") sounds more general and is unmeasured across the
+ * other 700 namespaces; the per-namespace counts in the provenance are what would show
+ * it going wrong.
+ *
+ * A holder never becomes a widget here: `Widgets` keeps its meaning and `ChildHolders`
+ * is its sibling.
+ */
+function childHoldersOf(module: GirModule): IntrospectedClass[] {
+  return classLikeMembers(module).filter((cls): cls is IntrospectedClass => {
+    if (!(cls instanceof IntrospectedClass)) return false;
+    if (cls.isAbstract || !cls.isIntrospectable) return false;
+    if (typeof cls.glibTypeName !== "string") return false;
+    // A widget is served by `concreteWidgetsOf`. Emitting it twice would put one GType
+    // in two lists a consumer is entitled to concatenate.
+    if (isWidgetClass(module, cls)) return false;
+    const accessors = new Set<string>();
+    for (const decl of [cls, ...ancestorsOf(module, cls)]) {
+      for (const member of decl.members) accessors.add(member.name);
+    }
+    return accessors.has("set_child") && accessors.has("get_child");
+  });
 }
 
 /**
@@ -553,6 +598,9 @@ export function buildWidgetSurface(
 ): WidgetSurface | null {
   const widgetClasses = concreteWidgetsOf(module);
   if (widgetClasses.length === 0) return null;
+  // Holders ride the SAME pipeline — they need declarations, props and since-versions
+  // exactly as widgets do, or a consumer cannot type them. Only the list differs.
+  const holderClasses = childHoldersOf(module);
 
   const namespaceImports = new Map<string, string>();
   const enums = new Map<string, SurfaceEnum>();
@@ -589,7 +637,7 @@ export function buildWidgetSurface(
 
   const needed = new Map<string, IntrospectedBaseClass>();
   const chains = new Map<string, IntrospectedBaseClass[]>();
-  for (const widget of widgetClasses) {
+  for (const widget of [...widgetClasses, ...holderClasses]) {
     const chain = declarationChain(module, widget);
     chains.set(keyOf(widget), chain);
     for (const decl of chain) needed.set(keyOf(decl), decl);
@@ -656,22 +704,26 @@ export function buildWidgetSurface(
     withBases.set(key, { ...decl, bases });
   }
 
-  const widgets: SurfaceWidget[] = widgetClasses
-    .filter((widget) => withBases.has(keyOf(widget)))
-    .map((widget) => ({
-      key: keyOf(widget),
-      namespace: widget.namespace.namespace,
-      local: widget.name,
-      gtype: widget.glibTypeName!,
-      slotCandidates: slotCandidatesOf(module, config, widget),
-      chain: (chains.get(keyOf(widget)) ?? [])
-        .filter((decl) => withBases.has(keyOf(decl)))
-        .map((decl) => decl.glibTypeName!),
-      signals: [...widget.signals].map((signal) => signal.name).sort(),
-    }))
-    .sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
+  const toEntries = (classes: readonly IntrospectedClass[]): SurfaceWidget[] =>
+    classes
+      .filter((widget) => withBases.has(keyOf(widget)))
+      .map((widget) => ({
+        key: keyOf(widget),
+        namespace: widget.namespace.namespace,
+        local: widget.name,
+        gtype: widget.glibTypeName!,
+        slotCandidates: slotCandidatesOf(module, config, widget),
+        chain: (chains.get(keyOf(widget)) ?? [])
+          .filter((decl) => withBases.has(keyOf(decl)))
+          .map((decl) => decl.glibTypeName!),
+        signals: [...widget.signals].map((signal) => signal.name).sort(),
+      }))
+      .sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
 
-  for (const widget of widgets) {
+  const widgets = toEntries(widgetClasses);
+  const childHolders = toEntries(holderClasses);
+
+  for (const widget of [...widgets, ...childHolders]) {
     const owner = module.getInstalledImport(widget.namespace);
     if (owner) namespaceImports.set(widget.namespace, owner.importPath);
   }
@@ -711,6 +763,10 @@ export function buildWidgetSurface(
   const provenanceParts = [`${module.packageName}`];
   if (module.libraryVersion?.declaredByLibrary)
     provenanceParts.push(`library ${module.libraryVersion}`);
+  // Counted, not named: the holder rule is a RULE, so what a reader needs from a diff is
+  // whether it started selecting more — a namespace where it suddenly picks forty is how
+  // an over-broad rule announces itself across the 700-namespace run.
+  if (childHolders.length > 0) provenanceParts.push(`${childHolders.length} child holder(s)`);
   // Named, not counted: both lists are how a GTK or dependency release that changes the
   // shape of the base graph shows up in a diff rather than in a support question.
   if (dropped.length > 0) provenanceParts.push(`dropped empty base(s): ${dropped.join(" ")}`);
@@ -734,6 +790,7 @@ export function buildWidgetSurface(
     importName: module.importName,
     provenance: provenanceParts.join(" — "),
     widgets,
+    childHolders,
     declarations: withBases,
     enums,
     namespaceImports,

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -275,21 +275,28 @@ function concreteWidgetsOf(module: GirModule): IntrospectedClass[] {
  * so leaving them out leaves the consumer re-reading the GIR for four types — which is
  * the second reader this subpath exists to remove.
  *
- * The rule is the accessor PAIR, not a hand-written list, and that distinction is
- * load-bearing: measured across Gtk-4.0 and Adw-1 it selects exactly those four, and
- * `AdwToggle` is the argument for having a rule at all — it was absent from the
- * hand-written list this replaces, has the identical shape, and would have been an
- * arbitrary gap.
+ * THE ACCESSOR NAMES ARE NOT ENOUGH, and that was measured the expensive way. A
+ * name-only rule (`set_child` + `get_child`, no type test) selects 17 classes across the
+ * 718-file corpus, not four: `St.Bin` and eleven `Mx.*` carry the same pair over a
+ * `ClutterActor`. A surface rooted at `GtkWidget` has nothing to say about those, and
+ * the first version took the whole 705-namespace run down with
+ * `St.Bin.child: unsupported type expression GenericType` — the generator was asked to
+ * print a property type belonging to a hierarchy it does not model.
  *
- * Names, not types, because that is what was measured. A type-directed version ("holds
- * anything descending from the root") sounds more general and is unmeasured across the
- * other 700 namespaces; the per-namespace counts in the provenance are what would show
- * it going wrong.
+ * So the child must be a WIDGET, tested with the same `takesOneWidget` the slot
+ * candidates use. The rule is then anchored to the surface's own root rather than to a
+ * GTK naming convention, which is also what makes it survive a namespace nobody has
+ * looked at.
+ *
+ * It stays a rule and not a hand-written list: `AdwToggle` was absent from the list this
+ * replaces, has the identical shape, and would have been an arbitrary gap. The
+ * per-namespace count is printed in the provenance so an over-broad rule shows up in a
+ * diff instead of in a support question.
  *
  * A holder never becomes a widget here: `Widgets` keeps its meaning and `ChildHolders`
  * is its sibling.
  */
-function childHoldersOf(module: GirModule): IntrospectedClass[] {
+function childHoldersOf(module: GirModule, config: OptionsGeneration): IntrospectedClass[] {
   return classLikeMembers(module).filter((cls): cls is IntrospectedClass => {
     if (!(cls instanceof IntrospectedClass)) return false;
     if (cls.isAbstract || !cls.isIntrospectable) return false;
@@ -297,11 +304,11 @@ function childHoldersOf(module: GirModule): IntrospectedClass[] {
     // A widget is served by `concreteWidgetsOf`. Emitting it twice would put one GType
     // in two lists a consumer is entitled to concatenate.
     if (isWidgetClass(module, cls)) return false;
-    const accessors = new Set<string>();
-    for (const decl of [cls, ...ancestorsOf(module, cls)]) {
-      for (const member of decl.members) accessors.add(member.name);
-    }
-    return accessors.has("set_child") && accessors.has("get_child");
+    // Nearest declaration first, so an override does not lose to its own ancestor.
+    const members = [cls, ...ancestorsOf(module, cls)].flatMap((decl) => [...decl.members]);
+    if (!members.some((member) => member.name === "get_child")) return false;
+    const setter = members.find((member) => member.name === "set_child");
+    return setter !== undefined && takesOneWidget(module, config, setter);
   });
 }
 
@@ -477,6 +484,23 @@ function slotNameOf(method: string): string | null {
   return null;
 }
 
+/** Does this method take exactly one argument, and is that argument a widget? */
+function takesOneWidget(
+  module: GirModule,
+  config: OptionsGeneration,
+  method: { parameters: readonly { direction?: string; type: { unwrap(): unknown } }[] },
+): boolean {
+  const params = method.parameters.filter((p) => p.direction === "in");
+  if (params.length !== 1) return false;
+  const type = params[0]!.type.unwrap();
+  if (!(type instanceof TypeIdentifier)) return false;
+  const resolved = type.resolveIdentifier(module, config);
+  if (!resolved) return false;
+  const owner = module.getInstalledImport(resolved.namespace);
+  const target = owner?.getClass(resolved.name);
+  return Boolean(target && isClassLike(target) && isWidgetClass(module, target));
+}
+
 function slotCandidatesOf(
   module: GirModule,
   config: OptionsGeneration,
@@ -487,15 +511,7 @@ function slotCandidatesOf(
   for (const method of methods) {
     const slot = slotNameOf(method.name);
     if (!slot) continue;
-    const params = method.parameters.filter((p) => p.direction === "in");
-    if (params.length !== 1) continue;
-    const type = params[0]!.type.unwrap();
-    if (!(type instanceof TypeIdentifier)) continue;
-    const resolved = type.resolveIdentifier(module, config);
-    if (!resolved) continue;
-    const owner = module.getInstalledImport(resolved.namespace);
-    const target = owner?.getClass(resolved.name);
-    if (!target || !isClassLike(target) || !isWidgetClass(module, target)) continue;
+    if (!takesOneWidget(module, config, method)) continue;
     // First wins in sorted method order: two methods can derive the same slot name
     // (`set_child` and `add_child` both yield `child`) and a duplicate key in an
     // emitted type literal is TS1117 rather than a warning.
@@ -600,7 +616,7 @@ export function buildWidgetSurface(
   if (widgetClasses.length === 0) return null;
   // Holders ride the SAME pipeline — they need declarations, props and since-versions
   // exactly as widgets do, or a consumer cannot type them. Only the list differs.
-  const holderClasses = childHoldersOf(module);
+  const holderClasses = childHoldersOf(module, config);
 
   const namespaceImports = new Map<string, string>();
   const enums = new Map<string, SurfaceEnum>();

--- a/tests/widget-surface/assert.mjs
+++ b/tests/widget-surface/assert.mjs
@@ -94,6 +94,10 @@ const must = [
   ],
   ["since map declared", /export const SINCE: Readonly<Record<string, string>>;/],
   ["helper types", /export type WidgetGType = keyof Widgets;/],
+  // Child holders: a sibling table, never four more rows in `Widgets`.
+  ["child holder table", /export interface ChildHolders \{/],
+  ["child holder helper type", /export type ChildHolderGType = keyof ChildHolders;/],
+  ["child holder list declared", /export const CHILD_HOLDERS: readonly string\[\];/],
 ];
 
 const mustNot = [
@@ -115,6 +119,8 @@ const mustNot = [
   // A non-widget gets neither.
   ["non-widget row", /GtkAdjustment: \{/],
   ["non-widget props interface", /GtkAdjustmentProps/],
+  // Half the accessor pair is not a holder, so it reaches no table at all.
+  ["a set_child-only class anywhere", /GtkSetter/],
 ];
 
 // The `mustNot` list runs against the DECLARATIONS with comments stripped. The header
@@ -146,10 +152,46 @@ for (const name of Object.keys(data)) {
 const rowGTypes = new Set([...types.matchAll(/^ {4}(\w+): \{$/gm)].map((match) => match[1]));
 const dataGTypes = new Set(Object.keys(data.DECLS ?? {}));
 for (const gtype of rowGTypes) {
-  if (!dataGTypes.has(gtype)) fail(`in the Widgets map but not in DECLS: ${gtype}`);
+  if (!dataGTypes.has(gtype)) fail(`in a surface row but not in DECLS: ${gtype}`);
 }
 for (const gtype of dataGTypes) {
-  if (!rowGTypes.has(gtype)) fail(`in DECLS but not in the Widgets map: ${gtype}`);
+  if (!rowGTypes.has(gtype)) fail(`in DECLS but in no surface row: ${gtype}`);
+}
+
+// ------------------------------------------------------- child holders vs widgets
+//
+// `Widgets` and `ChildHolders` have the SAME row shape, so the row-level regex above
+// cannot tell them apart — which is precisely what a consumer asking "is this a widget"
+// would get wrong. Both blocks are extracted and held against each other AND against the
+// runtime list, because agreement between two halves of one emitter is not the same fact
+// as the rule having selected correctly.
+const blockOf = (name) =>
+  new RegExp(`export interface ${name} \\{([\\s\\S]*?)\\n\\}`).exec(types)?.[1] ?? null;
+const widgetsBlock = blockOf("Widgets");
+const holdersBlock = blockOf("ChildHolders");
+if (widgetsBlock === null) fail("no Widgets interface in the surface .d.ts");
+if (holdersBlock === null) fail("no ChildHolders interface in the surface .d.ts");
+
+const holders = new Set(data.CHILD_HOLDERS ?? []);
+if (!holders.has("GtkListItem")) {
+  fail(`CHILD_HOLDERS omits the set_child/get_child carrier: ${JSON.stringify([...holders])}`);
+}
+// THE control: half a pair is not a pair. Matching either accessor alone would also sweep
+// in every `set_child`-carrying non-widget the real corpus has.
+if (holders.has("GtkSetter")) {
+  fail("CHILD_HOLDERS took a class with set_child and no get_child — the rule matched one half");
+}
+if (holders.has("GtkBox")) fail("CHILD_HOLDERS took a widget; concreteWidgetsOf already serves it");
+if (holders.has("GtkAdjustment")) fail("CHILD_HOLDERS took a class with neither accessor");
+if (widgetsBlock?.includes("GtkListItem:")) fail("a child holder appears as a WIDGET row");
+if (!holdersBlock?.includes("GtkListItem:")) fail("the child holder has no ChildHolders row");
+if (!widgetsBlock?.includes("GtkBox:")) fail("the widget table lost GtkBox");
+if (holdersBlock?.includes("GtkBox:")) fail("a widget appears as a CHILD HOLDER row");
+// A holder rides the same pipeline, so it must be describable like any other declaration:
+// a holder a consumer cannot type is a holder it has to re-read the GIR for.
+if (!data.DECLS?.GtkListItem) fail("DECLS omits the child holder — a consumer cannot type it");
+if (!data.OWN_PROPS?.GtkListItem?.includes("activatable")) {
+  fail(`OWN_PROPS lost the holder's own property: ${JSON.stringify(data.OWN_PROPS?.GtkListItem)}`);
 }
 
 // Every property the runtime data offers must be a key of the interface it belongs to.
@@ -322,7 +364,8 @@ if (failures.length > 0) {
 }
 
 console.log(
-  `OK: ${rowGTypes.size} widget row(s), ${Object.keys(data.OWN_PROPS).length} declaration(s) with props, ` +
+  `OK: ${rowGTypes.size - holders.size} widget row(s), ${holders.size} child holder(s), ` +
+    `${Object.keys(data.OWN_PROPS).length} declaration(s) with props, ` +
     `${Object.keys(data.ENUM_NICKS).length} nick union(s); flag-off control clean; ` +
     `broken fixture rejected with exit ${brokenExit}`,
 );

--- a/tests/widget-surface/assert.mjs
+++ b/tests/widget-surface/assert.mjs
@@ -181,6 +181,12 @@ if (!holders.has("GtkListItem")) {
 if (holders.has("GtkSetter")) {
   fail("CHILD_HOLDERS took a class with set_child and no get_child — the rule matched one half");
 }
+// The control for the defect that took a 705-namespace run down: both accessors over a
+// NON-widget child. Name-only matching selects 17 classes across the corpus instead of
+// four, and then asks the emitter to print a type from a hierarchy it does not model.
+if (holders.has("GtkActorBin")) {
+  fail("CHILD_HOLDERS took a set_child/get_child pair over a NON-widget — the type test is gone");
+}
 if (holders.has("GtkBox")) fail("CHILD_HOLDERS took a widget; concreteWidgetsOf already serves it");
 if (holders.has("GtkAdjustment")) fail("CHILD_HOLDERS took a class with neither accessor");
 if (widgetsBlock?.includes("GtkListItem:")) fail("a child holder appears as a WIDGET row");

--- a/tests/widget-surface/fixtures/Mini-1.0.gir
+++ b/tests/widget-surface/fixtures/Mini-1.0.gir
@@ -170,5 +170,30 @@
       </method>
     </class>
 
+    <!-- CONTROL for the defect that took a 705-namespace run down: BOTH accessors, but
+         the child is not a widget. `St.Bin` and eleven `Mx.*` are exactly this — the pair
+         over a `ClutterActor` — and a surface rooted at GtkWidget has nothing to say about
+         them. A name-only rule selects 17 classes across the corpus instead of four, and
+         then asks the emitter to print a property type from a hierarchy it does not
+         model. If this reaches CHILD_HOLDERS the type test is gone. -->
+    <class name="ActorBin" c:symbol-prefix="actor_bin" c:type="GtkActorBin" glib:type-name="GtkActorBin" glib:get-type="gtk_actor_bin_get_type" parent="GObject.Object">
+      <property name="tint" writable="1" transfer-ownership="none">
+        <type name="utf8" c:type="const gchar*"/>
+      </property>
+      <method name="set_child" c:identifier="gtk_actor_bin_set_child">
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.ActorBin" c:type="GtkActorBin*"/></instance-parameter>
+          <parameter name="child" transfer-ownership="none"><type name="Adjustment" c:type="GtkAdjustment*"/></parameter>
+        </parameters>
+      </method>
+      <method name="get_child" c:identifier="gtk_actor_bin_get_child">
+        <return-value transfer-ownership="none"><type name="Adjustment" c:type="GtkAdjustment*"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.ActorBin" c:type="GtkActorBin*"/></instance-parameter>
+        </parameters>
+      </method>
+    </class>
+
   </namespace>
 </repository>

--- a/tests/widget-surface/fixtures/Mini-1.0.gir
+++ b/tests/widget-surface/fixtures/Mini-1.0.gir
@@ -129,5 +129,46 @@
       </property>
     </class>
 
+    <!-- A CHILD HOLDER: not a widget, carries one through the set_child/get_child PAIR.
+         `GtkListItem`, `GtkListHeader`, `GtkColumnViewCell` and `AdwToggle` are this
+         shape in the real corpus — they descend from GObject.Object, and a renderer
+         places them exactly like a container. -->
+    <class name="ListItem" c:symbol-prefix="list_item" c:type="GtkListItem" glib:type-name="GtkListItem" glib:get-type="gtk_list_item_get_type" parent="GObject.Object">
+      <property name="activatable" writable="1" transfer-ownership="none">
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+      <method name="set_child" c:identifier="gtk_list_item_set_child">
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.ListItem" c:type="GtkListItem*"/></instance-parameter>
+          <parameter name="child" transfer-ownership="none"><type name="Widget" c:type="GtkWidget*"/></parameter>
+        </parameters>
+      </method>
+      <method name="get_child" c:identifier="gtk_list_item_get_child">
+        <return-value transfer-ownership="none"><type name="Widget" c:type="GtkWidget*"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.ListItem" c:type="GtkListItem*"/></instance-parameter>
+        </parameters>
+      </method>
+    </class>
+
+    <!-- CONTROL, and the one that decides whether the rule is the PAIR or either half:
+         a setter with no getter. If this reaches CHILD_HOLDERS the rule matched one
+         accessor, which would also sweep in every `set_child`-carrying non-widget the
+         real corpus has. `Adjustment` above is the weaker control (neither accessor)
+         and `Box` is the third (both a widget AND a `set_child` carrier). -->
+    <class name="Setter" c:symbol-prefix="setter" c:type="GtkSetter" glib:type-name="GtkSetter" glib:get-type="gtk_setter_get_type" parent="GObject.Object">
+      <property name="tag" writable="1" transfer-ownership="none">
+        <type name="utf8" c:type="const gchar*"/>
+      </property>
+      <method name="set_child" c:identifier="gtk_setter_set_child">
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Mini.Setter" c:type="GtkSetter*"/></instance-parameter>
+          <parameter name="child" transfer-ownership="none"><type name="Widget" c:type="GtkWidget*"/></parameter>
+        </parameters>
+      </method>
+    </class>
+
   </namespace>
 </repository>


### PR DESCRIPTION
`@girs/<ns>/surface` filters on `GtkWidget` descendants, so four types that carry a widget **without being one** fall out: `GtkListItem`, `GtkListHeader`, `GtkColumnViewCell` and `AdwToggle`. They descend from `GObject.Object` and hold their child through the `set_child`/`get_child` pair, and a renderer places them exactly like a container — so a consumer that wants them has to re-read the GIR for four types, which is the second reader this subpath exists to remove.

## What it emits

They ride the same pipeline as widgets (declarations, props, since-versions) and land in a **sibling** table:

```ts
export interface ChildHolders { GtkListItem: { class; props; signals; constructOnly; slotCandidates }; }
export type ChildHolderGType = keyof ChildHolders;
export const CHILD_HOLDERS: readonly string[];
```

`Widgets` keeps meaning "is a widget" and `CHILD_HOLDERS` is the line between the two kinds: a consumer wanting both concatenates them, one asking "is this a widget" still gets a truthful no. Four more rows in `Widgets` would have handed every consumer — peachy included — four non-widgets it never asked for.

## The rule, and how it was measured

Non-abstract · not a root descendant · has **both** `set_child` and `get_child` · **and the child is a widget**.

That last clause is not decoration, and the first revision of this PR lacked it. CI died on `St.Bin.child: unsupported type expression GenericType`, taking the whole 705-namespace `build:types` run with it. Measured across all 718 GIR files: name-only matching selects **17** classes, not four — `St.Bin` and eleven `Mx.*` carry the identical accessor pair over a `ClutterActor`, and a surface rooted at `GtkWidget` has nothing to say about those. `slotCandidatesOf` already answered "one argument, and is it a widget", so that test is extracted as `takesOneWidget` and shared. The rule is thereby anchored to the surface's own root rather than to a GTK naming convention.

Re-measured with the type clause, over Gtk-4.0 and Adw-1: the same four.

| reader | result |
|---|---|
| this generator | `CHILD_HOLDERS` on the fixture, A/B-proven twice |
| the consumer's own `placementCarriers()` | 4 |
| a raw XML scan over `Gtk-4.0.gir` + `Adw-1.gir`, written independently of both | `AdwToggle GtkColumnViewCell GtkListHeader GtkListItem` |

`AdwToggle` is the argument for having a rule at all: it was absent from the hand-written list this replaces, has the identical shape, and would have been an arbitrary gap.

The per-namespace count is printed in the provenance line, so a rule that starts over-selecting announces itself in a diff rather than in a support question.

## The control

Two controls, one per way the rule can go wrong, and both proven sharp rather than assumed:

- **half a pair** — a fixture class with `set_child` and no `get_child`, which must reach no table. Removing `get_child` from the holder fixture turns the gate red with four named failures and `CHILD_HOLDERS: []`.
- **a pair over a non-widget** — `GtkActorBin`, the `St.Bin` shape that broke CI. Disabling the type test puts it in `CHILD_HOLDERS` and turns the gate red with that named failure.

`Adjustment` (neither accessor) and `Box` (a widget that *does* carry `set_child`) are the two weaker controls.

## Checks

- `tests/widget-surface` green: `1 widget row(s), 1 child holder(s), 4 declaration(s) with props, 2 nick union(s); flag-off control clean; broken fixture rejected with exit 1`
- `gjsify run check:app` exit 0
