### PR TITLE
feat: key SINCE by signal as well as property

### DIFF
--- a/packages/generator-typescript/src/surface/emit-types.ts
+++ b/packages/generator-typescript/src/surface/emit-types.ts
@@ -269,11 +269,15 @@ export const ENUM_NICKS: Readonly<Record<string, readonly string[]>>;
 export const SLOT_CANDIDATES: Readonly<Record<string, Readonly<Record<string, string>>>>;
 
 /**
- * \`Type.property\` -> the release that introduced it.
+ * \`Type.property\` and \`Type::signal\` -> the release that introduced it.
  *
  * What keeps a runtime cross-check honest across a version gap without an
  * allowlist: a member the installed library lacks is a defect UNLESS the version
  * here is newer than the one running.
+ *
+ * BOTH key shapes, because that test only works for the members it covers. A
+ * property-only map leaves a consumer no way to explain a missing SIGNAL, which is
+ * a correct surface reported as 18 defects.
  */
 export const SINCE: Readonly<Record<string, string>>;
 `;

--- a/packages/generator-typescript/src/surface/model.ts
+++ b/packages/generator-typescript/src/surface/model.ts
@@ -769,11 +769,31 @@ export function buildWidgetSurface(
     }
   }
 
+  // Two key shapes, and the second one is not decoration.
+  //
+  // `SINCE` exists so a consumer can tell "this surface describes a NEWER library than the
+  // one installed" from "this surface is wrong". That test only works for the members it
+  // covers. Measured against gtk4-4.22.4 / libadwaita-1.9.3 while the surface described
+  // 4.23.3 / 1.10.0: every missing PROPERTY was explained by a since-version — 14 of them,
+  // 0 unexplained — and 18 missing SIGNALS were not, because a property-only `SINCE` has
+  // nothing to say about `GtkWindow::force-close`. A consumer checking signals against the
+  // installed typelib therefore went red on 18 widgets for a surface that was correct.
+  //
+  // `Type.property` and `Type::signal` are GObject's own two spellings, so they cannot
+  // collide, and a reader already knows which is which.
   const since = new Map<string, string>();
   for (const decl of withBases.values()) {
     if (!decl.emitted) continue;
     for (const prop of decl.props)
       if (prop.since) since.set(`${decl.gtype}.${prop.girName}`, prop.since);
+  }
+  for (const widget of [...widgetClasses, ...holderClasses]) {
+    const gtype = widget.glibTypeName;
+    if (!gtype) continue;
+    for (const signal of widget.signals) {
+      const introduced = signal.metadata?.introducedVersion;
+      if (introduced) since.set(`${gtype}::${signal.name}`, introduced);
+    }
   }
 
   const provenanceParts = [`${module.packageName}`];

--- a/tests/widget-surface/assert.mjs
+++ b/tests/widget-surface/assert.mjs
@@ -226,6 +226,21 @@ if (data.ENUM_NICKS?.GtkStateFlags) {
 if (data.SINCE?.["GtkOrientable.orientation"] !== "1.2") {
   fail(`SINCE lost the GIR version attribute: ${JSON.stringify(data.SINCE)}`);
 }
+// The SIGNAL half, keyed the way GObject spells a signal. Without it a consumer has no
+// way to tell "this surface describes a newer library" from "this surface is wrong" for
+// signals — measured against gtk4-4.22.4: 18 widgets reported as defects for a correct
+// surface, because `GtkWindow::force-close` had nothing to explain it.
+if (data.SINCE?.["GtkBox::child-added"] !== "1.6") {
+  fail(
+    `SINCE carries no signal key: ${JSON.stringify(
+      Object.keys(data.SINCE ?? {}).filter((k) => k.includes("::")),
+    )}`,
+  );
+}
+// And the two spellings must not collide: a property key never contains `::`.
+for (const key of Object.keys(data.SINCE ?? {})) {
+  if (key.includes("::") && key.includes(".")) fail(`SINCE key is neither spelling: ${key}`);
+}
 if (!data.OWN_PROPS?.GtkBox?.includes("user-data")) {
   // Dropping it from the runtime data would hide a real writable ParamSpec from the
   // consumer check that asks the installed library whether every name here exists.

--- a/tests/widget-surface/fixtures/Mini-1.0.gir
+++ b/tests/widget-surface/fixtures/Mini-1.0.gir
@@ -88,7 +88,9 @@
       <property name="user-data" writable="1" transfer-ownership="none">
         <type name="gpointer" c:type="gpointer"/>
       </property>
-      <glib:signal name="child-added" when="last">
+      <!-- A signal WITH a since-version, on a CONCRETE class: `OWN_SIGNALS` carries a
+           widget's own signals, so a version on the abstract base would reach nothing. -->
+      <glib:signal name="child-added" when="last" version="1.6">
         <parameters>
           <parameter name="child" transfer-ownership="none">
             <type name="Widget" c:type="GtkWidget*"/>


### PR DESCRIPTION
`SINCE` exists so a consumer can tell **"this surface describes a newer library than the one installed"** from **"this surface is wrong"**. That test only works for the members it covers, and it covered properties only.

## Measured

Against the installed `gtk4-4.22.4` / `libadwaita-1.9.3`, while `@girs/*@4.4.0` describes 4.23.3 / 1.10.0 — walking `DECLS`/`OWN_PROPS`/`OWN_SIGNALS` against the running typelib:

| | count |
|---|---:|
| properties missing from the installed library, **explained by `SINCE`** | 14 |
| properties missing, **unexplained** | **0** |
| signals missing, **unexplained** | **18** |

All eighteen are `force-close`, on every `GtkWindow` descendant. A correct surface, reported as eighteen defects — because a property-only map has nothing to say about `GtkWindow::force-close`. The consumer's only remaining options were an allowlist or not checking signals at all, and both give up the thing `SINCE` is for.

This is not hypothetical: `@gjsify/gtk-host`'s `generated.spec.ts` asks the installed typelib whether every emitted name is real, and its signal arm is exactly where those eighteen would land.

## The change

Signal since-versions are collected alongside the property ones and keyed `Type::signal`. `Type.property` and `Type::signal` are GObject's own two spellings, so they cannot collide and a reader already knows which is which.

The gate asserts both: the signal key is present, and no key carries both spellings.

## One thing the fixture had to get right

`OWN_SIGNALS` carries a widget's **own** signals, so a since-version on the abstract base reaches nothing — my first attempt put it on `Widget` and the assertion failed for the right reason. It now sits on a concrete class's signal, which is what the real corpus looks like.

## Checks

- `tests/widget-surface` green; A/B verified — removing the collection loop turns it red
- `gjsify lint` exit 0, `gjsify run check:app` exit 0
