### PR TITLE
fix: read glib:signal on an interface too

### DIFF
--- a/examples/gtk-4-signal-interfaces/main.ts
+++ b/examples/gtk-4-signal-interfaces/main.ts
@@ -27,7 +27,18 @@ const app = new Gtk.Application({
   flags: Gio.ApplicationFlags.FLAGS_NONE,
 });
 
+// ✅ DETAILED interface signal: Gio.ActionGroup registers all four of its signals as
+// detailed, and Gtk.Application implements the interface. The `::detail` catch-all
+// lives on the interface's own SignalSignatures, so `action-added::quit` is typed —
+// previously it only matched the untyped `(...args: any[])` overload.
+app.connect("action-added::quit", (_src, actionName) => {
+  console.log(`Action added: ${actionName}`);
+});
+
 app.connect("activate", () => {
+  // Register the action the detailed handler above is filtered on, so it fires.
+  app.add_action(Gio.SimpleAction.new("quit", null));
+
   // Create main window
   const window = new Gtk.ApplicationWindow({
     application: app,
@@ -192,6 +203,22 @@ app.connect("activate", () => {
   entry.connect("notify::text", (_obj, _pspec) => {
     const text = entry.get_text();
     statusLabel.set_text(`Entry text changed via detail signal: "${text}"`);
+  });
+
+  // ✅ INTERFACE signals: `changed` and `delete-text` are registered by the Gtk.Editable
+  // INTERFACE, not by Gtk.Entry — GIR writes `<glib:signal>` under `<interface>` exactly
+  // as it does under `<class>`. Until the generator read those, Gtk.Editable had no
+  // `SignalSignatures` at all and these connects fell through to the untyped
+  // `(...args: any[])` overload. The `keyof` line is the compile-time proof: it fails
+  // to build against types generated without interface signals.
+  const changedKey: keyof Gtk.Editable.SignalSignatures = "changed";
+  entry.connect(changedKey, (src) => {
+    console.log(`Editable changed, text is now: "${src.get_text()}"`);
+  });
+
+  // ✅ Parameter names and types come from the interface's GIR declaration
+  entry.connect("delete-text", (_src, startPos, endPos) => {
+    console.log(`Editable delete-text: ${startPos}..${endPos}`);
   });
 
   // Demonstrate property change notifications on the toggle button

--- a/packages/generator-typescript/src/generators/signal-generator.ts
+++ b/packages/generator-typescript/src/generators/signal-generator.ts
@@ -69,13 +69,33 @@ export class SignalGenerator {
 
     def.push(`${indent}// Signal signatures`);
 
-    // AN INTERFACE INHERITS NOTHING HERE, on purpose. Its members are unioned into the
-    // implementing class's `SignalSignatures extends …, Gtk.Editable.SignalSignatures`,
-    // and that class already reaches `GObject.Object.SignalSignatures` through its own
-    // parent chain. Extending it a second time from the interface side would carry the
-    // `notify::` keys down two branches into one declaration.
+    // AN INTERFACE NEVER REACHES `GObject.Object.SignalSignatures` FROM HERE, on purpose.
+    // Its members are unioned into the implementing class's
+    // `SignalSignatures extends …, Gtk.Editable.SignalSignatures`, and that class already
+    // reaches `GObject.Object.SignalSignatures` through its own parent chain — extending it
+    // a second time from the interface side would carry the `notify::` keys down two
+    // branches into one declaration.
+    //
+    // A PREREQUISITE INTERFACE with signals is the one thing it does extend: those signals
+    // reach an implementor only through this interface when the GIR omits the prerequisite
+    // from the class's `<implements>` (`ClutterGst.Camera` lists only `Player`; `eos` and
+    // `error` live on `Player`'s prerequisite `Clutter.Media`). Interface blocks only ever
+    // extend other interface blocks, so the `notify::` invariant holds by construction.
     if (girClass instanceof IntrospectedInterface) {
-      return [...def, ...this.signalSignatureBody(girClass, `interface SignalSignatures`, indentCount)];
+      const prerequisite = girClass.resolveParents().extends();
+      const prerequisiteSource =
+        prerequisite && prerequisite.node instanceof IntrospectedInterface
+          ? prerequisite.node.findSignalSource()
+          : null;
+      const prerequisiteRef = prerequisiteSource
+        ?.getType()
+        .resolveIdentifier(this.namespace, this.config)
+        ?.print(this.namespace, this.config);
+
+      const signatureDecl = prerequisiteRef
+        ? `interface SignalSignatures extends ${prerequisiteRef}.SignalSignatures`
+        : `interface SignalSignatures`;
+      return [...def, ...this.signalSignatureBody(girClass, signatureDecl, indentCount)];
     }
 
     const parentSignatures: string[] = [];
@@ -104,11 +124,14 @@ export class SignalGenerator {
       .resolveParents()
       .implements()
       .filter((iface) => iface.node instanceof IntrospectedInterface)
-      // `signals` is a real field on `IntrospectedInterface` now, so this reads it
+      // `signals` is a real field on `IntrospectedInterface` now, so this reads the model
       // instead of casting a guess at one. Until it was, the predicate was false for
       // every interface in every namespace and this whole branch was dead: 7 signals
       // over 4 Gtk-4.0 interfaces, 41 handler slots across 17 concrete widgets.
-      .filter((iface) => (iface.node as IntrospectedInterface).signals.length > 0)
+      // `findSignalSource()` rather than `signals.length`: the SAME predicate gates the
+      // block's emission, so this filter can never reference a name that does not exist —
+      // and an interface whose signals all sit on a prerequisite interface still counts.
+      .filter((iface) => (iface.node as IntrospectedInterface).findSignalSource() !== null)
       .map((iface) => {
         const interfaceTypeIdentifier = iface.identifier
           .resolveIdentifier(this.namespace, this.config)

--- a/packages/generator-typescript/src/generators/signal-generator.ts
+++ b/packages/generator-typescript/src/generators/signal-generator.ts
@@ -76,11 +76,15 @@ export class SignalGenerator {
     // a second time from the interface side would carry the `notify::` keys down two
     // branches into one declaration.
     //
-    // A PREREQUISITE INTERFACE with signals is the one thing it does extend: those signals
-    // reach an implementor only through this interface when the GIR omits the prerequisite
-    // from the class's `<implements>` (`ClutterGst.Camera` lists only `Player`; `eos` and
-    // `error` live on `Player`'s prerequisite `Clutter.Media`). Interface blocks only ever
-    // extend other interface blocks, so the `notify::` invariant holds by construction.
+    // A PREREQUISITE INTERFACE with signals is the one thing it does extend, because the
+    // block is the interface's OWN signature map and a prerequisite's signals are part of
+    // it: `ClutterGst.Player` (1.0/2.0) said `download-buffering` but not the `eos`/`error`
+    // its prerequisite `Clutter.Media` registers; Gtk-4.0's `SectionModel`/`SelectionModel`
+    // said nothing of `Gio.ListModel::items-changed`. It also guards the `<implements>`
+    // omission GIR does not forbid — measured per file over 718 GIRs, no class omits a
+    // signal-bearing prerequisite today, so that half is prophylactic. Interface blocks
+    // only ever extend other interface blocks, so the `notify::` invariant holds by
+    // construction.
     if (girClass instanceof IntrospectedInterface) {
       const prerequisite = girClass.resolveParents().extends();
       const prerequisiteSource =

--- a/packages/generator-typescript/src/generators/signal-generator.ts
+++ b/packages/generator-typescript/src/generators/signal-generator.ts
@@ -60,11 +60,23 @@ export class SignalGenerator {
    * enabling TypeScript to provide proper type checking and IntelliSense for
    * GObject signals using the centralized getAllSignals() method from the model.
    */
-  generateClassSignalInterfaces(girClass: IntrospectedClass, indentCount = 0): string[] {
+  generateClassSignalInterfaces(
+    girClass: IntrospectedClass | IntrospectedInterface,
+    indentCount = 0,
+  ): string[] {
     const def: string[] = [];
     const indent = generateIndent(indentCount);
 
     def.push(`${indent}// Signal signatures`);
+
+    // AN INTERFACE INHERITS NOTHING HERE, on purpose. Its members are unioned into the
+    // implementing class's `SignalSignatures extends …, Gtk.Editable.SignalSignatures`,
+    // and that class already reaches `GObject.Object.SignalSignatures` through its own
+    // parent chain. Extending it a second time from the interface side would carry the
+    // `notify::` keys down two branches into one declaration.
+    if (girClass instanceof IntrospectedInterface) {
+      return [...def, ...this.signalSignatureBody(girClass, `interface SignalSignatures`, indentCount)];
+    }
 
     const parentSignatures: string[] = [];
 
@@ -92,10 +104,11 @@ export class SignalGenerator {
       .resolveParents()
       .implements()
       .filter((iface) => iface.node instanceof IntrospectedInterface)
-      .filter((iface) => {
-        const node = iface.node as unknown as { signals?: unknown[] };
-        return node.signals && node.signals.length > 0;
-      })
+      // `signals` is a real field on `IntrospectedInterface` now, so this reads it
+      // instead of casting a guess at one. Until it was, the predicate was false for
+      // every interface in every namespace and this whole branch was dead: 7 signals
+      // over 4 Gtk-4.0 interfaces, 41 handler slots across 17 concrete widgets.
+      .filter((iface) => (iface.node as IntrospectedInterface).signals.length > 0)
       .map((iface) => {
         const interfaceTypeIdentifier = iface.identifier
           .resolveIdentifier(this.namespace, this.config)
@@ -130,6 +143,23 @@ export class SignalGenerator {
       }
     }
 
+    return [...def, ...this.signalSignatureBody(girClass, signatureDecl, indentCount)];
+  }
+
+  /**
+   * The `SignalSignatures { … }` block itself, given its already-decided declaration line.
+   *
+   * Split out so a class and an interface print the same body from the same code — the
+   * only thing that differs between them is what the declaration extends, which the
+   * caller has settled by the time it gets here.
+   */
+  private signalSignatureBody(
+    girClass: IntrospectedClass | IntrospectedInterface,
+    signatureDecl: string,
+    indentCount: number,
+  ): string[] {
+    const def: string[] = [];
+    const indent = generateIndent(indentCount);
     const allSignals = girClass.getAllSignals();
 
     if (allSignals.length === 0) {

--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -1675,15 +1675,16 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
     }
 
     if (girClass instanceof IntrospectedInterface) {
-      // An interface gets one only when it REGISTERS signals. Emitting an empty
+      // An interface gets one only when it CARRIES signals — its own, or a prerequisite
+      // interface's (`findSignalSource`, the same predicate the class-side filter reads,
+      // so neither can name a block the other refused to emit). Emitting an empty
       // `SignalSignatures` for the other ~1500 would put a namespace block on every
       // interface in the run — and, worse, offer implementors a name to extend that
-      // says nothing. `generateClassSignalInterfaces` produces a bare interface here
-      // rather than one extending `GObject.Object.SignalSignatures`: the implementing
-      // CLASS already extends that through its own parent chain, and inheriting the
-      // same `notify::` keys down two branches is a conflict waiting for the first
-      // interface whose prerequisite differs.
-      if (girClass.signals.length > 0) {
+      // says nothing. `generateClassSignalInterfaces` never extends
+      // `GObject.Object.SignalSignatures` here: the implementing CLASS already extends
+      // that through its own parent chain, and inheriting the same `notify::` keys down
+      // two branches is a conflict waiting for the first differing prerequisite.
+      if (girClass.findSignalSource() !== null) {
         bodyDef.push(
           ...this.signalGenerator.generateClassSignalInterfaces(girClass, indentCount + 1),
         );

--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -1675,6 +1675,20 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
     }
 
     if (girClass instanceof IntrospectedInterface) {
+      // An interface gets one only when it REGISTERS signals. Emitting an empty
+      // `SignalSignatures` for the other ~1500 would put a namespace block on every
+      // interface in the run — and, worse, offer implementors a name to extend that
+      // says nothing. `generateClassSignalInterfaces` produces a bare interface here
+      // rather than one extending `GObject.Object.SignalSignatures`: the implementing
+      // CLASS already extends that through its own parent chain, and inheriting the
+      // same `notify::` keys down two branches is a conflict waiting for the first
+      // interface whose prerequisite differs.
+      if (girClass.signals.length > 0) {
+        bodyDef.push(
+          ...this.signalGenerator.generateClassSignalInterfaces(girClass, indentCount + 1),
+        );
+      }
+
       // Virtual interface for implementation
       bodyDef.push(...this.generateVirtualInterface(girClass, indentCount + 1));
     }

--- a/packages/generator-typescript/src/vocabulary/model.ts
+++ b/packages/generator-typescript/src/vocabulary/model.ts
@@ -127,12 +127,13 @@ export interface VocabularyDecl {
    * missing all 13, while `OWN_PROPS` had carried `GtkWidget`'s properties all along.
    * The two halves of one vocabulary disagreed about which GTypes it describes.
    *
-   * INTERFACE signals are absent here because they are absent from the MODEL: only
-   * `IntrospectedClass.fromXML` reads `<glib:signal>`, so `Gtk.Editable::changed`,
-   * `Gtk.CellEditable::editing-done` and `Gtk.ColorChooser::color-activated` — 7 signals
-   * over 3 interfaces in Gtk-4.0 — reach neither this vocabulary nor the main `.d.ts`,
-   * which emits no `SignalSignatures` for an interface at all. A separate defect one
-   * level down, named here rather than left to be rediscovered from this file.
+   * INTERFACE signals are here too, and were not always: until `IntrospectedInterface`
+   * learned to read `<glib:signal>`, `Gtk.Editable::changed`, `Gtk.CellEditable::editing-done`,
+   * `Gtk.ColorChooser::color-activated` and `Gtk.FontChooser::font-activated` — 7 signals over
+   * 4 interfaces in Gtk-4.0 — reached neither this vocabulary nor the main `.d.ts`. Through
+   * `implements` that was 41 handler slots across 17 concrete widget types, `gtk-entry`'s
+   * `changed` among them. The chain in `DECLS` already carried the interfaces, so a consumer
+   * unioning it got the right answer the moment the model had the data.
    */
   readonly signals: readonly string[];
   /**
@@ -531,13 +532,14 @@ function ownProps(
  *
  * Deliberately NOT `getAllSignals()`: `DECLS` already publishes the chain, so folding a
  * base's signals into every descendant would say the same fact 53 times in Gtk-4.0 and
- * lose which GType actually owns `destroy`.
- *
- * Returns nothing for an interface, which carries no signals in this model — see
- * {@link VocabularyDecl.signals} for what that costs and why it is not decided here.
+ * lose which GType actually owns `destroy`. Interfaces answer the same way classes do,
+ * because GObject registers a signal on the interface GType and `DECLS` puts that GType
+ * in the chain.
  */
 const ownSignals = (cls: IntrospectedBaseClass): string[] =>
-  cls instanceof IntrospectedClass ? cls.signals.map((signal) => signal.name).sort() : [];
+  cls instanceof IntrospectedClass || cls instanceof IntrospectedInterface
+    ? cls.signals.map((signal) => signal.name).sort()
+    : [];
 
 /**
  * A method taking exactly one widget argument names a CANDIDATE slot.
@@ -884,7 +886,7 @@ export function buildWidgetVocabulary(
   for (const [key, decl] of withBases) {
     if (!decl.emitted) continue;
     const cls = needed.get(key);
-    if (!(cls instanceof IntrospectedClass)) continue;
+    if (!(cls instanceof IntrospectedClass || cls instanceof IntrospectedInterface)) continue;
     for (const signal of cls.signals) {
       const introduced = signal.metadata?.introducedVersion;
       if (introduced) since.set(`${decl.gtype}::${signal.name}`, introduced);

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -1395,11 +1395,15 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 	 * says "reference it" emits a name that does not exist.
 	 *
 	 * Own signals are not the whole answer: a `<prerequisite>` of interface type
-	 * carries its signals into every implementor, and GIR does not promise the class
-	 * lists the prerequisite in `<implements>` — measured: `ClutterGst.Camera` and
-	 * `ClutterGst.Playback` list only `Player`, whose prerequisite `Clutter.Media`
-	 * registers `eos` and `error`. A class prerequisite is not walked: its signals
-	 * reach the implementing class through its own `extends` chain.
+	 * carries its signals into every conformer, so they belong to this interface's
+	 * signature map — `ClutterGst.Player` (prerequisite `Clutter.Media`: `eos`,
+	 * `error`), `Gtk.SectionModel`/`Gtk.SelectionModel` (prerequisite
+	 * `Gio.ListModel`: `items-changed`), `Gio.RemoteActionGroup` (no own signals at
+	 * all, prerequisite `Gio.ActionGroup`). GIR also does not promise a class lists
+	 * the prerequisite in `<implements>` — measured per file over 718 GIRs no class
+	 * omits one today, so that half is prophylactic. A class prerequisite is not
+	 * walked: its signals reach the implementing class through its own `extends`
+	 * chain.
 	 */
 	findSignalSource(): IntrospectedInterface | null {
 		if (this.signals.length > 0) return this;

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -1320,19 +1320,94 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 	/**
 	 * This interface's own signals, in the shape the emitter consumes.
 	 *
-	 * Deliberately NOT {@link IntrospectedClass.getAllSignals}'s behaviour: no
-	 * `notify::` keys and no detailed variants. Those belong to the implementing
-	 * CLASS, whose `SignalSignatures` already extends `GObject.Object`'s and would
-	 * otherwise inherit the same keys twice, from two branches, for every interface
-	 * it implements.
+	 * No `notify::` keys, deliberately — unlike {@link IntrospectedClass.getAllSignals}.
+	 * Those belong to the implementing CLASS, whose `SignalSignatures` already extends
+	 * `GObject.Object`'s and enumerates every property it can see — this interface's
+	 * included, via `implementedProperties()` — so repeating them here would inherit
+	 * the same keys down two branches into one declaration.
+	 *
+	 * DETAIL variants are here, though, and the same reasoning says they must be: the
+	 * class expands details only for its OWN signals (see
+	 * {@link IntrospectedClass.addDetailedSignals}), so a detailed interface signal not
+	 * expanded here is expanded nowhere. Measured before this existed:
+	 * `Gio.ActionGroup`'s four signals are all detailed, so `action-added` was typed
+	 * while `action-added::quit` on the same application object fell through to the
+	 * untyped `connect(signal: string, …)` overload — 25 detailed interface signals
+	 * across the 718-GIR corpus, every one of them half-covered.
 	 */
 	getAllSignals(): SignalDescriptor[] {
-		return this.signals.map((signal) => ({
+		const allSignals: SignalDescriptor[] = this.signals.map((signal) => ({
 			name: signal.name,
 			signal,
 			isNotifySignal: false,
 			isDetailSignal: false,
 		}));
+
+		// Mirrors IntrospectedClass.addDetailedSignals over the interface's OWN properties —
+		// an interface has no parent chain to walk for more. `parameterTypes`/`returnType`
+		// are not duplicated onto the descriptors: the emitter derives both from `signal`
+		// whenever it is present.
+		const propertyNames = new Set(
+			this.props.map((prop) =>
+				prop.name
+					.replace(/_/g, "-")
+					.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+					.toLowerCase(),
+			),
+		);
+
+		for (const signal of this.signals) {
+			if (!signal.detailed) continue;
+			// `notify` is GObject.Object's; the implementing class already carries its keys.
+			if (signal.name === "notify") continue;
+
+			for (const propertyName of propertyNames) {
+				allSignals.push({
+					name: `${signal.name}::${propertyName}`,
+					signal,
+					isNotifySignal: false,
+					isDetailSignal: true,
+				});
+			}
+
+			// The catch-all is the functional half: details are action names, setting keys,
+			// property names — arbitrary strings GIR does not enumerate.
+			allSignals.push({
+				name: `${signal.name}::\${string}`,
+				signal,
+				isNotifySignal: false,
+				isDetailSignal: true,
+				isTemplateLiteral: true,
+			});
+		}
+
+		return allSignals;
+	}
+
+	/**
+	 * The nearest interface — this one included — in the prerequisite chain that
+	 * registers signals, or `null` when none does.
+	 *
+	 * This is the one predicate behind every `SignalSignatures` decision an interface
+	 * is part of: whether it gets a block of its own, what that block extends, and
+	 * whether an implementing class references it. One predicate, because the three
+	 * call sites MUST agree — a gate that says "no block" while the class-side filter
+	 * says "reference it" emits a name that does not exist.
+	 *
+	 * Own signals are not the whole answer: a `<prerequisite>` of interface type
+	 * carries its signals into every implementor, and GIR does not promise the class
+	 * lists the prerequisite in `<implements>` — measured: `ClutterGst.Camera` and
+	 * `ClutterGst.Playback` list only `Player`, whose prerequisite `Clutter.Media`
+	 * registers `eos` and `error`. A class prerequisite is not walked: its signals
+	 * reach the implementing class through its own `extends` chain.
+	 */
+	findSignalSource(): IntrospectedInterface | null {
+		if (this.signals.length > 0) return this;
+		const prerequisite = this.resolveParents().extends();
+		if (prerequisite && prerequisite.node instanceof IntrospectedInterface) {
+			return prerequisite.node.findSignalSource();
+		}
+		return null;
 	}
 
 	accept(visitor: GirVisitor): IntrospectedInterface {

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -1302,8 +1302,38 @@ export class IntrospectedClass extends IntrospectedBaseClass {
  * Represents a GIR interface
  */
 export class IntrospectedInterface extends IntrospectedBaseClass {
+	/**
+	 * The signals this interface registers itself, from `<glib:signal>`.
+	 *
+	 * GIR puts signals on `<interface>` exactly as it does on `<class>`, and GObject
+	 * registers them on the interface GType — `GtkEditable::changed` is the one every
+	 * entry-like widget in GTK4 emits. Reading them only in {@link IntrospectedClass}
+	 * dropped all of them: 7 signals over 4 interfaces in Gtk-4.0, reaching 17 concrete
+	 * widget types through `implements`, and `gtk-entry` alone lost five handler slots
+	 * including `changed`. Nothing said so, because a signal that is never parsed is a
+	 * signal nothing can miss.
+	 */
+	signals: IntrospectedSignal[] = [];
 	interfaces: TypeIdentifier[] = [];
 	noParent: boolean = false;
+
+	/**
+	 * This interface's own signals, in the shape the emitter consumes.
+	 *
+	 * Deliberately NOT {@link IntrospectedClass.getAllSignals}'s behaviour: no
+	 * `notify::` keys and no detailed variants. Those belong to the implementing
+	 * CLASS, whose `SignalSignatures` already extends `GObject.Object`'s and would
+	 * otherwise inherit the same keys twice, from two branches, for every interface
+	 * it implements.
+	 */
+	getAllSignals(): SignalDescriptor[] {
+		return this.signals.map((signal) => ({
+			name: signal.name,
+			signal,
+			isNotifySignal: false,
+			isDetailSignal: false,
+		}));
+	}
 
 	accept(visitor: GirVisitor): IntrospectedInterface {
 		const node = this.copy({
@@ -1312,6 +1342,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 			props: this.props.map((p) => p.accept(visitor)),
 			fields: this.fields.map((f) => f.accept(visitor)),
 			callbacks: this.callbacks.map((c) => c.accept(visitor)),
+			signals: this.signals.map((s) => s.accept(visitor)),
 		});
 		return visitor.visitInterface?.(node) ?? node;
 	}
@@ -1378,6 +1409,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 			props?: IntrospectedProperty[];
 			fields?: IntrospectedField[];
 			callbacks?: IntrospectedClassCallback[];
+			signals?: IntrospectedSignal[];
 		} = {},
 	): IntrospectedInterface {
 		const iface = new IntrospectedInterface({ name: this.name, namespace: this.namespace });
@@ -1393,6 +1425,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 			props = this.props,
 			fields = this.fields,
 			callbacks = this.callbacks,
+			signals = this.signals,
 		} = options;
 
 		iface.constructors = [...constructors.map((c) => c.copy({ parent: iface }))];
@@ -1400,6 +1433,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 		iface.props = [...props.map((p) => p.copy({ parent: iface }))];
 		iface.fields = [...fields.map((f) => f.copy({ parent: iface }))];
 		iface.callbacks = [...callbacks.map((c) => c.copy({ parent: iface }))];
+		iface.signals = [...signals.map((sig) => sig.copy({ parent: iface }))];
 
 		if (this.mainConstructor) {
 			iface.mainConstructor = this.mainConstructor.copy({ parent: iface });
@@ -1473,6 +1507,7 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 	): void {
 		try {
 			IntrospectedInterface.parseInterfaceConstructors(element, iface, options);
+			IntrospectedInterface.parseInterfaceSignals(element, iface, options);
 			IntrospectedInterface.parseInterfaceProperties(element, iface, options);
 			IntrospectedInterface.parseInterfaceMethods(element, iface, options);
 			IntrospectedInterface.parseInterfaceFields(element, iface);
@@ -1481,6 +1516,17 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 			IntrospectedInterface.parseInterfaceStaticFunctions(element, iface, options);
 		} catch (e) {
 			log.reportParsingFailure(iface.name, "interface", namespace.namespace, e as Error);
+		}
+	}
+
+	/** `<glib:signal>` on an `<interface>`, read exactly as {@link IntrospectedClass.parseSignals} reads it on a class. */
+	private static parseInterfaceSignals(
+		element: GirInterfaceElement,
+		iface: IntrospectedInterface,
+		options: OptionsLoad,
+	): void {
+		if (element["glib:signal"]) {
+			iface.signals.push(...element["glib:signal"].map((signal) => IntrospectedSignal.fromXML(signal, iface, options)));
 		}
 	}
 

--- a/packages/lib/src/gir/signal.ts
+++ b/packages/lib/src/gir/signal.ts
@@ -22,6 +22,7 @@ import {
 	type IntrospectedClass,
 	IntrospectedClassCallback,
 	IntrospectedClassFunction,
+	type IntrospectedInterface,
 } from "./introspected-classes.ts";
 import { IntrospectedFunctionParameter } from "./parameter.ts";
 
@@ -31,7 +32,13 @@ export enum IntrospectedSignalType {
 	EMIT,
 }
 
-export class IntrospectedSignal extends IntrospectedClassMember<IntrospectedClass> {
+/**
+ * The owner of a signal: GIR writes `<glib:signal>` under `<class>` AND under
+ * `<interface>`, and GObject registers it on that GType either way.
+ */
+export type SignalOwner = IntrospectedClass | IntrospectedInterface;
+
+export class IntrospectedSignal extends IntrospectedClassMember<SignalOwner> {
 	parameters: IntrospectedFunctionParameter[];
 	return_type: TypeExpression;
 	detailed: boolean;
@@ -60,7 +67,7 @@ export class IntrospectedSignal extends IntrospectedClassMember<IntrospectedClas
 		noRecurse?: boolean;
 		noHooks?: boolean;
 		when?: "first" | "last" | "cleanup";
-		parent: IntrospectedClass;
+		parent: SignalOwner;
 	}>) {
 		super(name, parent, { ...args });
 
@@ -94,7 +101,7 @@ export class IntrospectedSignal extends IntrospectedClassMember<IntrospectedClas
 		noHooks,
 		when,
 	}: {
-		parent?: IntrospectedClass;
+		parent?: SignalOwner;
 		parameters?: IntrospectedFunctionParameter[];
 		returnType?: TypeExpression;
 		detailed?: boolean;
@@ -116,7 +123,7 @@ export class IntrospectedSignal extends IntrospectedClassMember<IntrospectedClas
 		})._copyBaseProperties(this);
 	}
 
-	static fromXML(element: GirSignalElement, parent: IntrospectedClass, options: OptionsLoad): IntrospectedSignal {
+	static fromXML(element: GirSignalElement, parent: SignalOwner, options: OptionsLoad): IntrospectedSignal {
 		const ns = parent.namespace;
 		const signal = new IntrospectedSignal({
 			name: element.$.name,

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -329,8 +329,21 @@ if (data.SINCE?.["GtkWidget::state-flags-changed"] !== "1.3") {
 // (editing-done, remove-widget), `GtkColorChooser` (color-activated) and `GtkFontChooser`
 // (font-activated) reached no vocabulary at all, which through `implements` was 41 handler
 // slots missing across 17 concrete widgets, `<gtk-entry onChanged>` among them.
-if (data.OWN_SIGNALS?.GtkOrientable?.join(",") !== "orientation-flipped") {
-  fail(`OWN_SIGNALS lost the interface's own signal: ${JSON.stringify(data.OWN_SIGNALS?.GtkOrientable)}`);
+// EXACT equality, base names only: detail variants (`orientation-changed::x`) are a
+// TYPE-side expansion and must never leak into the runtime vocabulary — GObject
+// registers ONE signal, the details are connect-time strings.
+if (data.OWN_SIGNALS?.GtkOrientable?.join(",") !== "orientation-changed,orientation-flipped") {
+  fail(
+    `OWN_SIGNALS lost the interface's own signals: ${JSON.stringify(data.OWN_SIGNALS?.GtkOrientable)}`,
+  );
+}
+// `GtkFlippable` registers NOTHING — its signals-by-prerequisite are Orientable's, and
+// `OWN_SIGNALS` is keyed by the GType that REGISTERS. A key here would say the same
+// signal twice and lose which GType owns it.
+if ("GtkFlippable" in (data.OWN_SIGNALS ?? {})) {
+  fail(
+    `OWN_SIGNALS keys GtkFlippable, which registers no signal: ${JSON.stringify(data.OWN_SIGNALS?.GtkFlippable)}`,
+  );
 }
 // Same containment as the class case: an interface signal a consumer reads out of
 // `OWN_SIGNALS` needs a version to forgive its absence from an older library.
@@ -347,20 +360,57 @@ if (data.SINCE?.["GtkOrientable::orientation-flipped"] !== "1.7") {
 // consumer is allowed to write), and a consumer that has one without the other gets
 // either a handler it cannot name or a name that connects to nothing.
 const mainTypes = readFileSync(join(pkgDir, "mini-1.0.d.ts"), "utf8");
-if (!/namespace Orientable \{\s*\n\s*\/\/ Signal signatures\n\s*interface SignalSignatures \{/.test(mainTypes)) {
+if (
+  !/namespace Orientable \{\s*\n\s*\/\/ Signal signatures\n\s*interface SignalSignatures \{/.test(
+    mainTypes,
+  )
+) {
   fail("the interface got no SignalSignatures of its own in mini-1.0.d.ts");
 }
 // And the implementing class must UNION it in. A bare `interface SignalSignatures` on the
 // interface that nothing extends is the same hole one step later.
-if (!/interface SignalSignatures extends Widget\.SignalSignatures, Orientable\.SignalSignatures \{/.test(mainTypes)) {
-  fail("the implementing class does not extend the interface's SignalSignatures");
+if (
+  !/interface SignalSignatures extends Widget\.SignalSignatures, Orientable\.SignalSignatures, Flippable\.SignalSignatures \{/.test(
+    mainTypes,
+  )
+) {
+  fail("the implementing class does not extend the interfaces' SignalSignatures");
 }
-// The interface's own block must NOT extend `GObject.Object.SignalSignatures`: the class
-// already reaches it through its parent chain, and inheriting the same `notify::` keys
-// down two branches into one declaration is a conflict the first differing prerequisite
-// would surface.
+// The block that OWNS the signals must not extend anything here: Orientable's only
+// prerequisite is a class (GObject.Object, filled in by the InterfaceVisitor), and the
+// implementing class already reaches `GObject.Object.SignalSignatures` through its own
+// parent chain — inheriting the same `notify::` keys down two branches into one
+// declaration is a conflict the first differing prerequisite would surface.
 if (/interface SignalSignatures extends [^\n]*\n[^}]*"orientation-flipped"/.test(mainTypes)) {
-  fail("the interface's SignalSignatures extends something; it must be bare");
+  fail("the signal-owning interface's SignalSignatures extends something; it must be bare");
+}
+// DETAIL VARIANTS live on the interface block or nowhere: the class side expands details
+// only for its OWN signals, so `Gio.ActionGroup`-shaped signals (all four detailed) had
+// the base name typed while `action-added::quit` fell through to the untyped overload.
+// Both halves of the class convention: the enumerated key over the interface's own
+// property, and the template-literal catch-all for the details GIR cannot enumerate.
+if (!/"orientation-changed::orientation": \(what: string\) => void;/.test(mainTypes)) {
+  fail("the detailed interface signal lost its property-enumerated detail variant");
+}
+if (!/\[key: `orientation-changed::\$\{string\}`\]: \(what: string\) => void;/.test(mainTypes)) {
+  fail("the detailed interface signal lost its template-literal catch-all");
+}
+// A PREREQUISITE'S signals reach an implementor only through the derived interface when
+// the GIR omits the prerequisite from `<implements>` (ClutterGst.Camera lists only
+// Player; `eos`/`error` live on Player's prerequisite Clutter.Media). So Flippable — no
+// signals of its own — must still get a block, extending the prerequisite's…
+if (!/interface SignalSignatures extends Orientable\.SignalSignatures \{\}/.test(mainTypes)) {
+  fail("the signal-less interface does not extend its signal-bearing prerequisite");
+}
+// …and the class with the omission must reach the signals through it.
+if (
+  !/interface SignalSignatures extends GObject\.Object\.SignalSignatures, Flippable\.SignalSignatures \{/.test(
+    mainTypes,
+  )
+) {
+  fail(
+    "the class implementing only the derived interface does not reach the prerequisite's signals",
+  );
 }
 
 // Every GType `OWN_SIGNALS` names must be one this vocabulary actually describes — the

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -395,10 +395,13 @@ if (!/"orientation-changed::orientation": \(what: string\) => void;/.test(mainTy
 if (!/\[key: `orientation-changed::\$\{string\}`\]: \(what: string\) => void;/.test(mainTypes)) {
   fail("the detailed interface signal lost its template-literal catch-all");
 }
-// A PREREQUISITE'S signals reach an implementor only through the derived interface when
-// the GIR omits the prerequisite from `<implements>` (ClutterGst.Camera lists only
-// Player; `eos`/`error` live on Player's prerequisite Clutter.Media). So Flippable — no
-// signals of its own — must still get a block, extending the prerequisite's…
+// A PREREQUISITE'S signals are part of the derived interface's own signature map
+// (ClutterGst.Player without Clutter.Media's `eos`/`error` is wrong for any consumer of
+// `keyof Player.SignalSignatures`), and they reach an implementor only through the
+// derived interface when the GIR omits the prerequisite from `<implements>` — which GIR
+// does not forbid, though measured per file over 718 GIRs no real class does it today.
+// So Flippable — no signals of its own — must still get a block, extending the
+// prerequisite's…
 if (!/interface SignalSignatures extends Orientable\.SignalSignatures \{\}/.test(mainTypes)) {
   fail("the signal-less interface does not extend its signal-bearing prerequisite");
 }

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -322,6 +322,47 @@ if (data.SINCE?.["GtkWidget::state-flags-changed"] !== "1.3") {
     )}`,
   );
 }
+// AN INTERFACE REGISTERS SIGNALS TOO, and reading them only on `<class>` is a hole with
+// no symptom: an interface that contributes nothing looks exactly like one that has
+// nothing to contribute. Measured on Gtk-4.0 before this assertion existed —
+// `GtkEditable` (changed, delete-text, insert-text, input-intercepted), `GtkCellEditable`
+// (editing-done, remove-widget), `GtkColorChooser` (color-activated) and `GtkFontChooser`
+// (font-activated) reached no vocabulary at all, which through `implements` was 41 handler
+// slots missing across 17 concrete widgets, `<gtk-entry onChanged>` among them.
+if (data.OWN_SIGNALS?.GtkOrientable?.join(",") !== "orientation-flipped") {
+  fail(`OWN_SIGNALS lost the interface's own signal: ${JSON.stringify(data.OWN_SIGNALS?.GtkOrientable)}`);
+}
+// Same containment as the class case: an interface signal a consumer reads out of
+// `OWN_SIGNALS` needs a version to forgive its absence from an older library.
+if (data.SINCE?.["GtkOrientable::orientation-flipped"] !== "1.7") {
+  fail(
+    `SINCE has no version for the interface's signal: ${JSON.stringify(
+      Object.keys(data.SINCE ?? {}).filter((k) => k.startsWith("GtkOrientable")),
+    )}`,
+  );
+}
+// THE TYPE SIDE OF THE SAME FACT, read out of the main `.d.ts` rather than the
+// vocabulary's. The two halves fail independently: an interface can reach `OWN_SIGNALS`
+// (runtime, what a host connects) while emitting no `SignalSignatures` (types, what a
+// consumer is allowed to write), and a consumer that has one without the other gets
+// either a handler it cannot name or a name that connects to nothing.
+const mainTypes = readFileSync(join(pkgDir, "mini-1.0.d.ts"), "utf8");
+if (!/namespace Orientable \{\s*\n\s*\/\/ Signal signatures\n\s*interface SignalSignatures \{/.test(mainTypes)) {
+  fail("the interface got no SignalSignatures of its own in mini-1.0.d.ts");
+}
+// And the implementing class must UNION it in. A bare `interface SignalSignatures` on the
+// interface that nothing extends is the same hole one step later.
+if (!/interface SignalSignatures extends Widget\.SignalSignatures, Orientable\.SignalSignatures \{/.test(mainTypes)) {
+  fail("the implementing class does not extend the interface's SignalSignatures");
+}
+// The interface's own block must NOT extend `GObject.Object.SignalSignatures`: the class
+// already reaches it through its parent chain, and inheriting the same `notify::` keys
+// down two branches into one declaration is a conflict the first differing prerequisite
+// would surface.
+if (/interface SignalSignatures extends [^\n]*\n[^}]*"orientation-flipped"/.test(mainTypes)) {
+  fail("the interface's SignalSignatures extends something; it must be bare");
+}
+
 // Every GType `OWN_SIGNALS` names must be one this vocabulary actually describes — the
 // same containment `OWN_PROPS` is held to above, so a key can never appear that a
 // consumer walking `DECLS` has no interface for.

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -68,6 +68,33 @@
           </parameter>
         </parameters>
       </glib:signal>
+      <!-- DETAILED, because a detailed interface signal is the case with no other home:
+           the class side expands detail variants only for its OWN signals, so if the
+           interface's block does not carry `orientation-changed::x` nothing does. The
+           real shape is `Gio.ActionGroup` — all four of its signals are detailed, and
+           `action-added::quit` fell through to the untyped overload while `action-added`
+           beside it was typed. 25 such signals across the 718-GIR corpus. -->
+      <glib:signal name="orientation-changed" when="last" detailed="1">
+        <doc xml:space="preserve">Emitted when a named aspect of the orientation changed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="what" transfer-ownership="none">
+            <type name="utf8" c:type="const gchar*"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
+    </interface>
+
+    <!-- NO signals of its own; its prerequisite has them. They still reach an implementor
+         only through THIS interface when the GIR omits the prerequisite from the class's
+         `<implements>` — real case: `ClutterGst.Camera` and `ClutterGst.Playback` list
+         only `Player`, whose prerequisite `Clutter.Media` registers `eos` and `error`.
+         So this block must EXIST and extend the prerequisite's, while `OWN_SIGNALS` must
+         never key it: it registers nothing. -->
+    <interface name="Flippable" c:symbol-prefix="flippable" c:type="GtkFlippable" glib:type-name="GtkFlippable" glib:get-type="gtk_flippable_get_type">
+      <prerequisite name="Orientable"/>
     </interface>
 
     <!-- Abstract, so it must NOT get a `Widgets` row, and it must still get a props
@@ -118,6 +145,7 @@
          names neither the GType nor a version. -->
     <class name="Box" c:symbol-prefix="box" c:type="GtkBox" glib:type-name="GtkBox" glib:get-type="gtk_box_get_type" parent="Widget" version="1.4">
       <implements name="Orientable"/>
+      <implements name="Flippable"/>
       <property name="spacing" default-value="6" writable="1" transfer-ownership="none">
         <type name="gint" c:type="gint"/>
       </property>
@@ -167,6 +195,15 @@
           <parameter name="label" transfer-ownership="none"><type name="utf8" c:type="const gchar*"/></parameter>
         </parameters>
       </method>
+    </class>
+
+    <!-- The `<implements>` OMISSION, as a class: lists only Flippable, never its
+         prerequisite Orientable — the ClutterGst.Camera shape. The prerequisite's signals
+         reach this class's SignalSignatures only through Flippable's block extending
+         Orientable's. Not a widget on purpose, so the vocabulary walk stays exactly as
+         it was. -->
+    <class name="Flipper" c:symbol-prefix="flipper" c:type="GtkFlipper" glib:type-name="GtkFlipper" glib:get-type="gtk_flipper_get_type" parent="GObject.Object">
+      <implements name="Flippable"/>
     </class>
 
     <!-- Not a widget: no row, no props interface. -->

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -87,12 +87,15 @@
       </glib:signal>
     </interface>
 
-    <!-- NO signals of its own; its prerequisite has them. They still reach an implementor
-         only through THIS interface when the GIR omits the prerequisite from the class's
-         `<implements>` — real case: `ClutterGst.Camera` and `ClutterGst.Playback` list
-         only `Player`, whose prerequisite `Clutter.Media` registers `eos` and `error`.
-         So this block must EXIST and extend the prerequisite's, while `OWN_SIGNALS` must
-         never key it: it registers nothing. -->
+    <!-- NO signals of its own; its prerequisite has them. The prerequisite's signals are
+         part of this interface's signature map — real shape: `Gio.RemoteActionGroup`
+         (no own signals, prerequisite `Gio.ActionGroup`), and with own signals beside it
+         `ClutterGst.Player` (prerequisite `Clutter.Media`: `eos`/`error`) and
+         `Gtk.SectionModel` (prerequisite `Gio.ListModel`: `items-changed`). It also
+         carries the signals into a class whose `<implements>` omits the prerequisite,
+         which GIR does not forbid (Flipper below; measured per file over 718 GIRs, no
+         real class does it today). So this block must EXIST and extend the
+         prerequisite's, while `OWN_SIGNALS` must never key it: it registers nothing. -->
     <interface name="Flippable" c:symbol-prefix="flippable" c:type="GtkFlippable" glib:type-name="GtkFlippable" glib:get-type="gtk_flippable_get_type">
       <prerequisite name="Orientable"/>
     </interface>

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -51,6 +51,23 @@
         <doc xml:space="preserve">The orientation of the orientable.</doc>
         <type name="Orientation" c:type="GtkOrientation"/>
       </property>
+      <!-- GIR puts `<glib:signal>` on an interface exactly as it does on a class, and
+           GObject registers it on the interface GType. Reading it only on `<class>` cost
+           Gtk-4.0 eight signals over four interfaces, which through `implements` was 41
+           handler slots across 17 concrete widgets — `GtkEditable::changed`, so
+           `<gtk-entry onChanged>`, among them. Versioned, so the SINCE half is exercised
+           over an interface signal too. -->
+      <glib:signal name="orientation-flipped" when="last" version="1.7">
+        <doc xml:space="preserve">Emitted after the orientation changed.</doc>
+        <return-value transfer-ownership="none">
+          <type name="none" c:type="void"/>
+        </return-value>
+        <parameters>
+          <parameter name="previous" transfer-ownership="none">
+            <type name="Orientation" c:type="GtkOrientation"/>
+          </parameter>
+        </parameters>
+      </glib:signal>
     </interface>
 
     <!-- Abstract, so it must NOT get a `Widgets` row, and it must still get a props


### PR DESCRIPTION
GIR writes `<glib:signal>` under `<interface>` exactly as it does under `<class>`, and GObject registers the signal on the interface GType. Only `IntrospectedClass.fromXML` read it, so every interface signal in every namespace was dropped — and nothing said so, because an interface that contributes nothing looks exactly like one with nothing to contribute.

## What it costs, measured on Gtk-4.0

Four interfaces register eight signals between them:

| interface | signals |
|---|---|
| `GtkEditable` | `changed`, `delete-text`, `insert-text`, `input-intercepted` |
| `GtkCellEditable` | `editing-done`, `remove-widget` |
| `GtkColorChooser` | `color-activated` |
| `GtkFontChooser` | `font-activated` |

Through `implements` that is **41 handler slots across 17 concrete widget types**. `gtk-entry` and `gtk-spin-button` lose five each; `gtk-text`, `gtk-search-entry`, `gtk-password-entry`, `gtk-editable-label`, `adw-entry-row`, `adw-password-entry-row` and `adw-spin-row` lose three each. `changed` on an entry is as central a handler as GTK has.

## Before and after, as a set difference

Against the published `@girs/gtk-4.0` 4.5.0 vocabulary, not netted:

| | 4.5.0 | this branch |
|---|---|---|
| `OWN_SIGNALS` keys | 54 | 58 |
| `GtkEditable` | absent | 4 signals |
| `GtkCellEditable` | absent | 2 signals |
| `GtkColorChooser` | absent | 1 signal |
| `GtkFontChooser` | absent | 1 signal |
| `namespace Editable` has `SignalSignatures` | no | yes |
| declarations extending it | 0 | 5 |

Nothing was lost in either table.

## What changed

- `IntrospectedInterface` gets a `signals` field, parses `<glib:signal>`, and answers `getAllSignals()` with its own signals only.
- `IntrospectedSignal`'s owner widens from `IntrospectedClass` to a `SignalOwner` union.
- `generateClassNamespaces` emits a `SignalSignatures` block for an interface **that registers signals** — not for the other ~1500, which would put a namespace block on every interface in the run and offer implementors a name that says nothing.
- `signal-generator` needed no new logic on the consuming side. It already unioned `<iface>.SignalSignatures` into an implementing class, guarded by `iface.node as unknown as { signals?: unknown[] }` — a cast at a field that did not exist, so the branch was dead for every interface in every namespace. It reads a real field now.
- The vocabulary's `ownSignals` and its `SINCE` loop stop special-casing `IntrospectedClass`.

An interface's own block deliberately extends **nothing**. The implementing class already reaches `GObject.Object.SignalSignatures` through its parent chain, and inheriting the same `notify::` keys down two branches into one declaration is a conflict the first differing prerequisite would surface.

## Verification

`tests/widget-vocabulary`: the fixture interface `Orientable` gains a versioned signal, and the two halves are asserted separately — runtime (`OWN_SIGNALS.GtkOrientable`, `SINCE["GtkOrientable::orientation-flipped"]`) and types (the interface's own block, the implementing class extending it, and that the interface's block is bare).

A/B, both directions actually run:

| probe | exit |
|---|---|
| parser call reverted | 1 |
| emitter branch reverted | 1, naming the type half |
| restored | 0 |

Also green: `gjsify lint` 0, `gjsify foreach check -pt --include '@ts-for-gir/*' --include '@gi.ts/*'` 0, `check:girs` 0, `check:docs` 0, `test:tests` 0, and `tsc` over 16 freshly generated namespaces including Adw-1 with `skipLibCheck: false` — 0, so the new `extends` clauses introduce no conflict.

## Review findings, fixed on this branch

An independent re-measurement against the 718-GIR corpus (368 interfaces registering 960 signals across 69 namespaces) confirmed the numbers above — Gtk-4.0 `OWN_SIGNALS` 54 → 58 keys, +8 signals, none lost — and found two holes, both fixed in the follow-up commits:

- **Detail variants** (`fix: carry interface signal details and prereqs`). The interface's `getAllSignals()` skipped them on the claim that the implementing class owns them — but the class expands details only for its own signals, so a detailed interface signal was expanded nowhere. `Gio.ActionGroup`'s four signals are all detailed: `action-added` was typed, `action-added::quit` fell through to the untyped overload. 25 such signals in the corpus. The interface block now carries the property-enumerated variants and the template-literal catch-all, mirroring the class convention.
- **Prerequisites** (same commit, wording corrected in the follow-up `docs:` commit). An interface's block is its own signature map, and a `<prerequisite>` of interface type contributes to it: `ClutterGst.Player` (1.0/2.0) said `download-buffering` but not the `eos`/`error` its prerequisite `Clutter.Media` registers; Gtk-4.0's `SectionModel`/`SelectionModel` said nothing of `Gio.ListModel::items-changed`; `Gio.RemoteActionGroup` (no own signals) had no block at all. One model predicate, `findSignalSource()`, now drives the emission gate, what a block extends (the nearest signal-bearing prerequisite interface — never `GObject.Object`, so the `notify::` invariant holds by construction), and the class-side filter, so none can reference a block another refused to emit. The `<implements>`-omission case the predicate also guards is prophylactic: measured per file over 718 GIRs, no class today omits a signal-bearing prerequisite (an earlier draft claimed `ClutterGst.Camera`/`Playback` did — that mixed GIR versions; in 3.0, where those classes live, `Player` owns all five signals itself).
- **Example** (`test: exercise interface signals in the example`), per the repo rule for type-generation PRs: `gtk-4-signal-interfaces` connects `changed`/`delete-text` from `Gtk.Editable` — `keyof Gtk.Editable.SignalSignatures` is the compile-time proof, exit 1 (TS2694) against pre-fix types, exit 0 after regeneration — and the detailed `action-added::quit` on `Gtk.Application`.

Each fix carries its own fixture + assertions in `tests/widget-vocabulary`, A/B-run in both directions (detail loop reverted → exit 1; `findSignalSource` reduced to own-signals-only → exit 1; extends-only revert → exit 1; restored → exit 0). The runtime vocabulary is byte-identical before and after the follow-ups, now asserted by exact equality. `tsc` over the regenerated gtk-4.0, gio-2.0, cluttergst-2.0/3.0, atk-1.0, ges-1.0, rb-3.0, goocanvas-2.0 and adw-1 chains shows no diagnostic the pre-PR baseline did not already show (the two pre-existing families: `$signals` vs `Gst.ImplementsInterface` in cluttergst-1.0 and `element` in gstaudio-0.10 — both in namespaces the packages-all config already ignores).
