### PR TITLE
fix(lib): carry doc metadata into class members

### DIFF
--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -231,6 +231,12 @@ export class IntrospectedClassFunction<
 		});
 
 		classFn.returnTypeDoc = fn.returnTypeDoc;
+		// `IntrospectedFunction.fromXML` already parsed it; rebuilding as a class function
+		// dropped it, and with it every `@deprecated` and `@since` a METHOD carries — the
+		// most common kind there is. Measured on Gtk-4.0: 528 `<doc-deprecated>` on
+		// `<method>` reached no consumer, so an IDE showed no strikethrough for an API
+		// slated to disappear.
+		classFn.metadata = fn.metadata;
 		classFn.generics = [...fn.generics];
 		classFn.finishFuncName = element.$["glib:finish-func"];
 
@@ -341,7 +347,7 @@ export class IntrospectedVirtualClassFunction extends IntrospectedClassFunction<
 		// Convert the function to a virtual class function
 		const { raw_name: name, output_parameters, parameters, return_type, doc, isIntrospectable } = fn;
 
-		return new IntrospectedVirtualClassFunction({
+		const virtualFn = new IntrospectedVirtualClassFunction({
 			parent,
 			name,
 			output_parameters,
@@ -350,6 +356,10 @@ export class IntrospectedVirtualClassFunction extends IntrospectedClassFunction<
 			doc,
 			isIntrospectable,
 		});
+
+		virtualFn.metadata = fn.metadata;
+
+		return virtualFn;
 	}
 
 	asString<T extends FormatGenerator<unknown>>(generator: T): ReturnType<T["generateVirtualClassFunction"]> {
@@ -442,7 +452,7 @@ export class IntrospectedStaticClassFunction extends IntrospectedClassFunction {
 
 		const isShadowedBy = m.$["shadowed-by"] != null;
 
-		return new IntrospectedStaticClassFunction({
+		const staticFn = new IntrospectedStaticClassFunction({
 			parent,
 			name,
 			output_parameters,
@@ -451,6 +461,10 @@ export class IntrospectedStaticClassFunction extends IntrospectedClassFunction {
 			doc,
 			isIntrospectable: isIntrospectable && !isShadowedBy,
 		});
+
+		staticFn.metadata = fn.metadata;
+
+		return staticFn;
 	}
 }
 
@@ -512,6 +526,8 @@ export class IntrospectedClassCallback extends IntrospectedClassFunction {
 		const cb = new IntrospectedClassCallback(
 			IntrospectedClassFunction.fromXML(element, parent, options).getCallbackParameters(),
 		);
+
+		cb.metadata = parseMetadata(element);
 
 		const glibTypeName = element.$["glib:type-name"];
 		if (typeof glibTypeName === "string" && element.$["glib:type-name"]) {

--- a/tests/doc-tags/.ts-for-gir.rc.js
+++ b/tests/doc-tags/.ts-for-gir.rc.js
@@ -1,0 +1,8 @@
+export default {
+  girDirectories: ["./fixtures", "../../girs"],
+  modules: ["Docs-1.0"],
+  outdir: "./generated",
+  npmScope: "@girs",
+  package: true,
+  reporter: false,
+};

--- a/tests/doc-tags/assert.mjs
+++ b/tests/doc-tags/assert.mjs
@@ -1,0 +1,100 @@
+// Asserts that GIR's documentation METADATA — `@deprecated` with its version and reason,
+// and `@since` — reaches the emitted declarations.
+//
+// WHY THIS EXISTS. `parseMetadata` read all of it correctly and `getTsDocMetadataTags`
+// rendered it correctly, and between them the class-member rebuild dropped it on the
+// floor: `IntrospectedClassFunction.fromXML` builds an `IntrospectedFunction`, copies
+// `doc`, `parameters` and `return_type` out of it, and constructed a new object without
+// `metadata`. Every method, static function, virtual method and class callback in the
+// corpus lost its deprecation that way. Measured on Gtk-4.0 before the fix: 295
+// `@deprecated` in the output against 780 `<doc-deprecated>` in the GIR, and the 528 that
+// sit on `<method>` reached nobody — so an IDE showed no strikethrough for an API that
+// upstream says will be gone in GTK 5.
+//
+// A unit test over `getTsDocMetadataTags` would have passed throughout. The assertion has
+// to run the PARSE, so this suite generates and reads the emitted file.
+//
+// The property case is the positive control: properties never lost their metadata, so if
+// the property assertion fails the suite is broken rather than the fix.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const file = join(here, "generated", "docs-1.0", "docs-1.0.d.ts");
+if (!existsSync(file)) throw new Error(`types not generated: ${file}`);
+const types = readFileSync(file, "utf8");
+
+/** @type {string[]} */
+const failures = [];
+const fail = (message) => failures.push(message);
+
+/** The TSDoc block immediately above a declaration, or null. */
+function docBlockOf(declaration) {
+  const at = types.indexOf(declaration);
+  if (at === -1) return null;
+  const before = types.slice(0, at);
+  const open = before.lastIndexOf("/**");
+  const close = before.lastIndexOf("*/");
+  if (open === -1 || close < open) return null;
+  // Only if nothing but whitespace separates the block from the declaration.
+  if (before.slice(close + 2).trim() !== "") return null;
+  return before.slice(open, close + 2);
+}
+
+const must = [
+  // The reason text keeps the generator's own doc transform, which fences a C symbol in
+  // backticks — asserted as emitted rather than as written in the GIR.
+  [
+    "method keeps its deprecation",
+    "old_way(): void",
+    /@deprecated since 1\.8: Use `docs_thing_new_way\(\)` instead\./,
+  ],
+  ["method keeps its since", "new_way(): void", /@since 1\.8/],
+  ["method keeps BOTH tags", "old_way(): void", /@since 1\.2[\s\S]*@deprecated/],
+  [
+    "static function keeps its deprecation",
+    "static make_old(): Thing",
+    /@deprecated since 1\.9: Construct it directly\./,
+  ],
+  [
+    "property keeps its deprecation",
+    "get legacy_mode()",
+    /@deprecated since 1\.5: Legacy mode is gone\./,
+  ],
+];
+
+for (const [label, declaration, expected] of must) {
+  const block = docBlockOf(declaration);
+  if (block === null) {
+    fail(`${label}: no TSDoc block above \`${declaration}\``);
+    continue;
+  }
+  if (!expected.test(block))
+    fail(`${label}: block does not match ${expected}\n      ${block.replace(/\n/g, "\n      ")}`);
+}
+
+// The control: an undeprecated method must not inherit a sibling's tag.
+const newWay = docBlockOf("new_way(): void");
+if (newWay && /@deprecated/.test(newWay)) {
+  fail("an undeprecated method carries @deprecated — the tag is leaking between members");
+}
+
+// A virtual method is emitted under a different name; assert the tag reached the file at
+// all rather than guessing the spelling.
+if (!/@deprecated since 1\.8: Override handle_new instead\./.test(types)) {
+  fail("the virtual method's deprecation reached no declaration");
+}
+
+if (failures.length > 0) {
+  console.error("doc-tags assertion failures:");
+  for (const failure of failures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+
+const count = (re) => (types.match(re) ?? []).length;
+console.log(
+  `OK: ${count(/@deprecated/g)} @deprecated, ${count(/@since/g)} @since across method, ` +
+    `static function, virtual method and property; undeprecated sibling clean`,
+);

--- a/tests/doc-tags/fixtures/Docs-1.0.gir
+++ b/tests/doc-tags/fixtures/Docs-1.0.gir
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<repository version="1.2"
+            xmlns="http://www.gtk.org/introspection/core/1.0"
+            xmlns:c="http://www.gtk.org/introspection/c/1.0"
+            xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <include name="GObject" version="2.0"/>
+  <package name="docs-1.0"/>
+  <namespace name="Docs" version="1.0" shared-library="libdocs-1.0.so.0" c:identifier-prefixes="Docs" c:symbol-prefixes="docs">
+
+    <class name="Thing" c:symbol-prefix="thing" c:type="DocsThing" glib:type-name="DocsThing" glib:get-type="docs_thing_get_type" parent="GObject.Object">
+
+      <!-- An ordinary METHOD that upstream deprecated, with a version and a reason.
+           This is the common case: 528 of them in Gtk-4.0 alone. -->
+      <method name="old_way" c:identifier="docs_thing_old_way" version="1.2" deprecated="1" deprecated-version="1.8">
+        <doc xml:space="preserve">Does the thing the old way.</doc>
+        <doc-deprecated xml:space="preserve">Use docs_thing_new_way() instead.</doc-deprecated>
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Docs.Thing" c:type="DocsThing*"/></instance-parameter>
+        </parameters>
+      </method>
+
+      <!-- CONTROL: a method upstream did NOT deprecate. It must carry its doc and its
+           `@since`, and must NOT acquire a `@deprecated` from a sibling. -->
+      <method name="new_way" c:identifier="docs_thing_new_way" version="1.8">
+        <doc xml:space="preserve">Does the thing the new way.</doc>
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Docs.Thing" c:type="DocsThing*"/></instance-parameter>
+        </parameters>
+      </method>
+
+      <!-- A STATIC function: a different rebuild path, same loss. -->
+      <function name="make_old" c:identifier="docs_thing_make_old" deprecated="1" deprecated-version="1.9">
+        <doc xml:space="preserve">Builds one the old way.</doc>
+        <doc-deprecated xml:space="preserve">Construct it directly.</doc-deprecated>
+        <return-value transfer-ownership="full"><type name="Docs.Thing" c:type="DocsThing*"/></return-value>
+      </function>
+
+      <!-- A VIRTUAL method: the third rebuild path. -->
+      <virtual-method name="handle_old" invoker="old_way" deprecated="1" deprecated-version="1.8">
+        <doc xml:space="preserve">Handles the old way.</doc>
+        <doc-deprecated xml:space="preserve">Override handle_new instead.</doc-deprecated>
+        <return-value transfer-ownership="none"><type name="none" c:type="void"/></return-value>
+        <parameters>
+          <instance-parameter name="self" transfer-ownership="none"><type name="Docs.Thing" c:type="DocsThing*"/></instance-parameter>
+        </parameters>
+      </virtual-method>
+
+      <!-- A PROPERTY, which never lost its metadata: the positive control proving the
+           suite reads a file where deprecation DOES arrive by another route. -->
+      <property name="legacy-mode" writable="1" transfer-ownership="none" deprecated="1" deprecated-version="1.5">
+        <doc xml:space="preserve">Whether the legacy mode is on.</doc>
+        <doc-deprecated xml:space="preserve">Legacy mode is gone.</doc-deprecated>
+        <type name="gboolean" c:type="gboolean"/>
+      </property>
+
+    </class>
+  </namespace>
+</repository>

--- a/tests/doc-tags/package.json
+++ b/tests/doc-tags/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@ts-for-gir-test/doc-tags",
+  "description": "Tests that GIR documentation metadata survives the rebuild into class members",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "gjsify run clear && gjsify run generate && gjsify run assert",
+    "generate": "ts-for-gir-dev generate --configName .ts-for-gir.rc.js",
+    "assert": "node --no-warnings assert.mjs",
+    "clear": "rm -rf generated"
+  },
+  "devDependencies": {
+    "@ts-for-gir/cli": "workspace:^"
+  }
+}


### PR DESCRIPTION
Every **method** in the corpus was losing its `@deprecated` and its `@since`.

`parseMetadata` read them correctly and `getTsDocMetadataTags` rendered them correctly. Between the two, the rebuild into a class member dropped them: `IntrospectedClassFunction.fromXML` builds an `IntrospectedFunction`, destructures `doc`, `parameters` and `return_type` out of it, and constructs a new object with **no `metadata`**. The static, virtual and class-callback paths do the same.

## Measured

Generating Gtk-4.0 before and after, same command:

| tag | before | after |
|---|---:|---:|
| `@deprecated` | 295 | **1669** |
| `@since` | 467 | **2779** |

The GIR carries 780 `<doc-deprecated>` for Gtk-4.0 alone, **528 of them on `<method>`**, and none of those reached a consumer.

```ts
// before — the GIR says deprecated="1" deprecated-version="4.10"
//          <doc-deprecated>This widget will be removed in GTK 5</doc-deprecated>
append_custom_item(name: string, label: string, icon: Gio.Icon): void;

// after
/**
 * ...
 * @deprecated since 4.10: This widget will be removed in GTK 5
 */
append_custom_item(name: string, label: string, icon: Gio.Icon): void;
```

An editor showed no strikethrough for an API upstream has already scheduled for removal.

Properties, classes, interfaces, enums, constants, aliases and signals were never affected — they set `metadata` in their own `fromXML`, which is why the output had 295 rather than zero.

## The guard, and why it generates

`tests/doc-tags` runs the generator over a small fixture and reads the emitted `.d.ts`. That shape is not incidental: **a unit test over `getTsDocMetadataTags` would have passed throughout the defect**, because that function was never wrong. The assertion has to run the parse.

The fixture covers all three emitted paths (method · static function · virtual method) plus two controls:

- a **property**, as the positive control — it never lost metadata, so a failure there means the suite is broken rather than the fix;
- an **undeprecated sibling**, to catch a tag leaking between members.

`test:tests` globs `@ts-for-gir-test/*`, so the suite runs in CI with no list to maintain.

Proven sharp rather than assumed: removing the three assignments turns the suite red with five named failures, one per emitted path.

## Checks

- `gjsify workspace @ts-for-gir-test/doc-tags run test` exit 0 — `5 @deprecated, 2 @since across method, static function, virtual method and property; undeprecated sibling clean`
- `gjsify run check:app` exit 0
