### PR TITLE
fix: key the vocabulary's OWN_SIGNALS by declaration

### DIFF
--- a/packages/generator-typescript/src/vocabulary/emit-data.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-data.ts
@@ -23,13 +23,22 @@ const list = (items: readonly string[]): string =>
   `[${items.map((item) => `'${item}'`).join(", ")}]`;
 
 export function emitVocabularyData(surface: WidgetVocabulary): string {
-  const ownProps: string[] = [];
-  for (const decl of [...surface.declarations.values()].sort((a, b) =>
-    a.gtype < b.gtype ? -1 : 1,
-  )) {
-    if (!decl.emitted || decl.props.length === 0) continue;
-    ownProps.push(`    ${decl.gtype}: ${list(decl.props.map((prop) => prop.girName))},`);
-  }
+  // `OWN_PROPS` and `OWN_SIGNALS` are keyed by DECLARATION, not by creatable widget, and
+  // they must stay keyed the same way: `DECLS` hands the consumer a chain of GTypes, and
+  // it reads both tables at every link of it. Keying signals by concrete widget is what
+  // this fixes — `GtkWidget` owns 13 signals and no `Widgets` row, so the two tables
+  // disagreed about which GTypes the vocabulary describes.
+  const byGType = [...surface.declarations.values()]
+    .filter((decl) => decl.emitted)
+    .sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
+
+  const ownProps = byGType
+    .filter((decl) => decl.props.length > 0)
+    .map((decl) => `    ${decl.gtype}: ${list(decl.props.map((prop) => prop.girName))},`);
+
+  const ownSignals = byGType
+    .filter((decl) => decl.signals.length > 0)
+    .map((decl) => `    ${decl.gtype}: ${list(decl.signals)},`);
 
   // The runtime data describes EVERYTHING the surface knows, widgets and holders alike:
   // a holder a consumer cannot look up is a holder it has to re-read the GIR for.
@@ -37,10 +46,6 @@ export function emitVocabularyData(surface: WidgetVocabulary): string {
   const all = [...surface.widgets, ...surface.childHolders].sort((a, b) =>
     a.gtype < b.gtype ? -1 : 1,
   );
-
-  const ownSignals = all
-    .filter((widget) => widget.signals.length > 0)
-    .map((widget) => `    ${widget.gtype}: ${list(widget.signals)},`);
 
   const decls = all.map((widget) => `    ${widget.gtype}: ${list(widget.chain)},`);
 

--- a/packages/generator-typescript/src/vocabulary/emit-types.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-types.ts
@@ -282,7 +282,12 @@ export const PROVENANCE: {
 /** Declaration GType -> its own settable properties, as GObject registered them. */
 export const OWN_PROPS: Readonly<Record<string, readonly string[]>>;
 
-/** Widget GType -> its own signals. */
+/**
+ * Declaration GType -> the signals it registers itself, never its parents'.
+ *
+ * Keyed like \`OWN_PROPS\`, so both are read at every link of a \`DECLS\` chain. An
+ * abstract base has no \`Widgets\` row and still owns signals — \`GtkWidget\` owns 13.
+ */
 export const OWN_SIGNALS: Readonly<Record<string, readonly string[]>>;
 
 /** Widget GType -> every declaration its members come from, self first. */

--- a/packages/generator-typescript/src/vocabulary/model.ts
+++ b/packages/generator-typescript/src/vocabulary/model.ts
@@ -115,6 +115,26 @@ export interface VocabularyDecl {
   readonly inlined: boolean;
   readonly bases: readonly string[];
   readonly props: readonly VocabularyProp[];
+  /**
+   * The signals THIS declaration registers, dashed as GObject spells them.
+   *
+   * Keyed per declaration for the same reason {@link VocabularyDecl.props} is: `DECLS`
+   * publishes a chain, and a consumer unions the chain's entries to answer "what can I
+   * connect to on a `GtkButton`". The first version keyed signals by CONCRETE WIDGET
+   * instead, which dropped every signal an abstract base owns without saying so —
+   * measured on Gtk-4.0, where `GtkWidget` registers 13 (`destroy`, `map`, `realize`,
+   * `unrealize`, `show`, `state-flags-changed`, …): all 53 widgets in the namespace were
+   * missing all 13, while `OWN_PROPS` had carried `GtkWidget`'s properties all along.
+   * The two halves of one vocabulary disagreed about which GTypes it describes.
+   *
+   * INTERFACE signals are absent here because they are absent from the MODEL: only
+   * `IntrospectedClass.fromXML` reads `<glib:signal>`, so `Gtk.Editable::changed`,
+   * `Gtk.CellEditable::editing-done` and `Gtk.ColorChooser::color-activated` — 7 signals
+   * over 3 interfaces in Gtk-4.0 — reach neither this vocabulary nor the main `.d.ts`,
+   * which emits no `SignalSignatures` for an interface at all. A separate defect one
+   * level down, named here rather than left to be rediscovered from this file.
+   */
+  readonly signals: readonly string[];
   readonly doc?: string;
 }
 
@@ -127,8 +147,6 @@ export interface VocabularyWidget {
   readonly slotCandidates: ReadonlyMap<string, string>;
   /** Every declaration this widget draws members from, self first, by GType. */
   readonly chain: readonly string[];
-  /** Own signals, for the runtime data module. */
-  readonly signals: readonly string[];
 }
 
 export interface VocabularyEnum {
@@ -500,6 +518,19 @@ function ownProps(
 }
 
 /**
+ * The signals one declaration registers itself — never its parents'.
+ *
+ * Deliberately NOT `getAllSignals()`: `DECLS` already publishes the chain, so folding a
+ * base's signals into every descendant would say the same fact 53 times in Gtk-4.0 and
+ * lose which GType actually owns `destroy`.
+ *
+ * Returns nothing for an interface, which carries no signals in this model — see
+ * {@link VocabularyDecl.signals} for what that costs and why it is not decided here.
+ */
+const ownSignals = (cls: IntrospectedBaseClass): string[] =>
+  cls instanceof IntrospectedClass ? cls.signals.map((signal) => signal.name).sort() : [];
+
+/**
  * A method taking exactly one widget argument names a CANDIDATE slot.
  *
  * `pack_start` -> start, `set_title_widget` -> title, `add_top_bar` -> top. It is a
@@ -734,6 +765,7 @@ export function buildWidgetVocabulary(
       // owner's import to make, and adding it here would leave `noUnusedLocals` staring at
       // an import nothing in this file reads.
       props: ownProps(module, config, cls, emitted ? collect : () => {}),
+      signals: ownSignals(cls),
       doc: emitted ? blurb(cls.doc) : undefined,
     });
   }
@@ -766,7 +798,6 @@ export function buildWidgetVocabulary(
         chain: (chains.get(keyOf(widget)) ?? [])
           .filter((decl) => withBases.has(keyOf(decl)))
           .map((decl) => decl.glibTypeName!),
-        signals: [...widget.signals].map((signal) => signal.name).sort(),
       }))
       .sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
 
@@ -821,12 +852,16 @@ export function buildWidgetVocabulary(
     for (const prop of decl.props)
       if (prop.since) since.set(`${decl.gtype}.${prop.girName}`, prop.since);
   }
-  for (const widget of [...widgetClasses, ...holderClasses]) {
-    const gtype = widget.glibTypeName;
-    if (!gtype) continue;
-    for (const signal of widget.signals) {
+  // Over the DECLARATIONS, exactly the set `OWN_SIGNALS` is keyed by. Walking the concrete
+  // widgets instead leaves a signal a consumer can read out of `OWN_SIGNALS` with nothing
+  // to explain its absence from an older library — the same hole, one table over.
+  for (const [key, decl] of withBases) {
+    if (!decl.emitted) continue;
+    const cls = needed.get(key);
+    if (!(cls instanceof IntrospectedClass)) continue;
+    for (const signal of cls.signals) {
       const introduced = signal.metadata?.introducedVersion;
-      if (introduced) since.set(`${gtype}::${signal.name}`, introduced);
+      if (introduced) since.set(`${decl.gtype}::${signal.name}`, introduced);
     }
   }
 

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -257,9 +257,55 @@ if (!data.OWN_PROPS?.GtkBox?.includes("user-data")) {
   // consumer check that asks the installed library whether every name here exists.
   fail(`OWN_PROPS.GtkBox lost the gpointer property: ${JSON.stringify(data.OWN_PROPS?.GtkBox)}`);
 }
+
+// ------------------------------------------------------- signals are keyed by DECLARATION
+//
+// `OWN_SIGNALS` and `OWN_PROPS` describe the same set of GTypes, because `DECLS` hands a
+// consumer a CHAIN and it reads both tables at every link. Keying signals by creatable
+// widget instead is a hole with no symptom in this file's older shape: measured on
+// Gtk-4.0, `GtkWidget` registers 13 signals (`destroy`, `map`, `realize`, `unrealize`,
+// `show`, `state-flags-changed`, …), has no `Widgets` row because it is abstract, and so
+// contributed nothing — all 53 widgets in the namespace were missing all 13, while
+// `OWN_PROPS.GtkWidget` was there the whole time.
+const baseSignals = data.OWN_SIGNALS?.GtkWidget;
+if (baseSignals?.join(",") !== "destroy,state-flags-changed") {
+  fail(`OWN_SIGNALS lost the abstract base's own signals: ${JSON.stringify(baseSignals)}`);
+}
+// The control that has to go the OTHER way, and the reason the row above is not simply
+// "every signal reachable from GtkBox": `OWN_SIGNALS` is OWN. Folding the chain in would
+// repeat `destroy` under all 53 Gtk-4.0 widgets and lose which GType registers it.
 if (data.OWN_SIGNALS?.GtkBox?.join(",") !== "child-added") {
   fail(`OWN_SIGNALS.GtkBox is ${JSON.stringify(data.OWN_SIGNALS?.GtkBox)}`);
 }
+// `SINCE` is keyed over the same set for the same reason: a signal a consumer can read
+// out of `OWN_SIGNALS` with no version to explain its absence from an older library is
+// the correct-surface-reported-as-a-defect case again, one table over.
+if (data.SINCE?.["GtkWidget::state-flags-changed"] !== "1.3") {
+  fail(
+    `SINCE has no version for the abstract base's signal: ${JSON.stringify(
+      Object.keys(data.SINCE ?? {}).filter((k) => k.startsWith("GtkWidget")),
+    )}`,
+  );
+}
+// Every GType `OWN_SIGNALS` names must be one this vocabulary actually describes — the
+// same containment `OWN_PROPS` is held to above, so a key can never appear that a
+// consumer walking `DECLS` has no interface for.
+for (const gtype of Object.keys(data.OWN_SIGNALS ?? {})) {
+  if (!new RegExp(`export interface ${gtype}Props\\b`).test(types)) {
+    fail(`OWN_SIGNALS names ${gtype} but the .d.ts has no ${gtype}Props`);
+  }
+}
+// A REGRESSION GUARD, not evidence: nothing in the generator can produce this today.
+// It is written down because a reader of the consumer's output mistook `onNotifySuffix`
+// for a detail-qualified signal leaking in here. It is not one — `notify::<prop>` is the
+// consumer's own rendering of a PROPERTY (`AdwSidebar:suffix`, `GtkSwitch:state`), and no
+// signal name in any of the 719 GIRs in `girs/` contains `::`.
+for (const [gtype, signals] of Object.entries(data.OWN_SIGNALS ?? {})) {
+  for (const signal of signals) {
+    if (signal.includes("::")) fail(`OWN_SIGNALS[${gtype}] carries a detail-qualified ${signal}`);
+  }
+}
+
 if (data.SLOT_CANDIDATES?.GtkBox?.child !== "set_child") {
   fail(`SLOT_CANDIDATES.GtkBox is ${JSON.stringify(data.SLOT_CANDIDATES?.GtkBox)}`);
 }

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -77,7 +77,14 @@
         <doc-deprecated xml:space="preserve">Use the style class instead.</doc-deprecated>
         <type name="gboolean" c:type="gboolean"/>
       </property>
+      <!-- Signals on the ABSTRACT base, which has no `Widgets` row and every widget in
+           the namespace inherits from. `OWN_SIGNALS` is keyed by DECLARATION, so these
+           must be findable under `GtkWidget` — the version keyed by concrete widget
+           dropped all 13 of the real `GtkWidget`'s, for all 53 Gtk-4.0 widgets at once,
+           while `OWN_PROPS` carried this same declaration's properties throughout. -->
       <glib:signal name="destroy" when="cleanup"/>
+      <!-- …and one WITH a since-version, so `SINCE` is keyed over the same set. -->
+      <glib:signal name="state-flags-changed" when="first" version="1.3"/>
     </class>
 
     <class name="Box" c:symbol-prefix="box" c:type="GtkBox" glib:type-name="GtkBox" glib:get-type="gtk_box_get_type" parent="Widget">
@@ -95,8 +102,10 @@
       <property name="user-data" writable="1" transfer-ownership="none">
         <type name="gpointer" c:type="gpointer"/>
       </property>
-      <!-- A signal WITH a since-version, on a CONCRETE class: `OWN_SIGNALS` carries a
-           widget's own signals, so a version on the abstract base would reach nothing. -->
+      <!-- A signal WITH a since-version on a CONCRETE class. Together with the abstract
+           base's two above it holds the OTHER half of the rule: `OWN_SIGNALS` is OWN,
+           never inherited, so this row stays exactly `child-added` — folding the chain in
+           would say `destroy` once per descendant and lose which GType registers it. -->
       <glib:signal name="child-added" when="last" version="1.6">
         <parameters>
           <parameter name="child" transfer-ownership="none">


### PR DESCRIPTION
## The defect

`OWN_SIGNALS` in `@girs/<ns>/vocabulary` was keyed by **creatable widget**, while its
sibling `OWN_PROPS` is keyed by **declaration**. `DECLS` publishes a chain of GTypes and a
consumer reads both tables at every link of it, so the two halves of one vocabulary
disagreed about which GTypes it describes — and every signal an abstract base registers
was unreachable, with no symptom anywhere.

Measured at the source, generating from `girs/Gtk-4.0.gir`:

```
before -> after
OWN_SIGNALS keys      53 -> 54
OWN_SIGNALS entries  193 -> 206
keys lost              0
pre-existing rows changed 0

GtkWidget: destroy direction-changed hide keynav-failed map mnemonic-activate
           move-focus query-tooltip realize show state-flags-changed unmap unrealize
```

`GtkWidget` is abstract, so it has no `Widgets` row — and it registers 13 signals. All 53
widgets in the namespace were missing all 13, while `OWN_PROPS.GtkWidget` had been there
the whole time. Gtk-3.0 recovers 85 signals over four bases (`GtkWidget`, `GtkContainer`,
`GtkMenuShell`, `GtkRange`); Adw-1 has no abstract base that registers one and is
unchanged.

## What changed

- `VocabularyDecl` carries `signals`; `VocabularyWidget` no longer does. `OWN_SIGNALS` is
  emitted from the declarations, the same filter `OWN_PROPS` uses (`decl.emitted`).
- `SINCE` moves to the same set for the same reason: a signal a consumer can read out of
  `OWN_SIGNALS` with no version to explain its absence from an older library is the
  correct-surface-reported-as-a-defect case, one table over.
- Signals stay **own**, never inherited. The chain is already in `DECLS`; folding it in
  would repeat `destroy` under all 53 Gtk-4.0 widgets and lose which GType registers it.

## Known gap, named rather than left to be rediscovered

Interface signals are still absent, because they are absent from the **model**: only
`IntrospectedClass.fromXML` reads `<glib:signal>`, so `Gtk.Editable::changed`,
`Gtk.CellEditable::editing-done` and `Gtk.ColorChooser::color-activated` — 7 signals over
3 interfaces in Gtk-4.0 — reach neither this vocabulary nor the main `.d.ts`, which emits
no `SignalSignatures` for an interface at all. That is a separate defect one level down
and out of scope here; it is written down in `VocabularyDecl.signals`.

## Not a defect: `notify::<detail>` in `OWN_SIGNALS`

A second suspicion was that detail-qualified GObject names (`onNotifySuffix`,
`onNotifyState`, `onNotifyResource`, `onNotifyPrefix` in a consumer's rendering) were
leaking into `OWN_SIGNALS`. They are not, measured three ways:

- No `glib:signal` name in **any** of the 719 GIRs in `girs/` contains `::`
  (`grep -rno 'glib:signal name="[^"]*::[^"]*"' girs/` matches nothing).
- Freshly generated Gtk-4.0 and Adw-1 vocabularies contain 0 signal names matching
  `/notify/i` and 0 containing `::`.
- Every one of those four names is a **property**: `GtkSwitch:state`,
  `GtkSvgWidget:state`, `GtkImage:resource`, `GtkSvgWidget:resource`, `AdwSidebar:prefix`,
  `AdwSidebar:suffix`, `AdwViewSwitcherSidebar:prefix`, `AdwViewSwitcherSidebar:suffix`.
  `notify::<prop>` is the consumer's own rendering of a property, from `OWN_PROPS`.

A cheap regression guard for it is in the gate, labelled as a guard rather than as
evidence — nothing in the generator can produce a `::` today.

## Gate and A/B

`tests/widget-vocabulary`. The fixture's abstract `Mini.Widget` gains a second signal
carrying a since-version, so `OWN_SIGNALS` and `SINCE` are both exercised on a declaration
with no `Widgets` row. Each new assertion was proven to go red by reverting the half of
the fix it covers:

| reverted | result |
|---|---|
| `OWN_SIGNALS` keyed by widget rows again | `OWN_SIGNALS lost the abstract base's own signals: undefined` — exit 1 |
| `SINCE` signal keys walk creatable widgets again | `SINCE has no version for the abstract base's signal: []` — exit 1 |

`GtkBox` must stay exactly `['child-added']` throughout — the control that has to go the
other way if the chain is ever folded in.

Local: `gjsify run check:lint`, `check:app`, `check:girs`, `check:pm`, `check:prereqs`,
`check:docs` and `gjsify run test:tests` all exit 0.
