### PR TITLE
feat(cli): `--bundle` emits one package for an SDK

### DIFF
--- a/.github/workflows/release-types.yml
+++ b/.github/workflows/release-types.yml
@@ -94,6 +94,34 @@ jobs:
         Source: ${REPO}@${RELEASE_TAG}"
         git push origin main
 
+    # The SDK channels (`@girs/sdk-gnome-*`) are generated from Flatpak SDKs rather than from
+    # this repository's `girs/`, so they are not part of the commit above and no push event
+    # reaches them. They are rebuilt on their own schedule too — an SDK moves inside a GNOME
+    # cycle without a release here — and this dispatch is the other half: a new generator has
+    # to reach every channel, not only the next weekly poll.
+    #
+    # Not gated on `changes`: a release with no diff in the per-namespace types can still be a
+    # new generator version for the channels, which record the generator they were built from.
+    - name: Trigger the SDK channel builds
+      env:
+        PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+        RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
+      run: |
+        set -euo pipefail
+        status=$(curl -sS -o /tmp/dispatch.out -w '%{http_code}' \
+          -X POST https://api.github.com/repos/gjsify/types/dispatches \
+          -H "Authorization: Bearer ${PAT_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          -d "{\"event_type\":\"generator-released\",\"client_payload\":{\"release\":\"${RELEASE_TAG}\"}}")
+        # 204 is the only success. Anything else is a dispatch that did not happen, and a
+        # channel nobody rebuilt looks exactly like a channel that needed no rebuild.
+        if [ "$status" != "204" ]; then
+          echo "dispatch to gjsify/types failed with HTTP $status" >&2
+          cat /tmp/dispatch.out >&2
+          exit 1
+        fi
+        echo "Dispatched generator-released for ${RELEASE_TAG}"
+
     - name: Summary
       env:
         RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ repo/
 # and are no longer committed. A local harvest may still drop one here; it must not
 # come back into git.
 girs/*.typelib
+tests/**/control-package/

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -141,6 +141,12 @@ Options:
                                 GtkWidget descendants [boolean] [default: false]
       --npmScope                Scope of the generated NPM packages
                                                      [string] [default: "@girs"]
+      --bundle                  Emit every generated namespace as ONE npm package
+                                with this name (e.g. '@girs/sdk-gnome-50').
+                                Implies --package and sets --npmScope    [string]
+      --bundleMeta              JSON object merged into the bundle package.json,
+                                for provenance the generator cannot know. Only
+                                valid with --bundle                      [string]
       --workspace               Uses the workspace protocol for the generated
                                 packages              [boolean] [default: false]
       --onlyVersionPrefix       Only use the version prefix for the ambient
@@ -613,6 +619,58 @@ ts-for-gir generate * --package --npmScope my-scope
 ```
 
 This command will generate NPM packages with the scope `@my-scope` instead of the default `@girs` scope. For `Gtk-4.0` this would generate a package with the name of `@my-scope/gtk-4.0`.
+
+## bundle
+
+`--package` emits one npm package per namespace, each depending on the others by name. That is
+right for the published `@girs/*` set, and wrong whenever the types have to match one specific
+runtime: npm is free to satisfy `@girs/glib-2.0` from the registry for one namespace and from
+your pinned copy for another, and two copies of a namespace are not a version skew — they are
+duplicate `declare module 'gi://GLib'` blocks, which is the "Incompatible GObject type" failure
+of [#431](https://github.com/gjsify/ts-for-gir/issues/431).
+
+`--bundle` emits the same namespaces as ONE package instead:
+
+```bash
+ts-for-gir generate '*' \
+  -g /usr/share/gir-1.0 \
+  -o ./sdk-gnome-50 \
+  --bundle '@girs/sdk-gnome-50'
+```
+
+Every namespace becomes a subpath of that package, and the namespaces reference each other
+inside it, so the whole set installs, resolves and versions as a unit:
+
+```ts
+import "@girs/sdk-gnome-50/gtk-4.0";
+import "@girs/sdk-gnome-50/adw-1";
+
+import Gtk from "gi://Gtk?version=4.0";
+```
+
+The flag implies `--package` and sets `--npmScope` to the bundle name — bundle mode is a
+different shape of the same output, not a separate generator, so it sets the options that shape
+has to have rather than asking you to keep three flags consistent.
+
+There is deliberately no barrel: importing `@girs/sdk-gnome-50` on its own is not supported,
+because a single entry point over every namespace would pull the whole set into any program that
+touches one of them. To keep the classic specifiers in an existing project, map them once:
+
+```jsonc
+// tsconfig.json
+"paths": { "@girs/*": ["./node_modules/@girs/sdk-gnome-50/*"] }
+```
+
+`--bundleMeta` merges a JSON object into the bundle's `package.json`, for provenance the
+generator cannot know — which SDK the GIR files came from, at which commit:
+
+```bash
+--bundleMeta '{"sdk":{"id":"org.gnome.Sdk","branch":"50","commit":"c87589be…"}}'
+```
+
+`name` and `exports` are computed from the generated output and cannot be overridden. The
+library versions the namespaces state about themselves are recorded automatically, under
+`libraryVersions`.
 
 ## Ambient modules
 

--- a/packages/cli/src/config/config-loader.ts
+++ b/packages/cli/src/config/config-loader.ts
@@ -92,9 +92,72 @@ function parseExternalPackagePairs(
 }
 
 /**
- * Validate the configuration
+ * npm package name: an optional `@scope/` followed by a name. Deliberately stricter than npm
+ * itself (no uppercase, no leading dot/underscore) — the value also becomes `npmScope`, so it
+ * is pasted into every generated import specifier, where a name npm would reject only fails
+ * once the bundle is published.
+ */
+const NPM_PACKAGE_NAME = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/**
+ * Parse the `--bundleMeta` JSON string. Fails loudly: the alternative is a bundle published
+ * without the provenance the caller asked for, which nothing downstream can tell apart from a
+ * bundle that never wanted any.
+ */
+function parseBundleMeta(raw: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `--bundleMeta is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("--bundleMeta must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Validate the configuration, and apply the implications `--bundle` has on other options.
+ *
+ * Bundle mode is a different SHAPE of the same output, not a separate generator: the modules
+ * are generated exactly as in package mode, and only the manifests change. So it sets the two
+ * options that shape has to have — `package` and `npmScope` — rather than asking the caller to
+ * keep three flags consistent by hand.
  */
 export function validate(config: UserConfig): UserConfig {
+  if (config.bundleMeta !== undefined && !config.bundle) {
+    throw new Error("--bundleMeta is only valid together with --bundle");
+  }
+
+  if (!config.bundle) return config;
+
+  if (!NPM_PACKAGE_NAME.test(config.bundle)) {
+    throw new Error(`--bundle is not a valid npm package name: ${config.bundle}`);
+  }
+
+  // --external-deps resolves dep imports against INSTALLED @girs/* packages, which is the exact
+  // opposite of a bundle: one deliberately reaches outside the output, the other deliberately
+  // cannot. Silently letting one win would produce a bundle with unresolvable imports.
+  if (config.externalDeps) {
+    throw new Error("--bundle cannot be combined with --external-deps");
+  }
+
+  if (config.bundleMeta) {
+    for (const reserved of ["name", "exports"]) {
+      if (reserved in config.bundleMeta) {
+        throw new Error(
+          `--bundleMeta cannot override '${reserved}' — it is computed from the generated output`,
+        );
+      }
+    }
+  }
+
+  config.package = true;
+  config.npmScope = config.bundle;
+
   return config;
 }
 
@@ -155,6 +218,12 @@ export async function load(cliOptions: ConfigFlags): Promise<UserConfig> {
   const userConfig: UserConfig = {
     ...cliOptionsClean,
   };
+
+  // `--bundleMeta` arrives as a JSON string on the CLI and as an object from an rc file.
+  // Normalize here so everything downstream sees the object form only.
+  if (typeof userConfig.bundleMeta === "string") {
+    userConfig.bundleMeta = parseBundleMeta(userConfig.bundleMeta);
+  }
   if (externalPackagesFromCli) {
     userConfig.externalPackages = externalPackagesFromCli;
   }
@@ -187,6 +256,7 @@ export async function load(cliOptions: ConfigFlags): Promise<UserConfig> {
     // String options — config file overrides CLI defaults
     const stringKeys: Array<[keyof UserConfig, unknown]> = [
       ["npmScope", options.npmScope.default],
+      ["bundle", undefined],
       ["reporterOutput", options.reporterOutput.default],
       ["depVersionFormat", undefined],
       ["theme", docOptions.theme.default],
@@ -231,6 +301,11 @@ export async function load(cliOptions: ConfigFlags): Promise<UserConfig> {
       userConfig.outdir === options.outdir.default || userConfig.outdir === defaults.docOutdir;
     if (isDefaultOutdir && configFileData.outdir) {
       userConfig.outdir = userConfig.print ? null : configFileData.outdir;
+    }
+
+    // bundleMeta is an object in rc files; a CLI --bundleMeta wins.
+    if (userConfig.bundleMeta === undefined && configFileData.bundleMeta) {
+      userConfig.bundleMeta = configFileData.bundleMeta;
     }
 
     // externalPackages is a Record<string, string> in rc files; CLI overrides take precedence.

--- a/packages/cli/src/config/options.ts
+++ b/packages/cli/src/config/options.ts
@@ -97,6 +97,16 @@ export const options: { [name: string]: Options } = {
     default: defaults.widgetVocabulary,
     normalize: true,
   },
+  bundle: {
+    type: "string",
+    description:
+      "Emit every generated namespace as ONE npm package with this name (e.g. '@girs/sdk-gnome-50'). Implies --package, sets --npmScope to the bundle name, and replaces the per-namespace manifests with a single package.json whose exports map each namespace to a subpath",
+  },
+  bundleMeta: {
+    type: "string",
+    description:
+      'JSON object merged into the bundle package.json, for provenance the generator cannot know (e.g. \'{"sdk":{"id":"org.gnome.Sdk","branch":"50"}}\'). Only valid with --bundle; cannot override \'name\' or \'exports\'',
+  },
   npmScope: {
     type: "string",
     description: "Scope of the generated NPM packages",
@@ -193,6 +203,8 @@ export const generateOptions = {
   promisify: options.promisify,
   widgetVocabulary: options.widgetVocabulary,
   npmScope: options.npmScope,
+  bundle: options.bundle,
+  bundleMeta: options.bundleMeta,
   workspace: options.workspace,
   depVersionFormat: options.depVersionFormat,
   onlyVersionPrefix: options.onlyVersionPrefix,

--- a/packages/generator-typescript/src/bundle-package.ts
+++ b/packages/generator-typescript/src/bundle-package.ts
@@ -1,0 +1,164 @@
+import { readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  APP_NAME,
+  APP_VERSION,
+  type GirModule,
+  Logger,
+  type OptionsGeneration,
+} from "@ts-for-gir/lib";
+
+/** One resolved `exports` entry. `import`/`default` are absent when no runtime file was written. */
+type ExportTarget = { types: string; import?: string; default?: string };
+
+/**
+ * Writes the single `package.json` (and README) of a `--bundle` run.
+ *
+ * The `exports` map is derived from the files that were ACTUALLY written, not from the shape a
+ * namespace is expected to have. The per-namespace subpaths are already conditional today — the
+ * widget vocabulary only exists for namespaces that declare a `GtkWidget` descendant, and the
+ * `gjs` package carries six extra files no other namespace has — so a map built from the
+ * expected shape is a second source of truth that drifts silently: a subpath that resolves to a
+ * missing file fails at the consumer, long after generation reported success.
+ */
+export class BundlePackage {
+  config: OptionsGeneration;
+  girModules: GirModule[];
+  log: Logger;
+
+  constructor(config: OptionsGeneration, girModules: GirModule[]) {
+    this.config = config;
+    this.girModules = girModules;
+    this.log = new Logger(config.verbose, BundlePackage.name);
+  }
+
+  async export(): Promise<void> {
+    const { bundle, outdir } = this.config;
+    if (!bundle || !outdir) return;
+
+    const exports = await this.collectExports(outdir);
+    const namespaceCount = Object.keys(exports).filter((key) => !key.includes("/")).length - 1;
+
+    const manifest: Record<string, unknown> = {
+      name: bundle,
+      version: APP_VERSION,
+      description: `GJS TypeScript type definitions for ${namespaceCount} namespaces, generated as one self-contained package`,
+      type: "module",
+      // No "." entry, and no "main"/"types": a barrel over every namespace would pull the whole
+      // set into any program that touches one of them, which is exactly what the per-namespace
+      // subpaths exist to avoid. Importing the bare package name fails, and it fails clearly.
+      exports,
+      ...this.libraryVersions(),
+      keywords: ["gjs", "gir", "types", "typescript", "gnome"],
+      author: APP_NAME,
+      license: "MIT",
+      bugs: { url: "https://github.com/gjsify/ts-for-gir/issues" },
+      homepage: "https://github.com/gjsify/ts-for-gir#readme",
+    };
+
+    // Merged last so provenance can also correct a computed field (a channel build numbers its
+    // own `version`); `name` and `exports` are refused in `validate()`, before generation runs.
+    Object.assign(manifest, this.config.bundleMeta ?? {});
+
+    await writeFile(join(outdir, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    await writeFile(join(outdir, "README.md"), this.readme(bundle, namespaceCount), "utf8");
+
+    this.log.log(
+      `Bundle ${bundle}: ${namespaceCount} namespaces, ${Object.keys(exports).length} subpaths`,
+    );
+  }
+
+  /**
+   * `<dir>/index.d.ts` marks a generated namespace; every other `.d.ts` beside it becomes a
+   * subpath. Three names are re-spelled to the subpaths the per-namespace packages have always
+   * published (`@girs/gtk-4.0/ambient`), so moving a project onto a bundle changes the package
+   * name and nothing else.
+   */
+  private async collectExports(outdir: string): Promise<Record<string, ExportTarget | string>> {
+    const exports: Record<string, ExportTarget | string> = {
+      "./package.json": "./package.json",
+    };
+
+    const entries = await readdir(outdir, { withFileTypes: true });
+    const dirs = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+
+    for (const dir of dirs) {
+      const files = new Set(await readdir(join(outdir, dir)));
+      if (!files.has("index.d.ts")) continue;
+
+      exports[`./${dir}`] = this.target(files, dir, "index");
+
+      for (const file of [...files].sort()) {
+        if (!file.endsWith(".d.ts") || file === "index.d.ts") continue;
+        const stem = file.slice(0, -".d.ts".length);
+        const subpath =
+          stem === `${dir}-ambient`
+            ? "ambient"
+            : stem === `${dir}-import`
+              ? "import"
+              : stem === `${dir}-vocabulary`
+                ? "vocabulary"
+                : stem;
+        exports[`./${dir}/${subpath}`] = this.target(files, dir, stem);
+      }
+    }
+
+    return exports;
+  }
+
+  private target(files: Set<string>, dir: string, stem: string): ExportTarget {
+    const target: ExportTarget = { types: `./${dir}/${stem}.d.ts` };
+    if (files.has(`${stem}.js`)) {
+      target.import = `./${dir}/${stem}.js`;
+      target.default = `./${dir}/${stem}.js`;
+    }
+    return target;
+  }
+
+  /**
+   * Only versions the library states about itself, matching the per-namespace manifests: a
+   * namespace version wearing a release's clothes (`4.0.0` for Gdk-4.0, which ships inside GTK
+   * 4.2x) reads as a skew against the installed library that does not exist.
+   */
+  private libraryVersions(): { libraryVersions?: Record<string, string> } {
+    const versions: Record<string, string> = {};
+    for (const module of this.girModules) {
+      if (module.libraryVersion?.declaredByLibrary) {
+        versions[module.importName] = String(module.libraryVersion);
+      }
+    }
+    return Object.keys(versions).length > 0 ? { libraryVersions: versions } : {};
+  }
+
+  private readme(bundle: string, namespaceCount: number): string {
+    return `# ${bundle}
+
+GJS TypeScript type definitions for ${namespaceCount} namespaces, generated by
+[ts-for-gir](https://github.com/gjsify/ts-for-gir) as **one self-contained package**.
+
+Every namespace is a subpath, and the namespaces reference each other inside the package — so
+the whole set is installed, resolved and versioned as a unit, and no namespace can end up
+resolving against a differently-versioned copy from the registry.
+
+\`\`\`ts
+import "${bundle}/gtk-4.0";
+import "${bundle}/adw-1";
+
+import Gtk from "gi://Gtk?version=4.0";
+\`\`\`
+
+There is no barrel: importing \`${bundle}\` on its own is not supported, because a single entry
+point over every namespace would pull the whole set into any program that touches one of them.
+
+To keep the classic \`@girs/*\` import specifiers in an existing project, map them once:
+
+\`\`\`jsonc
+// tsconfig.json
+"paths": { "@girs/*": ["./node_modules/${bundle}/*"] }
+\`\`\`
+`;
+  }
+}

--- a/packages/generator-typescript/src/npm-package.ts
+++ b/packages/generator-typescript/src/npm-package.ts
@@ -47,6 +47,11 @@ export class NpmPackage<Wrapped extends Dependency | GirModule> {
   }
 
   async exportNPMPackage() {
+    // In bundle mode the namespaces are directories inside ONE package, so a manifest per
+    // namespace would describe a package that does not exist — and `<bundle>/<namespace>` is
+    // not even a legal npm name. The single manifest is written once by `BundlePackage`.
+    if (this.config.bundle) return;
+
     await this.exportNPMPackageJson();
     await this.exportNPMReadme();
     await this.exportTSConfig();

--- a/packages/generator-typescript/src/type-definition-generator.ts
+++ b/packages/generator-typescript/src/type-definition-generator.ts
@@ -7,8 +7,9 @@ import {
   Reporter,
   ReporterService,
 } from "@ts-for-gir/lib";
-import { ModuleGenerator } from "./module-generator.ts";
 //import { PackageDataParser } from './package-data-parser.ts'
+import { BundlePackage } from "./bundle-package.ts";
+import { ModuleGenerator } from "./module-generator.ts";
 import { NpmPackage } from "./npm-package.ts";
 import { TemplateProcessor } from "./template-processor.ts";
 
@@ -205,6 +206,12 @@ export class TypeDefinitionGenerator implements Generator {
     // single ambient `.d.ts` for one module and the aggregator would have nothing to do.
     if (!this.config.package && !this.config.externalDeps) {
       await this.exportAllModules(girModules);
+    }
+
+    // Last: the bundle manifest reads the directory it describes, so every namespace and the
+    // GJS package have to be on disk before it runs.
+    if (this.config.bundle) {
+      await new BundlePackage(this.config, girModules).export();
     }
   }
 }

--- a/packages/lib/src/types/options-generation.ts
+++ b/packages/lib/src/types/options-generation.ts
@@ -28,6 +28,13 @@ export interface OptionsGeneration extends OptionsBase {
 	 */
 	widgetVocabulary: boolean;
 	/**
+	 * Emit every generated namespace as ONE npm package with this name (see `UserConfig.bundle`).
+	 * Implies `package`, and `npmScope` is set to it.
+	 */
+	bundle?: string;
+	/** Extra fields merged into the bundle `package.json` (see `UserConfig.bundleMeta`). */
+	bundleMeta?: Record<string, unknown>;
+	/**
 	 * Scope of the generated NPM packages
 	 * @see https://docs.npmjs.com/cli/v7/using-npm/scope
 	 */

--- a/packages/lib/src/types/user-config.ts
+++ b/packages/lib/src/types/user-config.ts
@@ -35,6 +35,29 @@ export interface UserConfig {
 	 * never emits a surface even with this on.
 	 */
 	widgetVocabulary: boolean;
+	/**
+	 * Emit every generated namespace as ONE npm package with this name, instead of one
+	 * package per namespace.
+	 *
+	 * Implies `package: true` and sets `npmScope` to this name, so cross-namespace imports
+	 * become self-reference subpaths (`@girs/sdk-gnome-50/gdk-4.0`) that resolve inside the
+	 * bundle. The per-namespace manifests are replaced by a single `package.json` at the
+	 * output root whose `exports` map every namespace to a subpath.
+	 *
+	 * The point is a closed set: a runtime-pinned type set (a Flatpak SDK, say) must never
+	 * be able to resolve half its namespaces against a differently-versioned copy from the
+	 * registry. Two copies of one namespace are not a version skew, they are duplicate
+	 * `declare module 'gi://GLib'` blocks — the "Incompatible GObject type" failure of #431.
+	 * One package cannot be installed twice at different versions, so the failure mode is
+	 * gone by construction rather than by discipline.
+	 */
+	bundle?: string;
+	/**
+	 * JSON object merged into the bundle `package.json`. Carries provenance the generator
+	 * cannot know — which SDK the GIR files came from, at which commit. Only valid together
+	 * with `bundle`; `name` and `exports` are computed and cannot be overridden.
+	 */
+	bundleMeta?: Record<string, unknown>;
 	/** Scope of the generated NPM packages */
 	npmScope: string;
 	/** Uses the workspace protocol for the generated packages which can be used with package managers like Yarn and PNPM */

--- a/packages/templates/templates/README-GJS.md
+++ b/packages/templates/templates/README-GJS.md
@@ -37,7 +37,7 @@ const <%- pkg.namespace %> = require('<%- pkg.importPath %>');
 After the import, the global types of GJS are also available:
 
 ```ts
-import '@girs/gjs';
+import '<%- npmScope %>/gjs';
 
 print('Hello World from print');
 
@@ -52,7 +52,7 @@ Some types that conflict with the DOM are outsourced to allow frameworks like Gj
 Import them explicitly:
 
 ```ts
-import '@girs/gjs/dom';
+import '<%- npmScope %>/gjs/dom';
 
 console.log('Hello World from console');
 
@@ -104,11 +104,11 @@ If you want to have types for [GObject Introspection](https://gi.readthedocs.io/
 These types will then be available to you:
 
 ```ts
-import '@girs/gjs'
-import '@girs/gjs/dom'
-import '@girs/gio-2.0'
-import '@girs/gtk-4.0'
-import '@girs/adw-1'
+import '<%- npmScope %>/gjs'
+import '<%- npmScope %>/gjs/dom'
+import '<%- npmScope %>/gio-2.0'
+import '<%- npmScope %>/gtk-4.0'
+import '<%- npmScope %>/adw-1'
 
 import Gio from 'gi://Gio?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';

--- a/packages/templates/templates/gjs/gjs-ambient.d.ts
+++ b/packages/templates/templates/gjs/gjs-ambient.d.ts
@@ -1,32 +1,38 @@
 // @ts-nocheck
 // https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules
 // https://stackoverflow.com/questions/45099605/ambient-declaration-with-an-imported-type-in-typescript
+//
+// The scope is the CONFIGURED one, never the literal `@girs`: with `--npmScope` or `--bundle`
+// this file is part of a package that is not `@girs/gjs`, and a hardcoded specifier makes it
+// reach back into the published packages instead. That is not a cosmetic mismatch — it drags a
+// second copy of GJS, GLib and GObject into the program, and every ambient declaration they
+// share is then declared twice.
 
 declare module 'gettext' {
-    export * from '@girs/gjs/gettext'
-    import Gettext from '@girs/gjs/gettext'
+    export * from '<%- npmScope %>/gjs/gettext'
+    import Gettext from '<%- npmScope %>/gjs/gettext'
     export default Gettext
 }
 
 declare module 'system' {
-    export * from '@girs/gjs/system'
-    import System from '@girs/gjs/system'
+    export * from '<%- npmScope %>/gjs/system'
+    import System from '<%- npmScope %>/gjs/system'
     export default System
 }
 
 declare module 'cairo' {
-    import Cairo from '@girs/gjs/cairo'
+    import Cairo from '<%- npmScope %>/gjs/cairo'
     export default Cairo
 }
 
 declare module 'console' {
-    import Console, { setConsoleLogDomain, getConsoleLogDomain, DEFAULT_LOG_DOMAIN } from '@girs/gjs/console'
+    import Console, { setConsoleLogDomain, getConsoleLogDomain, DEFAULT_LOG_DOMAIN } from '<%- npmScope %>/gjs/console'
     export { setConsoleLogDomain, getConsoleLogDomain, DEFAULT_LOG_DOMAIN }
     export default Console
 }
 
 declare module 'gi' {
-    import Gi, { require } from '@girs/gjs/gi'
+    import Gi, { require } from '<%- npmScope %>/gjs/gi'
     export { require }
     export default Gi
 }

--- a/tests/bundle/.ts-for-gir.rc.js
+++ b/tests/bundle/.ts-for-gir.rc.js
@@ -1,0 +1,13 @@
+export default {
+  // Also the npmScope: every cross-namespace import inside the output is written as
+  // `@girs-test/bundle-fixture/<namespace>`, a self-reference that resolves in-package.
+  bundle: "@girs-test/bundle-fixture",
+  girDirectories: ["../external-deps/fixtures", "../../girs"],
+  modules: ["Greeter-1.0"],
+  outdir: "./generated",
+  bundleMeta: {
+    sdk: { id: "org.example.Sdk", branch: "1" },
+  },
+  ignoreVersionConflicts: true,
+  reporter: false,
+};

--- a/tests/bundle/assert.mjs
+++ b/tests/bundle/assert.mjs
@@ -1,0 +1,146 @@
+// Asserts the shape of a --bundle run: ONE manifest, every namespace on a subpath, every
+// subpath resolving to a file that exists, and cross-namespace imports pointing inside the
+// bundle. Bytewise snapshots would be brittle (formatter, dep bumps); these are the properties
+// a consumer actually depends on.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outdir = join(here, "generated");
+const BUNDLE = "@girs-test/bundle-fixture";
+
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+const manifestPath = join(outdir, "package.json");
+if (!existsSync(manifestPath)) {
+  console.error(`no bundle manifest at ${manifestPath}`);
+  process.exit(1);
+}
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+// --- the manifest itself -----------------------------------------------------------------
+if (manifest.name !== BUNDLE) fail(`name: expected ${BUNDLE}, got ${manifest.name}`);
+if (typeof manifest.version !== "string") fail("version: missing");
+if (manifest.type !== "module") fail("type: expected 'module'");
+for (const forbidden of ["main", "types", "module"]) {
+  if (forbidden in manifest) fail(`${forbidden}: a bundle has no single entry point`);
+}
+if ("." in (manifest.exports ?? {})) fail("exports['.']: a bundle must not publish a barrel");
+
+// --bundleMeta merged
+if (manifest.sdk?.id !== "org.example.Sdk")
+  fail(`bundleMeta not merged: sdk=${JSON.stringify(manifest.sdk)}`);
+
+// libraryVersions: only strings, and only for libraries that state their own version. GLib
+// states one, the Greeter fixture does not — so both directions are covered by real data.
+if (typeof manifest.libraryVersions?.["glib-2.0"] !== "string") {
+  fail("libraryVersions['glib-2.0']: GLib states its own version and must be recorded");
+}
+if ("greeter-1.0" in (manifest.libraryVersions ?? {})) {
+  fail("libraryVersions['greeter-1.0']: the fixture states no version of its own");
+}
+if (manifest.libraryVersions !== undefined) {
+  if (typeof manifest.libraryVersions !== "object" || Array.isArray(manifest.libraryVersions)) {
+    fail("libraryVersions: not an object");
+  } else {
+    for (const [ns, version] of Object.entries(manifest.libraryVersions)) {
+      if (typeof version !== "string" || version.length === 0) {
+        fail(`libraryVersions[${ns}]: not a version string (${JSON.stringify(version)})`);
+      }
+    }
+  }
+}
+
+// --- exactly one manifest, and no per-namespace manifests ---------------------------------
+const walk = (dir) => {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+};
+const allFiles = walk(outdir);
+const strays = allFiles.filter((f) => {
+  const rel = f.slice(outdir.length + 1);
+  if (!rel.includes("/")) return false; // root files are fine
+  return ["package.json", "tsconfig.json", "typedoc.json"].includes(rel.split("/").pop());
+});
+if (strays.length > 0) {
+  fail(
+    `per-namespace manifests must not be emitted in bundle mode: ${strays.map((f) => f.slice(outdir.length + 1)).join(", ")}`,
+  );
+}
+
+// --- every export target exists ------------------------------------------------------------
+// The assertion that catches a drifting map: an exports entry pointing at a file that was never
+// written fails at the consumer, long after generation reported success.
+let checkedTargets = 0;
+for (const [subpath, target] of Object.entries(manifest.exports ?? {})) {
+  const paths = typeof target === "string" ? [target] : Object.values(target);
+  for (const relative of paths) {
+    checkedTargets++;
+    const full = join(outdir, relative);
+    if (!existsSync(full) || !statSync(full).isFile()) {
+      fail(`exports['${subpath}'] -> ${relative} does not exist`);
+    }
+  }
+}
+if (checkedTargets === 0) fail("exports: empty");
+
+// --- and the other direction: every generated namespace is exported ------------------------
+const namespaceDirs = readdirSync(outdir, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && existsSync(join(outdir, e.name, "index.d.ts")))
+  .map((e) => e.name);
+if (namespaceDirs.length < 2)
+  fail(`expected a multi-namespace bundle, got ${namespaceDirs.length}`);
+for (const dir of namespaceDirs) {
+  if (!(`./${dir}` in manifest.exports)) fail(`namespace ${dir} generated but not exported`);
+}
+for (const required of ["greeter-1.0", "gjs"]) {
+  if (!namespaceDirs.includes(required))
+    fail(`expected namespace missing from output: ${required}`);
+}
+// The gjs package carries files no other namespace has — proof the map follows the output
+// rather than a fixed per-namespace shape.
+for (const required of ["./gjs/dom", "./gjs/console", "./greeter-1.0/ambient"]) {
+  if (!(required in manifest.exports)) fail(`expected subpath missing: ${required}`);
+}
+
+// --- cross-namespace imports stay inside the bundle ----------------------------------------
+const moduleFile = join(outdir, "greeter-1.0", "greeter-1.0.d.ts");
+const moduleSource = existsSync(moduleFile) ? readFileSync(moduleFile, "utf8") : "";
+if (!moduleSource) fail(`missing ${moduleFile}`);
+if (!new RegExp(`from '${BUNDLE.replace("/", "\\/")}/gobject-2\\.0'`).test(moduleSource)) {
+  fail("cross-namespace import does not point into the bundle");
+}
+if (/from '@girs\//.test(moduleSource)) {
+  fail("cross-namespace import escapes to the published @girs/* packages");
+}
+
+// And the same over the WHOLE tree, not just the module that happens to be under test. A single
+// specifier left at the literal `@girs` — the GJS ambient template had one — pulls a second copy
+// of GJS, GLib and GObject into the consumer's program, where every shared ambient declaration
+// is then declared twice. That is the failure this whole package shape exists to prevent, so it
+// is checked everywhere code is emitted, not by sampling.
+const escapes = allFiles
+  .filter((f) => f.endsWith(".d.ts") || f.endsWith(".js"))
+  .filter((f) => /['"]@girs\/(?!\w)|['"]@girs\/[a-z]/.test(readFileSync(f, "utf8")))
+  .map((f) => f.slice(outdir.length + 1));
+if (escapes.length > 0) {
+  fail(`files reaching outside the bundle to @girs/*: ${escapes.join(", ")}`);
+}
+
+if (failures.length > 0) {
+  console.error("bundle assertion failures:");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log(
+  `OK: ${BUNDLE} — ${namespaceDirs.length} namespaces, ${Object.keys(manifest.exports).length} subpaths, ${checkedTargets} targets all present`,
+);

--- a/tests/bundle/controls.mjs
+++ b/tests/bundle/controls.mjs
@@ -1,0 +1,90 @@
+// The controls. A gate that only checks the happy path cannot tell "the flag works" from "the
+// output happens to look like that anyway", so each of these must go the OTHER way.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+
+const bin = [
+  join(here, "node_modules", ".bin", "ts-for-gir-dev"),
+  join(repoRoot, "node_modules", ".bin", "ts-for-gir-dev"),
+].find((candidate) => existsSync(candidate));
+
+if (!bin) {
+  console.error("ts-for-gir-dev not found — run `gjsify install` first");
+  process.exit(1);
+}
+
+const run = (args) =>
+  spawnSync(bin, args, { cwd: here, encoding: "utf8", env: { ...process.env, NO_COLOR: "1" } });
+
+const failures = [];
+const GIRS = ["--girDirectories", "../external-deps/fixtures", "--girDirectories", "../../girs"];
+const COMMON = [
+  "generate",
+  "Greeter-1.0",
+  ...GIRS,
+  "--ignoreVersionConflicts",
+  "--configName",
+  "none.rc.js",
+];
+
+// 1. --bundleMeta without --bundle is a contradiction, not a silently ignored flag.
+{
+  const result = run([...COMMON, "--outdir", "./control-package", "--bundleMeta", '{"sdk":"x"}']);
+  if (result.status === 0) failures.push("--bundleMeta without --bundle exited 0");
+  else if (!`${result.stderr}${result.stdout}`.includes("--bundleMeta is only valid"))
+    failures.push(
+      `--bundleMeta without --bundle failed for the wrong reason: ${result.stderr.trim().split("\n").pop()}`,
+    );
+}
+
+// 2. A name npm would reject must fail before anything is generated, not at publish time.
+{
+  const result = run([...COMMON, "--outdir", "./control-package", "--bundle", "Not A Name"]);
+  if (result.status === 0) failures.push("--bundle with an invalid package name exited 0");
+  else if (!`${result.stderr}${result.stdout}`.includes("not a valid npm package name"))
+    failures.push(
+      `invalid --bundle failed for the wrong reason: ${result.stderr.trim().split("\n").pop()}`,
+    );
+}
+
+// 3. Without --bundle the SAME inputs must produce the opposite shape: a manifest per
+//    namespace and no manifest at the root. This is what proves the flag does the work.
+{
+  const controlDir = join(here, "control-package");
+  rmSync(controlDir, { recursive: true, force: true });
+  const result = run([...COMMON, "--outdir", "./control-package", "--package"]);
+  if (result.status !== 0) {
+    failures.push(
+      `control run (plain package mode) failed: ${result.stderr.trim().split("\n").pop()}`,
+    );
+  } else {
+    if (existsSync(join(controlDir, "package.json"))) {
+      failures.push(
+        "plain package mode wrote a root manifest — the bundle assertions prove nothing",
+      );
+    }
+    const perNamespace = readdirSync(controlDir, { withFileTypes: true }).filter(
+      (e) => e.isDirectory() && existsSync(join(controlDir, e.name, "package.json")),
+    );
+    if (perNamespace.length === 0) {
+      failures.push("plain package mode wrote no per-namespace manifests — the control is broken");
+    }
+  }
+  rmSync(controlDir, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error("bundle control failures:");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log(
+  "OK: controls — bad flags rejected, and plain package mode still emits per-namespace manifests",
+);

--- a/tests/bundle/main.ts
+++ b/tests/bundle/main.ts
@@ -1,0 +1,9 @@
+// Compiles ONLY if the emitted exports map resolves: the subpath below is served by the bundle
+// package.json, and `gi://Greeter` by the ambient declaration it pulls in.
+import "@girs-test/bundle-fixture/greeter-1.0";
+
+import Greeter from "gi://Greeter?version=1.0";
+
+const hello = new Greeter.HelloWorld();
+
+export const greeting: string = hello.say_hello("world");

--- a/tests/bundle/package.json
+++ b/tests/bundle/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@ts-for-gir-test/bundle",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "test": "gjsify run clear && gjsify run generate && gjsify run assert && gjsify run controls && gjsify run link && gjsify run check:types",
+        "generate": "ts-for-gir-dev generate --configName .ts-for-gir.rc.js",
+        "assert": "node --no-warnings assert.mjs",
+        "controls": "node --no-warnings controls.mjs",
+        "link": "mkdir -p node_modules/@girs-test && ln -sfn ../../generated node_modules/@girs-test/bundle-fixture",
+        "check:types": "tsc --noEmit",
+        "clear": "rm -rf generated control-package node_modules/@girs-test"
+    },
+    "devDependencies": {
+        "@ts-for-gir/cli": "workspace:^",
+        "typescript": "^6.0.3"
+    }
+}

--- a/tests/bundle/tsconfig.json
+++ b/tests/bundle/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["ESNext"],
+    "moduleResolution": "bundler",
+    "skipLibCheck": false,
+    "types": [],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true
+  },
+  "include": ["main.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
Types pinned to one runtime need a closed set. `--package` cannot give one: npm is free to satisfy `@girs/glib-2.0` from the registry for one namespace and from a pinned copy for another, and two copies of a namespace are not a version skew — they are duplicate `declare module 'gi://GLib'` blocks. That is #431, the "Incompatible GObject type" error.

`--bundle '@girs/sdk-gnome-50'` emits every generated namespace as ONE self-contained package: each becomes a subpath, and cross-namespace imports become self-references that resolve in-package. One package cannot be installed twice at different versions, so the failure mode is gone by construction.

```bash
ts-for-gir generate '*' -g /usr/share/gir-1.0 -o ./sdk-gnome-50 --bundle '@girs/sdk-gnome-50'
```

```ts
import "@girs/sdk-gnome-50/gtk-4.0";
import Gtk from "gi://Gtk?version=4.0";
```

The immediate use is the request in #462 (Workbench): a Flatpak app is tied to one runtime version, the SDK ships the GIR XML the Platform runtime does not, and `org.gnome.Sdk//50` carries Gtk 4.22.4 while today's `@girs/gtk-4.0@latest` is 4.23.3.

### What is in here

- `--bundle <name>` implies `--package` and sets `--npmScope`, in `validate()` — bundle mode is a different shape of the same output, not a separate generator.
- `--bundleMeta '<json>'` merges provenance the generator cannot know (which SDK, which commit). `name` and `exports` are computed and refused there.
- The exports map is built from the files actually **written**, never from the shape a namespace is expected to have — the subpaths are already conditional (widget vocabulary, and `gjs` carries six files no other namespace has), so an expected-shape map drifts into a subpath resolving to nothing.
- A pre-existing defect fixed on the way: `gjs-ambient.d.ts` imported from the literal `@girs/gjs/…` instead of `npmScope`, so under any non-default scope the generated package reached back into the published one. Measured: 35 TypeScript errors, 14 `Duplicate identifier` and 12 `Cannot redeclare block-scoped variable`, none naming the file that caused them.

### Gate

`tests/bundle` generates a 7-namespace bundle from the Greeter fixture and holds it to four properties: exactly one manifest, every exports target present on disk, every generated namespace exported, and no specifier anywhere in the tree reaching back to `@girs/*`. It then compiles a consumer against the emitted map — which is what proves the map resolves rather than merely looks right; removing one exports entry turns it red with TS2307.

Three controls must go the other way: `--bundleMeta` without `--bundle`, an invalid package name, and the same inputs in plain package mode, which must still produce per-namespace manifests and no root one.

Companion PR in `gjsify/types` publishes one such bundle per Flatpak SDK channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvMH98Xsfh6rAJK5HRfxFq