### PR TITLE
feat: key SINCE by the type, not only its members

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -563,7 +563,12 @@ these names instead.
 Beside the `.d.ts`, the same subpath exports the facts as runtime **data** (`OWN_PROPS`,
 `OWN_SIGNALS`, `DECLS`, `ENUM_NICKS`, `SLOT_CANDIDATES`, `SINCE`), because types are erased and
 the check worth having is a consumer asking the *installed* library whether every name is real.
-`SINCE` is what lets that check tell a version gap from a defect without an allowlist.
+`SINCE` is what lets that check tell a version gap from a defect without an allowlist. It is
+keyed in GObject's own three spellings — `GtkSvgWidget`, `GtkBox.spacing`, `GtkBox::clicked` —
+so a consumer can forgive a missing TYPE as well as a missing member; without the bare key a
+class added after the installed library fails as `TypeError: can't access property "$gtype",
+ctor() is undefined`, which does not name the GType. Only where the GIR states a version: the
+attribute sits on 29 of the 301 classes and interfaces in Gtk-4.0, and none is ever inferred.
 
 ### package
 

--- a/packages/generator-typescript/src/vocabulary/emit-types.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-types.ts
@@ -303,15 +303,21 @@ export const ENUM_NICKS: Readonly<Record<string, readonly string[]>>;
 export const SLOT_CANDIDATES: Readonly<Record<string, Readonly<Record<string, string>>>>;
 
 /**
- * \`Type.property\` and \`Type::signal\` -> the release that introduced it.
+ * \`Type\`, \`Type.property\` and \`Type::signal\` -> the release that introduced it.
  *
  * What keeps a runtime cross-check honest across a version gap without an
- * allowlist: a member the installed library lacks is a defect UNLESS the version
+ * allowlist: a name the installed library lacks is a defect UNLESS the version
  * here is newer than the one running.
  *
- * BOTH key shapes, because that test only works for the members it covers. A
+ * ALL THREE key shapes, because that test only works for the names it covers. A
  * property-only map leaves a consumer no way to explain a missing SIGNAL, which is
- * a correct surface reported as 18 defects.
+ * a correct vocabulary reported as 18 defects; a member-only map leaves it no way to
+ * explain a missing CLASS, and that one fails as a bare
+ * \`TypeError: can't access property "$gtype", ctor() is undefined\` that does not
+ * even name the GType.
+ *
+ * A key is present only where the GIR states a version — sparse by nature (\`version\`
+ * sits on 29 of the 301 classes and interfaces in Gtk-4.0), never inferred.
  */
 export const SINCE: Readonly<Record<string, string>>;
 `;

--- a/packages/generator-typescript/src/vocabulary/model.ts
+++ b/packages/generator-typescript/src/vocabulary/model.ts
@@ -135,6 +135,15 @@ export interface VocabularyDecl {
    * level down, named here rather than left to be rediscovered from this file.
    */
   readonly signals: readonly string[];
+  /**
+   * The release that introduced the TYPE itself — GIR's `version` on `<class>`/`<interface>`.
+   *
+   * Absent where the GIR states none, and never inferred: a wrong version here is worse
+   * than no version, because the whole point of the value is to let a consumer forgive
+   * an absence, and a forgiven absence that is actually a defect is a defect that stops
+   * being reported.
+   */
+  readonly since?: string;
   readonly doc?: string;
 }
 
@@ -200,7 +209,7 @@ export interface WidgetVocabulary {
   readonly surfaceImports: ReadonlyMap<string, readonly string[]>;
   /** Base -> members it must not contribute, because a nearer declaration disagrees. */
   readonly omissions: ReadonlyMap<string, ReadonlyMap<string, readonly string[]>>;
-  /** Declaration GType -> its own properties' since versions, for the skew rule. */
+  /** GType, `GType.property` and `GType::signal` -> since versions, for the skew rule. */
   readonly since: ReadonlyMap<string, string>;
 }
 
@@ -766,6 +775,7 @@ export function buildWidgetVocabulary(
       // an import nothing in this file reads.
       props: ownProps(module, config, cls, emitted ? collect : () => {}),
       signals: ownSignals(cls),
+      since: cls.metadata?.introducedVersion,
       doc: emitted ? blurb(cls.doc) : undefined,
     });
   }
@@ -834,21 +844,37 @@ export function buildWidgetVocabulary(
     }
   }
 
-  // Two key shapes, and the second one is not decoration.
+  // Three key shapes, and none of them is decoration.
   //
-  // `SINCE` exists so a consumer can tell "this surface describes a NEWER library than the
-  // one installed" from "this surface is wrong". That test only works for the members it
-  // covers. Measured against gtk4-4.22.4 / libadwaita-1.9.3 while the surface described
+  // `SINCE` exists so a consumer can tell "this vocabulary describes a NEWER library than
+  // the one installed" from "this vocabulary is wrong". That test only works for the names
+  // it covers, and each shape was added because a real cross-check went red without it.
+  //
+  // MEMBERS. Measured against gtk4-4.22.4 / libadwaita-1.9.3 while the vocabulary described
   // 4.23.3 / 1.10.0: every missing PROPERTY was explained by a since-version — 14 of them,
   // 0 unexplained — and 18 missing SIGNALS were not, because a property-only `SINCE` has
   // nothing to say about `GtkWindow::force-close`. A consumer checking signals against the
-  // installed typelib therefore went red on 18 widgets for a surface that was correct.
+  // installed typelib therefore went red on 18 widgets for a vocabulary that was correct.
   //
-  // `Type.property` and `Type::signal` are GObject's own two spellings, so they cannot
-  // collide, and a reader already knows which is which.
+  // THE TYPE ITSELF, keyed bare. A member-only map explains an absent member and says
+  // nothing about an absent CLASS, and the class is the worse failure of the two: a
+  // consumer resolving `GtkSvgWidget` (GIR `version="4.24"`) against an older GTK does not
+  // get a name it can attribute the miss to, it gets `TypeError: can't access property
+  // "$gtype", ctor() is undefined` — the GType it asked for is not in the message, so the
+  // one fact needed to forgive the absence is the one fact the failure withholds.
+  //
+  // The attribute is real but SPARSE, which is why the entry is conditional rather than
+  // required: `version` sits on 23 of 272 `<class>` and 6 of 29 `<interface>` in
+  // Gtk-4.0.gir, and on 1777 of 16156 across the 715 GIRs in `girs/`. Where GIR states no
+  // version none is written — inventing one would let a consumer forgive an absence that
+  // is a genuine defect, which is the failure this table exists to prevent.
+  //
+  // `GtkBox`, `GtkBox.spacing` and `GtkBox::clicked` are GObject's own three spellings, so
+  // they cannot collide, and a reader already knows which is which.
   const since = new Map<string, string>();
   for (const decl of withBases.values()) {
     if (!decl.emitted) continue;
+    if (decl.since) since.set(decl.gtype, decl.since);
     for (const prop of decl.props)
       if (prop.since) since.set(`${decl.gtype}.${prop.girName}`, prop.since);
   }

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -248,9 +248,44 @@ if (data.SINCE?.["GtkBox::child-added"] !== "1.6") {
     )}`,
   );
 }
-// And the two spellings must not collide: a property key never contains `::`.
+// The TYPE half. A member-only `SINCE` explains a missing property or signal and says
+// nothing about a missing CLASS — and that is the worse failure: `GtkSvgWidget` against a
+// pre-4.24 GTK is a bare `TypeError: can't access property "$gtype", ctor() is undefined`,
+// which names neither the GType asked for nor a version to forgive it with. Measured on
+// the published vocabulary before this: 0 keys of this shape.
+for (const [gtype, expected] of [
+  // A class, an interface, and a child holder — the holders ride the same pipeline, and a
+  // holder whose type has no key is a holder a consumer cannot forgive either.
+  ["GtkBox", "1.4"],
+  ["GtkOrientable", "1.1"],
+  ["GtkListItem", "1.8"],
+]) {
+  if (data.SINCE?.[gtype] !== expected) {
+    fail(
+      `SINCE has no version for the type ${gtype} (expected ${expected}): ${JSON.stringify(
+        Object.keys(data.SINCE ?? {}).filter((k) => !k.includes(".") && !k.includes("::")),
+      )}`,
+    );
+  }
+}
+// The CONTROL that keeps the entry honest, and the reason it is conditional: `GtkWidget`
+// is emitted and carries five properties, and its GIR states NO version. An invented one
+// would let a consumer forgive an absence that is a genuine defect — the exact failure
+// this table exists to prevent. Sparse is correct: `version` sits on 29 of the 301 classes
+// and interfaces in Gtk-4.0.gir.
+if ("GtkWidget" in (data.SINCE ?? {})) {
+  fail(`SINCE invented a version for a type whose GIR states none: ${data.SINCE.GtkWidget}`);
+}
+// And the three spellings must not collide, nor may the bare one over-generate: a property
+// key always contains `.`, a signal key `::`, and a type key neither.
 for (const key of Object.keys(data.SINCE ?? {})) {
   if (key.includes("::") && key.includes(".")) fail(`SINCE key is neither spelling: ${key}`);
+}
+const typeKeys = Object.keys(data.SINCE ?? {})
+  .filter((key) => !key.includes(".") && !key.includes("::"))
+  .sort();
+if (typeKeys.join(",") !== "GtkBox,GtkListItem,GtkOrientable") {
+  fail(`SINCE keys a type the fixture gives no version: ${JSON.stringify(typeKeys)}`);
 }
 if (!data.OWN_PROPS?.GtkBox?.includes("user-data")) {
   // Dropping it from the runtime data would hide a real writable ParamSpec from the

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -40,8 +40,13 @@
 
     <!-- The interface that carries `orientation`. GObject installs interface properties on
          the implementor at runtime while GIR keeps them once, here — a class-only walk
-         emits a Box without its most-written property. -->
-    <interface name="Orientable" c:symbol-prefix="orientable" c:type="GtkOrientable" glib:type-name="GtkOrientable" glib:get-type="gtk_orientable_get_type">
+         emits a Box without its most-written property.
+
+         Also VERSIONED at the interface level, one release before the property it carries:
+         `SINCE` must key `GtkOrientable` and `GtkOrientable.orientation` separately, or a
+         consumer resolving the interface itself against an older library has nothing to
+         forgive the absence with. -->
+    <interface name="Orientable" c:symbol-prefix="orientable" c:type="GtkOrientable" glib:type-name="GtkOrientable" glib:get-type="gtk_orientable_get_type" version="1.1">
       <property name="orientation" writable="1" transfer-ownership="none" version="1.2">
         <doc xml:space="preserve">The orientation of the orientable.</doc>
         <type name="Orientation" c:type="GtkOrientation"/>
@@ -87,7 +92,14 @@
       <glib:signal name="state-flags-changed" when="first" version="1.3"/>
     </class>
 
-    <class name="Box" c:symbol-prefix="box" c:type="GtkBox" glib:type-name="GtkBox" glib:get-type="gtk_box_get_type" parent="Widget">
+    <!-- VERSIONED as a TYPE, on the class that already carries a versioned SIGNAL: the
+         two must stand as SEPARATE `SINCE` keys, `GtkBox` (1.4) and `GtkBox::child-added`
+         (1.6). Together with `GtkOrientable` below, which pairs a type key with a property
+         key, the fixture exercises all three spellings and their independence.
+         The real case is `GtkSvgWidget`, `version="4.24"` — resolving it against an older
+         GTK raises `TypeError: can't access property "$gtype", ctor() is undefined`, which
+         names neither the GType nor a version. -->
+    <class name="Box" c:symbol-prefix="box" c:type="GtkBox" glib:type-name="GtkBox" glib:get-type="gtk_box_get_type" parent="Widget" version="1.4">
       <implements name="Orientable"/>
       <property name="spacing" default-value="6" writable="1" transfer-ownership="none">
         <type name="gint" c:type="gint"/>
@@ -151,7 +163,7 @@
          `GtkListItem`, `GtkListHeader`, `GtkColumnViewCell` and `AdwToggle` are this
          shape in the real corpus — they descend from GObject.Object, and a renderer
          places them exactly like a container. -->
-    <class name="ListItem" c:symbol-prefix="list_item" c:type="GtkListItem" glib:type-name="GtkListItem" glib:get-type="gtk_list_item_get_type" parent="GObject.Object">
+    <class name="ListItem" c:symbol-prefix="list_item" c:type="GtkListItem" glib:type-name="GtkListItem" glib:get-type="gtk_list_item_get_type" parent="GObject.Object" version="1.8">
       <property name="activatable" writable="1" transfer-ownership="none">
         <type name="gboolean" c:type="gboolean"/>
       </property>


### PR DESCRIPTION
## The gap

The generated vocabulary's `SINCE` table carried `GtkBox.spacing` and `GtkBox::clicked` and **no key for `GtkBox` itself**. Measured on the published package:

```
$ node -e 'const g=require("@girs/gtk-4.0/gtk-4.0-vocabulary.js");
           console.log(Object.keys(g.SINCE).filter(k=>!k.includes(".")&&!k.includes("::")).length)'
0
```

A consumer generates types against this vocabulary (built from GTK 4.23.3) and checks them back against the **installed** GTK, which may be older. For a property or a signal it can read `SINCE` and conclude "not in the running version yet, not a defect". For a whole class it cannot — it runs into a bare

```
TypeError: can't access property "$gtype", ctor() is undefined
```

which names neither the GType it asked for nor a version to forgive it with. The concrete case is `GtkSvgWidget`, added in GTK 4.24.

## Measured first, built second

GIR already carries the answer: `version` on `<class>` / `<interface>` has the same meaning as `@since`, and `parseMetadata` has been reading it into `IntrospectedBaseClass.metadata` all along — nothing new is derived here.

How well is it filled? Counted over the real GIR corpus in `girs/` before writing any code:

| scope | classes + interfaces | carry `version` |
|---|---|---|
| `Gtk-4.0.gir` classes | 272 | 23 |
| `Gtk-4.0.gir` interfaces | 29 | 6 |
| all 715 GIRs | 16156 | 1777 (11.0%) |

`GtkSvgWidget` carries `version="4.24"`. Sparse but real, so the entry is **conditional**: where GIR states no version, none is written. An invented version would let a consumer forgive an absence that is a genuine defect — the exact failure this table exists to prevent.

## The change

`VocabularyDecl` gains a `since`, read from the declaration's own metadata, and the `SINCE` builder keys it bare alongside the two member spellings. `GtkBox`, `GtkBox.spacing` and `GtkBox::clicked` are GObject's own three spellings and cannot collide.

Effect on the real corpus: `@girs/gtk-4.0` gains 12 type keys (including `GtkSvgWidget: '4.24'`), `@girs/adw-1` gains 32.

## Gate, proven in both directions

`tests/widget-vocabulary`. The fixture gains a version on a class (`GtkBox` 1.4), an interface (`GtkOrientable` 1.1) and a child holder (`GtkListItem` 1.8) — `GtkBox` then carries all three key shapes at once — and `GtkWidget` deliberately keeps none.

Reverting the one-line fix, the suite exits **1**:

```
  - SINCE has no version for the type GtkBox (expected 1.4): []
  - SINCE has no version for the type GtkOrientable (expected 1.1): []
  - SINCE has no version for the type GtkListItem (expected 1.8): []
  - SINCE keys a type the fixture gives no version: []
```

And the control is not dead weight either — making the entry unconditional (`decl.since ?? "0.0"`) also exits **1**:

```
  - SINCE invented a version for a type whose GIR states none: 0.0
  - SINCE keys a type the fixture gives no version: ["GtkBox","GtkListItem","GtkOrientable","GtkWidget"]
```

With the fix in place: exit **0**.

## Checks

`gjsify run check:app` 0 · `gjsify run check:lint` 0 · `gjsify run test:tests` 0 · `gjsify format` clean. Exit codes read directly, not through a pipe.