### PR TITLE
fix(lib): lint the core package, and fix the hang it hid

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -20,7 +20,7 @@
     "**/*.gir",
     "**/node_modules",
     "**/dist",
-    "**/lib",
+    "packages/*/lib",
     "**/build",
     "**/coverage",
     "refs",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -29,7 +29,7 @@
     "**/*.cjs",
     "**/node_modules",
     "**/dist",
-    "**/lib",
+    "packages/*/lib",
     "**/build",
     "**/coverage",
     "refs",

--- a/packages/lib/src/gir-module.ts
+++ b/packages/lib/src/gir-module.ts
@@ -296,7 +296,12 @@ export class GirModule implements IGirModule {
 	}
 
 	accept(visitor: GirVisitor) {
-		for (const key of [...this.members.keys()]) {
+		// Snapshot the keys: the loop writes each visited member back into the very
+		// map it is walking, and a live iterator only survives that by a subtle rule
+		// about re-setting existing keys. Not worth depending on.
+		const keys = [...this.members.keys()];
+
+		for (const key of keys) {
 			const member = this.members.get(key);
 
 			if (!member) continue;

--- a/packages/lib/src/gir/generics.ts
+++ b/packages/lib/src/gir/generics.ts
@@ -26,31 +26,30 @@ const GenericNames = [
 	"Z",
 ];
 
-export function* getGenericNames(start: string = "A") {
-	let names = GenericNames.map((s) => `${s}`);
+/**
+ * An unbounded supply of generic parameter names: `A`…`Z`, then `A1`…`Z1`,
+ * then `A2`…`Z2`, and so on.
+ *
+ * `start` resumes the sequence at an already-issued name, so a copied class
+ * keeps handing out the names the original had not reached yet. The first
+ * pass begins at that letter; every later pass covers the full alphabet.
+ *
+ * The generator is infinite by design and therefore never returns — that is
+ * what the `never` return type states, so callers can treat `next().value`
+ * as a plain `string`.
+ */
+export function* getGenericNames(start: string = "A"): Generator<string, never, unknown> {
+	// A name is a letter plus the pass number, with pass 0 left bare ("A", not "A0").
 	const startIteration = Number.parseInt(start.slice(1) || "0", 10);
+	const startPosition = GenericNames.indexOf(start[0]);
 
-	let i = startIteration;
+	for (let iteration = startIteration; ; iteration++) {
+		for (const [position, letter] of GenericNames.entries()) {
+			if (iteration === startIteration && position < startPosition) continue;
 
-	names = names.map((s) => (i === 0 ? s : `${s}${i}`));
-
-	const StartLetter = start[0];
-	const position = GenericNames.indexOf(StartLetter);
-
-	while (true) {
-		for (const name of names) {
-			if (i === startIteration && GenericNames.indexOf(name) >= position) {
-				yield name;
-			}
+			yield iteration === 0 ? letter : `${letter}${iteration}`;
 		}
-
-		names = names.map((s) => `${s}${i}`);
-
-		i++;
 	}
-
-	// This will always be a string return.
-	return "ThisShouldNeverHappen";
 }
 
 export function createGenericNameGenerator(): () => string {

--- a/packages/lib/src/gir/introspected-classes.ts
+++ b/packages/lib/src/gir/introspected-classes.ts
@@ -608,11 +608,11 @@ export abstract class IntrospectedBaseClass extends IntrospectedNamespaceMember 
 		this.superType = superType;
 
 		this.mainConstructor = mainConstructor?.copy({ parent: this }) ?? null;
-		this.constructors = [...constructors.map((c) => c.copy({ parent: this }))];
-		this.members = [...members.map((m) => m.copy({ parent: this }))];
-		this.props = [...props.map((p) => p.copy({ parent: this }))];
-		this.fields = [...fields.map((f) => f.copy({ parent: this }))];
-		this.callbacks = [...callbacks.map((c) => c.copy({ parent: this }))];
+		this.constructors = constructors.map((c) => c.copy({ parent: this }));
+		this.members = members.map((m) => m.copy({ parent: this }));
+		this.props = props.map((p) => p.copy({ parent: this }));
+		this.fields = fields.map((f) => f.copy({ parent: this }));
+		this.callbacks = callbacks.map((c) => c.copy({ parent: this }));
 	}
 
 	abstract accept(visitor: GirVisitor): IntrospectedBaseClass;
@@ -1085,12 +1085,12 @@ export class IntrospectedClass extends IntrospectedBaseClass {
 			callbacks = this.callbacks,
 		} = options;
 
-		klass.signals = [...signals.map((s) => s.copy({ parent: klass }))];
-		klass.constructors = [...constructors.map((c) => c.copy({ parent: klass }))];
-		klass.members = [...members.map((m) => m.copy({ parent: klass }))];
-		klass.props = [...props.map((p) => p.copy({ parent: klass }))];
-		klass.fields = [...fields.map((f) => f.copy({ parent: klass }))];
-		klass.callbacks = [...callbacks.map((c) => c.copy({ parent: klass }))];
+		klass.signals = signals.map((s) => s.copy({ parent: klass }));
+		klass.constructors = constructors.map((c) => c.copy({ parent: klass }));
+		klass.members = members.map((m) => m.copy({ parent: klass }));
+		klass.props = props.map((p) => p.copy({ parent: klass }));
+		klass.fields = fields.map((f) => f.copy({ parent: klass }));
+		klass.callbacks = callbacks.map((c) => c.copy({ parent: klass }));
 
 		if (this.mainConstructor) {
 			klass.mainConstructor = this.mainConstructor.copy({ parent: klass });
@@ -1395,11 +1395,11 @@ export class IntrospectedInterface extends IntrospectedBaseClass {
 			callbacks = this.callbacks,
 		} = options;
 
-		iface.constructors = [...constructors.map((c) => c.copy({ parent: iface }))];
-		iface.members = [...members.map((m) => m.copy({ parent: iface }))];
-		iface.props = [...props.map((p) => p.copy({ parent: iface }))];
-		iface.fields = [...fields.map((f) => f.copy({ parent: iface }))];
-		iface.callbacks = [...callbacks.map((c) => c.copy({ parent: iface }))];
+		iface.constructors = constructors.map((c) => c.copy({ parent: iface }));
+		iface.members = members.map((m) => m.copy({ parent: iface }));
+		iface.props = props.map((p) => p.copy({ parent: iface }));
+		iface.fields = fields.map((f) => f.copy({ parent: iface }));
+		iface.callbacks = callbacks.map((c) => c.copy({ parent: iface }));
 
 		if (this.mainConstructor) {
 			iface.mainConstructor = this.mainConstructor.copy({ parent: iface });

--- a/packages/lib/src/gir/namespace.ts
+++ b/packages/lib/src/gir/namespace.ts
@@ -32,11 +32,9 @@ export function promisifyNamespaceFunctions(namespace: GirModule) {
 		const internal = last_param_unwrapped.type;
 
 		if (internal instanceof TypeIdentifier && internal.is("Gio", "AsyncReadyCallback")) {
-			const async_res = [
-				...Array.from(namespace.members.values()).filter(
-					(m): m is IntrospectedFunction => m instanceof IntrospectedFunction,
-				),
-			].find((m) => m.name === `${node.name.replace(/_async$/, "")}_finish` || m.name === `${node.name}_finish`);
+			const async_res = Array.from(namespace.members.values())
+				.filter((m): m is IntrospectedFunction => m instanceof IntrospectedFunction)
+				.find((m) => m.name === `${node.name.replace(/_async$/, "")}_finish` || m.name === `${node.name}_finish`);
 
 			if (async_res) {
 				const async_parameters = node.parameters.slice(0, -1).map((p) => p.copy());

--- a/packages/lib/src/gir/promisify.ts
+++ b/packages/lib/src/gir/promisify.ts
@@ -60,7 +60,7 @@ function findFinishMethodInClass(cls: IntrospectedBaseClass, node: IntrospectedC
 	const members =
 		node instanceof IntrospectedStaticClassFunction
 			? [...cls.constructors, ...cls.members.filter((m) => m instanceof IntrospectedStaticClassFunction)]
-			: [...cls.members.filter((m) => !(m instanceof IntrospectedStaticClassFunction))];
+			: cls.members.filter((m) => !(m instanceof IntrospectedStaticClassFunction));
 
 	// Prefer the GIR-specified finish function name over name heuristics
 	if (node.finishFuncName) {

--- a/packages/lib/src/utils/types.ts
+++ b/packages/lib/src/utils/types.ts
@@ -27,6 +27,7 @@ import {
 	UnknownType,
 	VoidType,
 } from "../gir.ts";
+import type { OptionsGeneration } from "../types/index.ts";
 import { girParsingReporter } from "./gir-parsing.ts";
 
 /**
@@ -397,11 +398,11 @@ class HashTableDictType extends TypeExpression {
 		super();
 	}
 
-	print(namespace: IntrospectedNamespace, options: import("../types/index.ts").OptionsGeneration): string {
+	print(namespace: IntrospectedNamespace, options: OptionsGeneration): string {
 		return `{ [key: ${this.keyShape}]: ${this.valueType.rootPrint(namespace, options)} }`;
 	}
 
-	resolve(_namespace: IntrospectedNamespace, _options: import("../types/index.ts").OptionsGeneration): TypeExpression {
+	resolve(_namespace: IntrospectedNamespace, _options: OptionsGeneration): TypeExpression {
 		return this;
 	}
 

--- a/tests/generic-names/package.json
+++ b/tests/generic-names/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@ts-for-gir-test/generic-names",
+  "description": "Tests for getGenericNames — the unbounded supply of generic parameter names a class draws on",
+  "type": "module",
+  "private": true,
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "gir",
+    "testing",
+    "generics"
+  ],
+  "author": "Pascal Garber <pascal@mailfreun.de>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@ts-for-gir/lib": "workspace:^",
+    "vitest": "^4.1.11"
+  },
+  "devDependencies": {
+    "@types/node": "^26.4.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/tests/generic-names/src/drive-generic-names.ts
+++ b/tests/generic-names/src/drive-generic-names.ts
@@ -1,0 +1,17 @@
+// Prints the first N names from `getGenericNames(start)`, one per line.
+//
+// This runs as its own process on purpose. The defect the suite next door
+// guards against is a generator that stops YIELDING but never RETURNS, and a
+// synchronous loop like that cannot be interrupted from inside JavaScript —
+// not by vitest's test timeout, not by an AbortSignal. Driving it from a child
+// process turns "hangs the whole CI job" into "one test fails in N seconds".
+
+import { getGenericNames } from "@ts-for-gir/lib";
+
+const [, , start, count] = process.argv;
+const names = start === "" ? getGenericNames() : getGenericNames(start);
+const wanted = Number.parseInt(count, 10);
+
+for (let taken = 0; taken < wanted; taken++) {
+  process.stdout.write(`${names.next().value}\n`);
+}

--- a/tests/generic-names/src/generic-names.test.ts
+++ b/tests/generic-names/src/generic-names.test.ts
@@ -1,0 +1,133 @@
+// Tests for `getGenericNames` — the supply of TypeScript generic parameter names
+// that every generified class and callback draws on.
+//
+// WHY THIS EXISTS
+//
+// The generator is documented as an unbounded sequence: `A`…`Z`, then `A1`…`Z1`,
+// then `A2`…, for as long as a declaration keeps asking. It was not one. After the
+// first pass it kept looping without ever yielding again, so the 26th call to
+// `createGenericNameGenerator()`'s returned function never came back — an infinite
+// loop, not a wrong value. `createGenericNameGeneratorAt` made the ceiling lower
+// still: a class copied at `"Z"` had exactly one name left before the same hang.
+//
+// Nothing caught it, in two ways. `packages/lib` was excluded from linting by an
+// `ignorePatterns` entry meant for build output, so `no-unreachable` never reported
+// the `return "ThisShouldNeverHappen"` the loop had left behind as its tombstone.
+// And a hang produces no error, no partial output and no stack — a generator that
+// hangs only past name 25 looks exactly like a generator that works, because the
+// GIR corpus rarely reaches 26 generics on one declaration. Rarely is not never,
+// and the failure mode is a build that stops making progress in silence.
+//
+// So these tests do two things. They pin the names actually handed out, because
+// those names appear verbatim in every generated `.d.ts` and must not move. And
+// they drive the generator well past the old ceiling — from a child process with a
+// hard timeout, so that a regression fails loudly instead of hanging the suite.
+
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const DRIVER = fileURLToPath(new URL("./drive-generic-names.ts", import.meta.url));
+
+/**
+ * A healthy run of the driver takes ~250 ms, so this is ~80x headroom. It has to be
+ * enforced here: `execFileSync` blocks the thread, so vitest's own test timeout cannot
+ * fire while a child is spinning.
+ */
+const TIMEOUT_MS = 20_000;
+
+/**
+ * The alphabet the generator walks. Note the gap: `T` is absent upstream, so a
+ * pass is 25 names, not 26. Pinned here so a change to the table is a test change.
+ */
+const FIRST_PASS = [
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "I",
+  "J",
+  "K",
+  "L",
+  "M",
+  "N",
+  "O",
+  "P",
+  "Q",
+  "R",
+  "S",
+  "U",
+  "V",
+  "W",
+  "X",
+  "Y",
+  "Z",
+];
+
+/**
+ * Takes `count` names from `getGenericNames(start)`, running it out-of-process so
+ * that a generator which stops yielding is killed rather than waited on.
+ *
+ * @param start - Resume point, or `""` for the default.
+ */
+function take(start: string, count: number): string[] {
+  // `--experimental-transform-types`, not `--strip-types`: the driver reaches
+  // `getGenericNames` through the `@ts-for-gir/lib` barrel, which re-exports a
+  // real `enum` that strip-only mode refuses.
+  const args = ["--no-warnings", "--experimental-transform-types", DRIVER, start, String(count)];
+
+  let stdout: string;
+  try {
+    stdout = execFileSync(process.execPath, args, { encoding: "utf8", timeout: TIMEOUT_MS });
+  } catch (error) {
+    const killed = (error as { signal?: string | null }).signal;
+    if (killed) {
+      throw new Error(
+        `getGenericNames(${start === "" ? "" : JSON.stringify(start)}) did not produce ${count} names ` +
+          `within ${TIMEOUT_MS} ms — it was killed with ${killed}. A generator that stops yielding without ` +
+          `returning hangs its caller; see the note at the top of this file.`,
+      );
+    }
+    throw error;
+  }
+
+  return stdout.split("\n").filter((line) => line !== "");
+}
+
+describe("getGenericNames", () => {
+  it("hands out the bare alphabet on the first pass", () => {
+    expect(take("", FIRST_PASS.length)).toEqual(FIRST_PASS);
+  });
+
+  it("keeps going past the end of the alphabet", () => {
+    const names = take("", FIRST_PASS.length * 3);
+
+    expect(names).toHaveLength(FIRST_PASS.length * 3);
+    expect(names.slice(FIRST_PASS.length, FIRST_PASS.length * 2)).toEqual(FIRST_PASS.map((n) => `${n}1`));
+    expect(names.slice(FIRST_PASS.length * 2)).toEqual(FIRST_PASS.map((n) => `${n}2`));
+  });
+
+  it("never repeats a name", () => {
+    const names = take("", 200);
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("resumes at the letter a copied class stopped on", () => {
+    expect(take("C", 3)).toEqual(["C", "D", "E"]);
+  });
+
+  it("carries on past the alphabet even when it resumes at the last letter", () => {
+    // `Z` is the worst case for a copy chain: one name left on the first pass.
+    // This is where the old generator hung after a single `next()`.
+    expect(take("Z", 4)).toEqual(["Z", "A1", "B1", "C1"]);
+  });
+
+  it("resumes at a suffixed name from a later pass", () => {
+    expect(take("B1", 3)).toEqual(["B1", "C1", "D1"]);
+  });
+});

--- a/tests/generic-names/tsconfig.json
+++ b/tests/generic-names/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "lib": ["ESNext"],
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": false,
+    "types": ["node", "vitest/globals"],
+    "strict": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "diagnostics": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## What

`.oxlintrc.json`'s `ignorePatterns` carried `"**/lib"`, meant for the `lib/` build output that nine `packages/*/tsconfig.json` files declare as their `outDir`. As written it also matched `packages/lib` — the source package holding the whole GIR model, which every other package is built on. **It had never been linted.**

Narrowed to `packages/*/lib`, which keeps the intent and exposes the source.

## The blindness was real

Measured tree-wide, with a control in the row:

| probe | `ignorePatterns` | exit |
|---|---|---|
| `debugger;` in `packages/lib/src/gir/signal.ts` | `**/lib` | **0** — not seen |
| the same statement | `packages/*/lib` | **1** — reported |
| `debugger;` in `packages/generator-typescript/src/generators/signal-generator.ts` | `**/lib` | **1** — seen |

Naming the file explicitly *does* report it — only the tree-wide run applies `ignorePatterns` — so a per-file check is not evidence here.

Unblinding surfaced **20 errors and 2 warnings**, all in `packages/lib`.

## And what it hid was not clean

`no-unreachable` flagged `return "ThisShouldNeverHappen"` after a `while (true)` in `getGenericNames`. The dead code was a tombstone for a **live defect**: the generator produced its first 25 names and then spun forever without yielding.

The yield was gated on `i === startIteration`, true only on the first pass, so once the loop incremented the counter nothing came out of it again. The 26th call to `createGenericNameGenerator()`'s returned function never returns — an infinite loop, not a wrong value. `createGenericNameGeneratorAt` lowers the ceiling further, because a copy resumes at the last name the original issued: a class copied at `"Z"` had exactly one name left before the same hang. Reproduced in-process; the caller does not come back.

**Generated types cannot change.** Measured over every reachable `start` (the 25 bare letters plus the default), old and new emit an identical prefix — the old one simply hangs where the new one continues.

The dead `return` existed so `next().value` typed as `string`; removing it without a replacement breaks `tsc` at both call sites (`TS2322: Type 'string | void' is not assignable to type 'string'`). A `Generator<string, never>` return type states the same thing honestly.

## The rest was style

The other 19 errors are `unicorn(no-useless-spread)`, and the 2 warnings are `typescript(consistent-type-imports)`. No behaviour change:

- **`[...xs.map(f)]` in the `copy()` methods and the base constructor.** `.map()` always allocates, so the spread copies a copy. The freshness callers depend on — no aliasing between a class and the one it was copied from — comes from `.map()`, not from the spread. The neighbouring `[...this.interfaces]` and `[...this.generics]` stay: there the spread *is* the copy, and the rule correctly leaves them alone.
- **`GirModule.accept` keeps its snapshot.** It writes each visited member back into the map it is iterating. Re-setting an existing key happens to be safe on a live `Map` iterator, but that is a subtle rule to rest on for no gain, so the array just moves into a named local.

## Guard

New `tests/generic-names` suite, picked up by `test:tests`. It pins the names actually handed out and drives the generator well past the old ceiling.

It runs the generator **from a child process under a hard timeout**. A generator that stops yielding cannot be interrupted in-process — not even by vitest's own test timeout, because `execFileSync` blocks the thread — so an in-suite guard would hang CI instead of failing it. Verified against the old generator: 4 of 6 tests fail in 117 s with an attributable message, rather than hanging.

No lockfile change: the new workspace's deps were already resolved.

## Verification

Real exit codes, all at HEAD:

| command | exit |
|---|---|
| `gjsify lint` (bare, tree-wide) | 0 |
| `gjsify run check:app` | 0 |
| `gjsify run check:girs` | 0 |
| `gjsify run check:docs` | 0 |
| `gjsify run test:tests` | 0 — 35 tests, incl. the 6 new |
| `biome format` over the touched files | 0 |

`packages/lib` now reports **0 findings**. The 10 warnings that remain tree-wide are pre-existing on `main` in `examples/`, `packages/cli`, `packages/generator-json` and `packages/typedoc-theme`, and are left alone.

Two notes on the toolchain, both pre-existing and neither caused here:

- `gjsify format --check` exits 1 with *"oxfmt not found"*. This repo formats with Biome (`biome.json`, `@biomejs/biome` devDependency) and does not install `oxfmt`; the failure reproduces identically on files this branch never touched. Biome is used as the format gate above.
- `.oxfmtrc.json` carried the same `"**/lib"` entry and gets the same narrowing. That half is unmeasured for the same reason — but Biome never excluded `lib` and reports no drift across all 143 files in `packages/lib/src`, so the change is a no-op today and disarms the trap for whoever installs `oxfmt`.