### PR TITLE
fix(generator)!: enforce typed signals

### DIFF
--- a/examples/di-needle/main.ts
+++ b/examples/di-needle/main.ts
@@ -208,6 +208,10 @@ class GObjectUserService extends GObject.Object {
 }
 
 // GObject-based Application service
+interface GObjectAppSignals extends Gio.Application.SignalSignatures {
+  "user-processed": (userName: string, userId: string) => void;
+}
+
 @injectable()
 class GObjectApp extends Gio.Application {
   static {
@@ -234,6 +238,27 @@ class GObjectApp extends Gio.Application {
   }
 
   private _appName = "User Management App";
+
+  override connect<K extends keyof GObjectAppSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
+  ): number {
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof GObjectAppSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof GObjectAppSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<GObjectAppSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
+  }
 
   constructor(
     public readonly userService = inject(GObjectUserService),

--- a/examples/di-needle/main.ts
+++ b/examples/di-needle/main.ts
@@ -239,26 +239,9 @@ class GObjectApp extends Gio.Application {
 
   private _appName = "User Management App";
 
-  override connect<K extends keyof GObjectAppSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
-
-  override connect_after<K extends keyof GObjectAppSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof GObjectAppSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<GObjectAppSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
-  }
+  declare connect: GObject.SignalMethods<this, GObjectAppSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, GObjectAppSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, GObjectAppSignals>["emit"];
 
   constructor(
     public readonly userService = inject(GObjectUserService),

--- a/examples/di-tsyringe/main.ts
+++ b/examples/di-tsyringe/main.ts
@@ -208,6 +208,10 @@ class GObjectUserService extends GObject.Object {
 }
 
 // GObject-based Application service
+interface GObjectAppSignals extends Gio.Application.SignalSignatures {
+  "user-processed": (userName: string, userId: string) => void;
+}
+
 @injectable()
 class GObjectApp extends Gio.Application {
   static {
@@ -234,6 +238,27 @@ class GObjectApp extends Gio.Application {
   }
 
   private _appName = "User Management App";
+
+  override connect<K extends keyof GObjectAppSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
+  ): number {
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof GObjectAppSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof GObjectAppSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<GObjectAppSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
+  }
 
   constructor(
     @inject(GObjectUserService) public readonly userService: GObjectUserService,

--- a/examples/di-tsyringe/main.ts
+++ b/examples/di-tsyringe/main.ts
@@ -239,26 +239,9 @@ class GObjectApp extends Gio.Application {
 
   private _appName = "User Management App";
 
-  override connect<K extends keyof GObjectAppSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
-
-  override connect_after<K extends keyof GObjectAppSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, GObjectAppSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof GObjectAppSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<GObjectAppSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
-  }
+  declare connect: GObject.SignalMethods<this, GObjectAppSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, GObjectAppSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, GObjectAppSignals>["emit"];
 
   constructor(
     @inject(GObjectUserService) public readonly userService: GObjectUserService,

--- a/examples/gio-2-list-model/main.ts
+++ b/examples/gio-2-list-model/main.ts
@@ -31,26 +31,9 @@ export class GjsListStore
   declare get_item_type: Gio.ListModel["get_item_type"];
   declare get_n_items: Gio.ListModel["get_n_items"];
 
-  override connect<K extends keyof GjsListStoreSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, GjsListStoreSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
-
-  override connect_after<K extends keyof GjsListStoreSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, GjsListStoreSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof GjsListStoreSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<GjsListStoreSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
-  }
+  declare connect: GObject.SignalMethods<this, GjsListStoreSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, GjsListStoreSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, GjsListStoreSignals>["emit"];
 
   static {
     GObject.registerClass(

--- a/examples/gio-2-list-model/main.ts
+++ b/examples/gio-2-list-model/main.ts
@@ -7,6 +7,10 @@
 import Gio from "gi://Gio?version=2.0";
 import GObject from "gi://GObject?version=2.0";
 
+// Include signals provided by the registered GObject interface.
+interface GjsListStoreSignals
+  extends GObject.Object.SignalSignatures, Gio.ListModel.SignalSignatures {}
+
 /**
  * An example of implementing the GListModel interface using the new virtual interface pattern.
  *
@@ -26,6 +30,27 @@ export class GjsListStore
   declare get_item: Gio.ListModel["get_item"];
   declare get_item_type: Gio.ListModel["get_item_type"];
   declare get_n_items: Gio.ListModel["get_n_items"];
+
+  override connect<K extends keyof GjsListStoreSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, GjsListStoreSignals[K]>,
+  ): number {
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof GjsListStoreSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, GjsListStoreSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof GjsListStoreSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<GjsListStoreSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
+  }
 
   static {
     GObject.registerClass(

--- a/examples/gobject-param-spec/main.ts
+++ b/examples/gobject-param-spec/main.ts
@@ -1,3 +1,4 @@
+import "./strict-signals.js";
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
 import GObject from "gi://GObject";

--- a/examples/gobject-param-spec/strict-signals.ts
+++ b/examples/gobject-param-spec/strict-signals.ts
@@ -1,0 +1,101 @@
+// Rationale: real Gio signals must retain inference when untyped fallbacks are omitted.
+import Gio from "gi://Gio?version=2.0";
+import GObject from "gi://GObject?version=2.0";
+
+const action = new Gio.SimpleAction({ name: "strict-signals" });
+let calls = 0;
+action.connect("activate", (source, parameter) => {
+  if (source !== action || parameter !== null) throw new Error("Unexpected signal arguments");
+  calls++;
+});
+const after = action.connect_after("activate", (source) => {
+  if (source.name !== "strict-signals") throw new Error("Emitter type lost");
+  calls++;
+});
+action.emit("activate", null);
+action.disconnect(after);
+if (calls !== 2) throw new Error(`Expected two callbacks, got ${calls}`);
+print("Strict signal connections and emission passed.");
+
+// Rationale: registerClass signals absent from GIR need all three typed overrides.
+interface StrictSignalActionSignals extends Gio.SimpleAction.SignalSignatures {
+  "value-changed": (value: number, label: string) => void;
+}
+
+class StrictSignalAction extends Gio.SimpleAction {
+  static {
+    GObject.registerClass(
+      {
+        GTypeName: "StrictSignalAction",
+        Signals: {
+          "value-changed": {
+            flags: GObject.SignalFlags.RUN_LAST,
+            param_types: [GObject.TYPE_INT, GObject.TYPE_STRING],
+          },
+        },
+      },
+      StrictSignalAction,
+    );
+  }
+
+  override connect<K extends keyof StrictSignalActionSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, StrictSignalActionSignals[K]>,
+  ): number {
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof StrictSignalActionSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, StrictSignalActionSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof StrictSignalActionSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<StrictSignalActionSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
+  }
+}
+
+const customAction = new StrictSignalAction({ name: "custom-signals" });
+const received: string[] = [];
+const firstHandler = customAction.connect("value-changed", (source, value, label) => {
+  const amount: number = value;
+  const text: string = label;
+  received.push(
+    source === customAction ? `connect:${source.name}:${amount}:${text}` : "wrong source",
+  );
+});
+const afterHandler = customAction.connect_after("value-changed", (source, value, label) => {
+  const amount: number = value;
+  const text: string = label;
+  received.push(
+    source === customAction ? `after:${source.name}:${amount}:${text}` : "wrong source",
+  );
+});
+customAction.emit("value-changed", 42, "answer");
+customAction.disconnect(firstHandler);
+customAction.emit("value-changed", 7, "remaining");
+customAction.disconnect(afterHandler);
+customAction.emit("value-changed", 0, "disconnected");
+const expected = [
+  "connect:custom-signals:42:answer",
+  "after:custom-signals:42:answer",
+  "after:custom-signals:7:remaining",
+];
+if (JSON.stringify(received) !== JSON.stringify(expected)) {
+  throw new Error(`Unexpected custom signal callbacks: ${JSON.stringify(received)}`);
+}
+let inheritedCalls = 0;
+customAction.connect("activate", (_source, parameter) => {
+  if (parameter === null) inheritedCalls++;
+});
+customAction.connect_after("activate", (_source, parameter) => {
+  if (parameter === null) inheritedCalls++;
+});
+customAction.emit("activate", null);
+if (inheritedCalls !== 2) throw new Error("Inherited signal callbacks were lost");
+print("Registered custom signals and inherited signals passed.");

--- a/examples/gobject-param-spec/strict-signals.ts
+++ b/examples/gobject-param-spec/strict-signals.ts
@@ -17,7 +17,7 @@ action.disconnect(after);
 if (calls !== 2) throw new Error(`Expected two callbacks, got ${calls}`);
 print("Strict signal connections and emission passed.");
 
-// Rationale: registerClass signals absent from GIR need all three typed overrides.
+// Rationale: SignalMethods refines registered signals without replacing GJS methods.
 interface StrictSignalActionSignals extends Gio.SimpleAction.SignalSignatures {
   "value-changed": (value: number, label: string) => void;
 }
@@ -38,25 +38,12 @@ class StrictSignalAction extends Gio.SimpleAction {
     );
   }
 
-  override connect<K extends keyof StrictSignalActionSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, StrictSignalActionSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
+  declare connect: GObject.SignalMethods<this, StrictSignalActionSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, StrictSignalActionSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, StrictSignalActionSignals>["emit"];
 
-  override connect_after<K extends keyof StrictSignalActionSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, StrictSignalActionSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof StrictSignalActionSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<StrictSignalActionSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
+  publishValue(value: number, label: string): void {
+    this.emit("value-changed", value, label);
   }
 }
 
@@ -76,7 +63,7 @@ const afterHandler = customAction.connect_after("value-changed", (source, value,
     source === customAction ? `after:${source.name}:${amount}:${text}` : "wrong source",
   );
 });
-customAction.emit("value-changed", 42, "answer");
+customAction.publishValue(42, "answer");
 customAction.disconnect(firstHandler);
 customAction.emit("value-changed", 7, "remaining");
 customAction.disconnect(afterHandler);

--- a/examples/gtk-3-builder/main.ts
+++ b/examples/gtk-3-builder/main.ts
@@ -17,12 +17,12 @@ win.connect("destroy", () => {
   return true;
 });
 
-const closeButton = builder.get_object("closeButton");
+const closeButton = builder.get_object("closeButton") as Gtk.Button | null;
 if (!closeButton) {
   throw new Error("Builder object closeButton not found!");
 }
 
-const actionButton = builder.get_object("actionButton");
+const actionButton = builder.get_object("actionButton") as Gtk.Button | null;
 if (!actionButton) {
   throw new Error("Builder object actionButton not found!");
 }

--- a/examples/gtk-4-application/main.ts
+++ b/examples/gtk-4-application/main.ts
@@ -47,26 +47,9 @@ class ExampleApplication extends Gtk.Application {
   // Define a custom signal interface as instance property
   declare $signals: ExampleApplicationSignals;
 
-  override connect<K extends keyof ExampleApplicationSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, ExampleApplicationSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
-
-  override connect_after<K extends keyof ExampleApplicationSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, ExampleApplicationSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof ExampleApplicationSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<ExampleApplicationSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
-  }
+  declare connect: GObject.SignalMethods<this, ExampleApplicationSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, ExampleApplicationSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, ExampleApplicationSignals>["emit"];
 
   constructor() {
     super({

--- a/examples/gtk-4-application/main.ts
+++ b/examples/gtk-4-application/main.ts
@@ -20,7 +20,7 @@ import System from "system";
 
 // Define a custom signal interface
 interface ExampleApplicationSignals extends Gtk.Application.SignalSignatures {
-  hello: (arg: string) => void;
+  examplesig: (arg: number) => void;
 }
 
 // An example GtkApplication with a few bells and whistles, see also:
@@ -51,7 +51,21 @@ class ExampleApplication extends Gtk.Application {
     signal: K,
     callback: GObject.SignalCallback<this, ExampleApplicationSignals[K]>,
   ): number {
-    return super.connect(signal, callback);
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof ExampleApplicationSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, ExampleApplicationSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof ExampleApplicationSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<ExampleApplicationSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
   }
 
   constructor() {

--- a/examples/gtk-4-signal-helpers/main.tsx
+++ b/examples/gtk-4-signal-helpers/main.tsx
@@ -37,26 +37,9 @@ class MyButton extends Gtk.Button {
     );
   }
 
-  override connect<K extends keyof MyButtonSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
-
-  override connect_after<K extends keyof MyButtonSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof MyButtonSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<MyButtonSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
-  }
+  declare connect: GObject.SignalMethods<this, MyButtonSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, MyButtonSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, MyButtonSignals>["emit"];
 
   triggerCustomSignal() {
     this.emit("my-signal", 42);

--- a/examples/gtk-4-signal-helpers/main.tsx
+++ b/examples/gtk-4-signal-helpers/main.tsx
@@ -41,7 +41,21 @@ class MyButton extends Gtk.Button {
     signal: K,
     callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
   ): number {
-    return super.connect(signal, callback);
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof MyButtonSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof MyButtonSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<MyButtonSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
   }
 
   triggerCustomSignal() {
@@ -89,7 +103,7 @@ function jsx<T extends GObject.Object>(widget: T, props: ElementProps<T>): T {
         .toLowerCase()
         .replace(/^-/, ""); // Remove leading dash if any
 
-      widget.connect(signalName, handler as AnySignalCallback<T>);
+      GObject.signal_connect(widget, signalName, handler as AnySignalCallback<T>);
     }
   }
 

--- a/examples/gtk-4-signal-interfaces/main.ts
+++ b/examples/gtk-4-signal-interfaces/main.ts
@@ -137,7 +137,21 @@ app.connect("activate", () => {
       signal: K,
       callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
     ): number {
-      return super.connect(signal, callback);
+      return GObject.signal_connect(this, signal, callback);
+    }
+
+    override connect_after<K extends keyof MyButtonSignals>(
+      signal: K,
+      callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
+    ): number {
+      return GObject.signal_connect_after(this, signal, callback);
+    }
+
+    override emit<K extends keyof MyButtonSignals>(
+      signal: K,
+      ...args: GObject.GjsParameters<MyButtonSignals[K]>
+    ): void {
+      GObject.signal_emit_by_name(this, signal, ...args);
     }
 
     public customMethod() {

--- a/examples/gtk-4-signal-interfaces/main.ts
+++ b/examples/gtk-4-signal-interfaces/main.ts
@@ -133,26 +133,9 @@ app.connect("activate", () => {
     // Define a custom signal interface as instance property
     declare $signals: MyButtonSignals;
 
-    override connect<K extends keyof MyButtonSignals>(
-      signal: K,
-      callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
-    ): number {
-      return GObject.signal_connect(this, signal, callback);
-    }
-
-    override connect_after<K extends keyof MyButtonSignals>(
-      signal: K,
-      callback: GObject.SignalCallback<this, MyButtonSignals[K]>,
-    ): number {
-      return GObject.signal_connect_after(this, signal, callback);
-    }
-
-    override emit<K extends keyof MyButtonSignals>(
-      signal: K,
-      ...args: GObject.GjsParameters<MyButtonSignals[K]>
-    ): void {
-      GObject.signal_emit_by_name(this, signal, ...args);
-    }
+    declare connect: GObject.SignalMethods<this, MyButtonSignals>["connect"];
+    declare connect_after: GObject.SignalMethods<this, MyButtonSignals>["connect_after"];
+    declare emit: GObject.SignalMethods<this, MyButtonSignals>["emit"];
 
     public customMethod() {
       this.emit("hello", "world");

--- a/examples/virtual-interface-test/main.ts
+++ b/examples/virtual-interface-test/main.ts
@@ -2,6 +2,10 @@ import Gdk from "gi://Gdk";
 import Gio from "gi://Gio";
 import GObject from "gi://GObject";
 
+// Include signals provided by the registered GObject interface.
+interface CustomListModelSignals
+  extends GObject.Object.SignalSignatures, Gio.ListModel.SignalSignatures {}
+
 /**
  * Example demonstrating the new virtual interface functionality.
  *
@@ -23,6 +27,27 @@ class CustomListModel extends GObject.Object implements Gio.ListModel.Interface<
   declare get_item: Gio.ListModel["get_item"];
   declare get_item_type: Gio.ListModel["get_item_type"];
   declare get_n_items: Gio.ListModel["get_n_items"];
+
+  override connect<K extends keyof CustomListModelSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, CustomListModelSignals[K]>,
+  ): number {
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof CustomListModelSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, CustomListModelSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof CustomListModelSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<CustomListModelSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
+  }
 
   static {
     GObject.registerClass(

--- a/examples/virtual-interface-test/main.ts
+++ b/examples/virtual-interface-test/main.ts
@@ -28,26 +28,9 @@ class CustomListModel extends GObject.Object implements Gio.ListModel.Interface<
   declare get_item_type: Gio.ListModel["get_item_type"];
   declare get_n_items: Gio.ListModel["get_n_items"];
 
-  override connect<K extends keyof CustomListModelSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, CustomListModelSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
-
-  override connect_after<K extends keyof CustomListModelSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, CustomListModelSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof CustomListModelSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<CustomListModelSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
-  }
+  declare connect: GObject.SignalMethods<this, CustomListModelSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, CustomListModelSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, CustomListModelSignals>["emit"];
 
   static {
     GObject.registerClass(

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -740,8 +740,10 @@ This is a breaking change: the permissive `string`/`any` fallback overloads have
 `emit` takes every declared signal argument; the emitter is only added to connection callbacks.
 
 For a `GObject.registerClass` subclass, extend the parent's `SignalSignatures` with your custom
-signals and override all three methods. Keep the signatures consistent with the registered
-`param_types`; the signal interface lists arguments without the emitter:
+signals and declare all three methods using `GObject.SignalMethods`. These declarations only
+refine the types; they emit no JavaScript and keep the inherited GJS implementations.
+Keep the signatures consistent with the registered `param_types`; the signal interface lists
+arguments without the emitter:
 
 ```ts
 import GObject from "gi://GObject?version=2.0";
@@ -763,26 +765,9 @@ class Counter extends GObject.Object {
     );
   }
 
-  override connect<K extends keyof CounterSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, CounterSignals[K]>,
-  ): number {
-    return GObject.signal_connect(this, signal, callback);
-  }
-
-  override connect_after<K extends keyof CounterSignals>(
-    signal: K,
-    callback: GObject.SignalCallback<this, CounterSignals[K]>,
-  ): number {
-    return GObject.signal_connect_after(this, signal, callback);
-  }
-
-  override emit<K extends keyof CounterSignals>(
-    signal: K,
-    ...args: GObject.GjsParameters<CounterSignals[K]>
-  ): void {
-    GObject.signal_emit_by_name(this, signal, ...args);
-  }
+  declare connect: GObject.SignalMethods<this, CounterSignals>["connect"];
+  declare connect_after: GObject.SignalMethods<this, CounterSignals>["connect_after"];
+  declare emit: GObject.SignalMethods<this, CounterSignals>["emit"];
 }
 
 const counter = new Counter();

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -731,3 +731,75 @@ The `--reporterOutput` option specifies the output file path for the reporter. T
 ```bash
 ts-for-gir generate * --reporterOutput custom-report.json
 ```
+
+### Signal type checking
+
+Generated `connect`, `connect_after`, and `emit` methods only accept signals described by GIR.
+This makes misspelled signal names and incompatible callback parameters TypeScript errors.
+This is a breaking change: the permissive `string`/`any` fallback overloads have been removed.
+`emit` takes every declared signal argument; the emitter is only added to connection callbacks.
+
+For a `GObject.registerClass` subclass, extend the parent's `SignalSignatures` with your custom
+signals and override all three methods. Keep the signatures consistent with the registered
+`param_types`; the signal interface lists arguments without the emitter:
+
+```ts
+import GObject from "gi://GObject?version=2.0";
+
+interface CounterSignals extends GObject.Object.SignalSignatures {
+  "count-changed": (count: number) => void;
+}
+
+class Counter extends GObject.Object {
+  static {
+    GObject.registerClass(
+      {
+        GTypeName: "SignalExampleCounter",
+        Signals: {
+          "count-changed": { param_types: [GObject.TYPE_INT] },
+        },
+      },
+      Counter,
+    );
+  }
+
+  override connect<K extends keyof CounterSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, CounterSignals[K]>,
+  ): number {
+    return GObject.signal_connect(this, signal, callback);
+  }
+
+  override connect_after<K extends keyof CounterSignals>(
+    signal: K,
+    callback: GObject.SignalCallback<this, CounterSignals[K]>,
+  ): number {
+    return GObject.signal_connect_after(this, signal, callback);
+  }
+
+  override emit<K extends keyof CounterSignals>(
+    signal: K,
+    ...args: GObject.GjsParameters<CounterSignals[K]>
+  ): void {
+    GObject.signal_emit_by_name(this, signal, ...args);
+  }
+}
+
+const counter = new Counter();
+counter.connect("count-changed", (_source, count) => console.log(count.toFixed()));
+counter.connect_after("count-changed", (_source, count) => console.log(count.toFixed()));
+counter.emit("count-changed", 1);
+```
+
+For a class registered with `Implements: [Gio.ListModel]`, also extend
+`Gio.ListModel.SignalSignatures` in its signal interface, alongside the parent signatures.
+This preserves type checking for interface signals such as `items-changed`.
+See the [list model example](../../examples/gio-2-list-model/main.ts) and the
+[custom signal runtime example](../../examples/gobject-param-spec/strict-signals.ts).
+
+`notify::` details remain unchecked: the inherited `` [key: `notify::${string}`] `` index
+signature accepts any property name, including misspellings. The callback itself stays typed.
+
+Truly dynamic signal names can use `GObject.signal_connect`, `GObject.signal_connect_after`,
+or `GObject.signal_emit_by_name` explicitly. These lower-level APIs do not check signal names
+or argument types.

--- a/packages/generator-typescript/src/generators/signal-generator.ts
+++ b/packages/generator-typescript/src/generators/signal-generator.ts
@@ -349,7 +349,6 @@ export class SignalGenerator {
       groups.push([
         SIGNAL_JSDOC,
         `connect<K extends keyof ${girClass.name}.SignalSignatures>(signal: K, callback: ${gobjectRef}SignalCallback<this, ${girClass.name}.SignalSignatures[K]>): number;`,
-        "connect(signal: string, callback: (...args: any[]) => any): number;",
       ]);
     }
 
@@ -357,15 +356,13 @@ export class SignalGenerator {
       groups.push([
         SIGNAL_JSDOC,
         `connect_after<K extends keyof ${girClass.name}.SignalSignatures>(signal: K, callback: ${gobjectRef}SignalCallback<this, ${girClass.name}.SignalSignatures[K]>): number;`,
-        "connect_after(signal: string, callback: (...args: any[]) => any): number;",
       ]);
     }
 
     if (allowedNames.has("emit")) {
       groups.push([
         SIGNAL_JSDOC,
-        `emit<K extends keyof ${girClass.name}.SignalSignatures>(signal: K, ...args: ${gobjectRef}GjsParameters<${girClass.name}.SignalSignatures[K]> extends [any, ...infer Q] ? Q : never): void;`,
-        "emit(signal: string, ...args: any[]): void;",
+        `emit<K extends keyof ${girClass.name}.SignalSignatures>(signal: K, ...args: ${gobjectRef}GjsParameters<${girClass.name}.SignalSignatures[K]>): void;`,
       ]);
     }
 

--- a/packages/templates/templates/gobject-2.0.d.ts
+++ b/packages/templates/templates/gobject-2.0.d.ts
@@ -304,6 +304,29 @@ export type SignalCallback<Emitter, Fn> = Fn extends (...args: infer P) => infer
     ? (source: Emitter, ...args: P) => R
     : never
 
+/**
+ * Typed signal methods for subclasses with custom or implemented-interface signals.
+ * Include the parent's SignalSignatures in Signals, then use each member with
+ * a `declare` field to refine the inherited method without replacing it at runtime.
+ * The constraint checks each signal without requiring a string index signature.
+ *
+ * @example
+ * declare connect: GObject.SignalMethods<this, MySignals>["connect"]
+ * declare connect_after: GObject.SignalMethods<this, MySignals>["connect_after"]
+ * declare emit: GObject.SignalMethods<this, MySignals>["emit"]
+ */
+export interface SignalMethods<
+    Emitter,
+    Signals extends Record<keyof Signals, (...args: never[]) => unknown>,
+> {
+    /** Connect a callback, with the emitter prepended to the signal arguments. */
+    connect<K extends keyof Signals>(signal: K, callback: SignalCallback<Emitter, Signals[K]>): number
+    /** Connect a callback to run after the signal's default handler. */
+    connect_after<K extends keyof Signals>(signal: K, callback: SignalCallback<Emitter, Signals[K]>): number
+    /** Emit a signal with its declared arguments, without the emitter. */
+    emit<K extends keyof Signals>(signal: K, ...args: GjsParameters<Signals[K]>): void
+}
+
 // TODO: What about the generated class Closure
 export type TClosure<R = any, P = any> = (...args: P[]) => R
 

--- a/tests/strict-signals/assert.mjs
+++ b/tests/strict-signals/assert.mjs
@@ -1,0 +1,144 @@
+// Rationale: compile consumers of freshly generated types. Checking declaration text alone
+// cannot detect an inherited fallback that defeats strict signal checking.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const temporary = mkdtempSync(join(tmpdir(), "gir-strict-signals-"));
+
+try {
+  const outdir = join(temporary, "generated");
+  execFileSync(
+    join(root, "node_modules/.bin/ts-for-gir-dev"),
+    [
+      "generate",
+      "Gio-2.0",
+      "--girDirectories",
+      join(root, "girs"),
+      "--outdir",
+      outdir,
+      "--package",
+      "--noPrettyPrint",
+    ],
+    { cwd: temporary, stdio: "pipe", timeout: 120000 },
+  );
+
+  const consumer = join(temporary, "consumer.ts");
+  // Rationale: compile the registerClass migration recipe against fresh GIR types,
+  // then reject invalid calls on the same subclass used by the GJS runtime test.
+  const example = join(root, "examples/gobject-param-spec/strict-signals.ts");
+  const runtimeSource = readFileSync(example, "utf8");
+  const header = runtimeSource
+    .replace("gi://Gio?version=2.0", "@girs/gio-2.0")
+    .replace("gi://GObject?version=2.0", "@girs/gobject-2.0");
+  const positives = `action.connect('activate', (source, parameter) => {
+    const name: string = source.name;
+    const value: import('@girs/glib-2.0').default.Variant | null = parameter;
+    void name; void value;
+  });
+  action.connect_after('activate', source => { const enabled: boolean = source.enabled; void enabled; });
+  action.emit('activate', null);
+  new Gio.Cancellable().emit('cancelled');
+  action.connect('notify::enabled', (source, pspec) => { void source.enabled; void pspec.name; });
+  // Rationale: GObject's notify index signature deliberately accepts arbitrary details.
+  customAction.connect('notify::nonexistent-property', (_source, pspec) => { void pspec.name; });`;
+  const negatives = [
+    "action.connect('activtae', () => {});",
+    "action.connect('activate', (_source, parameter: number) => {});",
+    "action.connect_after('activtae', () => {});",
+    "action.connect_after('activate', (_source, parameter: number) => {});",
+    "action.emit('activtae', null);",
+    "action.emit('activate', 123);",
+    "action.emit('activate');",
+    "customAction.connect('value-chagned', () => {});",
+    "customAction.connect('value-changed', (_source, value: string) => {});",
+    "customAction.connect_after('value-chagned', () => {});",
+    "customAction.connect_after('value-changed', (_source, value: string) => {});",
+    "customAction.emit('value-chagned', 42, 'answer');",
+    "customAction.emit('value-changed', 'wrong', 'answer');",
+    "customAction.emit('value-changed', 42, 123);",
+    "customAction.emit('value-changed', 42);",
+    "customAction.emit('value-changed', 42, 'answer', 'extra');",
+    "customAction.connect('activtae', () => {});",
+    "customAction.connect_after('activate', (_source, parameter: number) => {});",
+    "customAction.emit('activate', 123);",
+  ];
+  const options = {
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    paths: { "@girs/*": [join(outdir, "*")] },
+    types: [],
+    noUncheckedSideEffectImports: true,
+  };
+
+  function check(body, prefix = header) {
+    writeFileSync(consumer, prefix + body);
+    return ts.getPreEmitDiagnostics(ts.createProgram([consumer], options));
+  }
+
+  const valid = check(positives);
+  assert.equal(
+    valid.length,
+    0,
+    ts.formatDiagnosticsWithColorAndContext(valid, {
+      getCanonicalFileName: (file) => file,
+      getCurrentDirectory: () => root,
+      getNewLine: () => "\n",
+    }),
+  );
+  for (const negative of negatives) {
+    assert.notEqual(check(negative).length, 0, negative);
+  }
+
+  // Rationale: the documented migration recipe must compile and execute as written.
+  const readme = readFileSync(join(root, "packages/cli/README.md"), "utf8");
+  const signalDocs = readme.slice(readme.indexOf("### Signal type checking"));
+  const recipe = /```ts\n([\s\S]*?)```/.exec(signalDocs)?.[1];
+  assert.ok(recipe, "Missing custom signal migration recipe");
+  const recipeErrors = check(recipe.replace("gi://GObject?version=2.0", "@girs/gobject-2.0"), "");
+  assert.equal(
+    recipeErrors.length,
+    0,
+    recipeErrors
+      .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+      .join("\n"),
+  );
+
+  writeFileSync(consumer, runtimeSource);
+  const exampleProgram = ts.createProgram(
+    [
+      consumer,
+      join(outdir, "gio-2.0/gio-2.0-ambient.d.ts"),
+      join(outdir, "gobject-2.0/gobject-2.0-ambient.d.ts"),
+    ],
+    options,
+  );
+  const errors = ts.getPreEmitDiagnostics(exampleProgram);
+  assert.equal(
+    errors.length,
+    0,
+    errors
+      .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+      .join("\n"),
+  );
+
+  const js = ts.transpileModule(runtimeSource, { compilerOptions: options }).outputText;
+  const executable = join(temporary, "strict-signals.js");
+  writeFileSync(executable, js);
+  execFileSync("gjs", ["-m", executable], { stdio: "inherit", timeout: 15000 });
+  writeFileSync(executable, ts.transpileModule(recipe, { compilerOptions: options }).outputText);
+  execFileSync("gjs", ["-m", executable], { stdio: "inherit", timeout: 15000 });
+
+  console.log("Generated signal overloads passed compile-time and runtime checks.");
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/tests/strict-signals/assert.mjs
+++ b/tests/strict-signals/assert.mjs
@@ -46,7 +46,13 @@ try {
   new Gio.Cancellable().emit('cancelled');
   action.connect('notify::enabled', (source, pspec) => { void source.enabled; void pspec.name; });
   // Rationale: GObject's notify index signature deliberately accepts arbitrary details.
-  customAction.connect('notify::nonexistent-property', (_source, pspec) => { void pspec.name; });`;
+  customAction.connect('notify::nonexistent-property', (_source, pspec) => { void pspec.name; });
+  // Rationale: SignalMethods<this, Signals> must preserve the most-derived emitter type.
+  class DerivedAction extends StrictSignalAction { derivedOnly(): void {} }
+  const derived = new DerivedAction({ name: 'derived' });
+  derived.connect('value-changed', source => source.derivedOnly());
+  derived.connect_after('value-changed', source => source.derivedOnly());
+  derived.emit('value-changed', 42, 'answer');`;
   const negatives = [
     "action.connect('activtae', () => {});",
     "action.connect('activate', (_source, parameter: number) => {});",
@@ -67,6 +73,8 @@ try {
     "customAction.connect('activtae', () => {});",
     "customAction.connect_after('activate', (_source, parameter: number) => {});",
     "customAction.emit('activate', 123);",
+    // Rationale: the helper requires a callback signature for every signal entry.
+    "type InvalidSignals = GObject.SignalMethods<GObject.Object, { broken: string }>;",
   ];
   const options = {
     strict: true,

--- a/tests/strict-signals/package.json
+++ b/tests/strict-signals/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@ts-for-gir-test/strict-signals",
+  "private": true,
+  "type": "module",
+  "scripts": {"test": "node --no-warnings assert.mjs"},
+  "devDependencies": {"@ts-for-gir/cli": "workspace:^", "typescript": "^6.0.3"}
+}


### PR DESCRIPTION
## Problem

Generated GObject classes accept misspelled signal names and incompatible callbacks through
`string`/`any` fallback overloads, even when they have `SignalSignatures`. The typed `emit`
overload also drops the first declared argument: a signal taking `Variant | null` incorrectly
accepts an emission without that value.

## Changes

- Remove the permissive overloads from `connect`, `connect_after`, and `emit` by default, and
  preserve every declared signal argument in `emit`.
- Add the declaration-only `GObject.SignalMethods<Emitter, Signals>` helper. Custom classes
  refine their three inherited methods with `declare` fields, without runtime forwarding code.
  Merge `Gio.ListModel.SignalSignatures` into the two list model examples so `items-changed`
  connections and emissions stay checked.
- Document the full `registerClass` migration recipe, interface signals, dynamic GObject APIs,
  and the unchecked `notify::` property-name details.
- Extend `gobject-param-spec/strict-signals.ts` with a registered subclass that exercises custom
  and inherited signals, emission inside a class method, callback order, arguments, and
  disconnection in GJS. Check that further subclasses retain their callback emitter types.
- Compile consumers of freshly generated types to reject invalid names, callbacks, values, and
  argument counts. Compile and execute the README migration recipe as well.

BREAKING CHANGE: `connect`, `connect_after`, and `emit` reject unknown signal names and
incompatible arguments. Custom signals need typed signatures and method declarations, using
`GObject.SignalMethods`; truly dynamic calls can use the lower-level GObject signal APIs
explicitly. `notify::` details remain unchecked because of the inherited index signature.

## Validation

- `gjsify run build:types` and inspection of generated signal declarations
- `gjsify run build:examples`
- `gjsify run check`
- `gjsify run check:types`
- `gjsify run check:examples`
- `gjsify run test:tests`
- `gjsify run test:examples:cli`
- `gjsify workspace @ts-for-gir-test/strict-signals run test`
- GJS execution of `gio-2-list-model-example` and `virtual-interface-test`
- Formatting checks for changed sources and commitlint with the repository configuration

## LLM disclosure

Developed with Codex (initial implementation: GPT-6 Astra medium; review follow-up: GPT-6).

