### PR TITLE
feat: the number behind each vocabulary nick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,9 @@ When modifying generators, templates, injections, or lib code that affects gener
 
 Opt-in subpath (`widgetVocabulary`, on in `.ts-for-gir.packages-all.rc.js`) carrying the
 GIR-derived widget VOCABULARY: a writable-only, optional, GObject-keyed props interface per
-declaration, the construct-only name union, enum nick unions from `glib:nick`, a GType-keyed
+declaration, the construct-only name union, enum nick unions from `glib:nick`, the number
+behind each of those nicks from `value` (with the deprecated half of an alias named, since
+two names on one value is how GObject spells one), a GType-keyed
 `Widgets` map, and the same facts again as runtime data in the sibling `.js` — because types
 are erased and the only check that can go red for a real reason is a consumer asking the
 INSTALLED library whether every name is real. Code: `packages/generator-typescript/src/surface/`.
@@ -101,7 +103,8 @@ a namespace with no surface is dropped when it contributes no settable property 
 when it does, named in that file's provenance line. (Refusing it was the first version, and it
 took a 705-namespace run down at namespace 265 on `Gcr.Prompt` — the only such base in the
 corpus.) **Nothing is derived that GIR carries**: the nick comes
-from `glib:nick` — substitution is not a law, some nicks keep an underscore it would have
+from `glib:nick` and the number from `value` — position in the nick list is NOT the value, and
+counting is wrong on 6 of the 129 enums a GTK 4 vocabulary carries — substitution is not a law, some nicks keep an underscore it would have
 replaced, and Gtk-4.0 and Adw-1 contradict nothing, which is how a derived nick passes review;
 `gjsify run check:girs` re-measures that over `girs/` and asserts the two invariants the
 fallback rests on — the dashed property name from `IntrospectedProperty.girName`, the GType

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,11 +83,14 @@ When modifying generators, templates, injections, or lib code that affects gener
 Opt-in subpath (`widgetVocabulary`, on in `.ts-for-gir.packages-all.rc.js`) carrying the
 GIR-derived widget VOCABULARY: a writable-only, optional, GObject-keyed props interface per
 declaration, the construct-only name union, enum nick unions from `glib:nick`, the number
-behind each of those nicks from `value` (with the deprecated half of an alias named, since
-two names on one value is how GObject spells one), a GType-keyed
-`Widgets` map, and the same facts again as runtime data in the sibling `.js` — because types
-are erased and the only check that can go red for a real reason is a consumer asking the
-INSTALLED library whether every name is real. Code: `packages/generator-typescript/src/surface/`.
+behind each of those nicks from `value` (plus each nick GIR marks deprecated — evidence only,
+4 members in 718 GIRs carry it, so absence is silence not currency), the same numbers again
+for the registered BITFIELDS — which get no nick union, because GObject cannot resolve a nick
+SET, and whose members still carry numbers 21 bitfield-typed widget properties need — a
+GType-keyed `Widgets` map, and the same facts again as runtime data in the sibling `.js` —
+because types are erased and the only check that can go red for a real reason is a consumer asking the
+INSTALLED library whether every name is real. Code:
+`packages/generator-typescript/src/vocabulary/`.
 Decided in gjsify's ADR 0029.
 
 Three rules bind work here. **The vocabulary ships, the dialect does not** — no tag spelling,
@@ -102,15 +105,15 @@ neither -- but a consumer declaring a module-scoped namespace is doing it right.
 a namespace with no surface is dropped when it contributes no settable property and INLINED
 when it does, named in that file's provenance line. (Refusing it was the first version, and it
 took a 705-namespace run down at namespace 265 on `Gcr.Prompt` — the only such base in the
-corpus.) **Nothing is derived that GIR carries**: the nick comes
-from `glib:nick` and the number from `value` — position in the nick list is NOT the value, and
-counting is wrong on 6 of the 129 enums a GTK 4 vocabulary carries — substitution is not a law, some nicks keep an underscore it would have
-replaced, and Gtk-4.0 and Adw-1 contradict nothing, which is how a derived nick passes review;
-`gjsify run check:girs` re-measures that over `girs/` and asserts the two invariants the
-fallback rests on — the dashed property name from `IntrospectedProperty.girName`, the GType
-from `glibTypeName`.
+corpus.) **Nothing is derived that GIR carries**: the nick comes from `glib:nick` and the
+number from `value` — position in the nick list is NOT the value, and counting is wrong on
+6 of the 129 enums a GTK 4 vocabulary carries (104 in Gtk-4.0, 25 in Adw-1) — substitution
+is not a law, some nicks keep an underscore it would have replaced, and Gtk-4.0 and Adw-1
+contradict nothing, which is how a derived nick passes review; `gjsify run check:girs`
+re-measures that over `girs/` and asserts the two invariants the fallback rests on — the
+dashed property name from `IntrospectedProperty.girName`, the GType from `glibTypeName`.
 
-Gate: `tests/widget-surface` — positives plus three controls that must go the other way (flag
+Gate: `tests/widget-vocabulary` — positives plus three controls that must go the other way (flag
 off emits nothing, a broken fixture exits non-zero naming the declaration, and the `.d.ts` and
 `.js` halves are read separately and compared). The emitted surface is also in each package's
 own `tsconfig.json#include`, so `gjsify run check:types` compiles it — the only thing that

--- a/packages/generator-typescript/src/module-generator.ts
+++ b/packages/generator-typescript/src/module-generator.ts
@@ -108,15 +108,6 @@ const DOC_BASE_URLS = new Map<string, string>([
   ["GtkSource-5", "https://gnome.pages.gitlab.gnome.org/gtksourceview/gtksourceview5/"],
 ]);
 
-/** A GIR enum value TypeScript can use as an initialiser, or null to keep the default. */
-function enumInitialiser(raw: string | undefined): string | null {
-  if (raw === undefined) return null;
-  const trimmed = raw.trim();
-  if (!/^-?\d+$/.test(trimmed)) return null;
-  // Beyond this, the literal loses precision and the emitted number is not the GIR's.
-  return Number.isSafeInteger(Number(trimmed)) ? trimmed : null;
-}
-
 export class ModuleGenerator extends FormatGenerator<string[]> {
   log: Reporter;
   dependencyManager: DependencyManager;
@@ -1173,20 +1164,11 @@ export class ModuleGenerator extends FormatGenerator<string[]> {
 
     const invalid = isInvalid(tsMember.name);
 
-    // The GIR's VALUE, not TypeScript's positional default.
-    //
-    // Without it the numbers are simply wrong, and since TS 5.0 made numeric enums literal
-    // unions, wrong in a way the compiler enforces: `Gtk.ResponseType.OK` is -5 upstream and
-    // was emitted as 4, so `response === -5` failed to compile against the very enum that
-    // defines it. Bitfields are worse than off-by-one — `Gtk.StateFlags` declares
-    // 0,1,2,4,8,16 and got 0,1,2,3,4,5, so `SELECTED | INSENSITIVE` computed 7 where GTK
-    // means 12. Measured: 124 of 806 members in Gtk-4.0 and 424 of 751 in GLib had a value
-    // that is not their position.
-    //
-    // Only a plain integer is carried. GIR also holds symbolic and out-of-range values that
-    // TypeScript cannot express as an initialiser, and those keep the positional default
-    // rather than emitting something that does not compile.
-    const value = enumInitialiser(tsMember.value);
+    // The GIR's VALUE, not TypeScript's positional default. The rule for which GIR values
+    // can be carried — and the incident that put it here — lives on the model, in
+    // `GirEnumMember.numericValue`, because `./vocabulary` emits the same numbers as
+    // runtime data and two copies of that rule would drift apart silently.
+    const value = tsMember.numericValue;
     const assignment = value === null ? "" : ` = ${value}`;
 
     const indent = generateIndent(indentCount);

--- a/packages/generator-typescript/src/vocabulary/emit-data.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-data.ts
@@ -22,6 +22,16 @@ const record = (rows: readonly string[]): string =>
 const list = (items: readonly string[]): string =>
   `[${items.map((item) => `'${item}'`).join(", ")}]`;
 
+/**
+ * A single-quoted literal for text that is NOT an identifier.
+ *
+ * `list` above quotes nicks and GTypes, which GObject constrains to
+ * `[A-Za-z0-9_-]`. The raw GIR `value` of a member no number could be read from is
+ * arbitrary text -- Vala writes `(null)`, a char enum writes a letter -- so it is the
+ * one thing emitted here that has to survive a quote of its own.
+ */
+const quote = (text: string): string => `'${text.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+
 export function emitVocabularyData(surface: WidgetVocabulary): string {
   // `OWN_PROPS` and `OWN_SIGNALS` are keyed by DECLARATION, not by creatable widget, and
   // they must stay keyed the same way: `DECLS` hands the consumer a chain of GTypes, and
@@ -49,9 +59,29 @@ export function emitVocabularyData(surface: WidgetVocabulary): string {
 
   const decls = all.map((widget) => `    ${widget.gtype}: ${list(widget.chain)},`);
 
-  const nicks = [...surface.enums.values()]
-    .sort((a, b) => (a.gtype < b.gtype ? -1 : 1))
-    .map((entry) => `    ${entry.gtype}: ${list(entry.nicks)},`);
+  const enums = [...surface.enums.values()].sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
+
+  const nicks = enums.map((entry) => `    ${entry.gtype}: ${list(entry.nicks)},`);
+
+  // `<GType>.<nick>`, the same grammar `SINCE` uses for a member, because a consumer that
+  // reads both should not need two key parsers. Emitted for exactly the enums `ENUM_NICKS`
+  // covers, so "every nick has a number or is named in the remainder" is a claim about one
+  // subject rather than about the overlap of two.
+  const values = enums.flatMap((entry) =>
+    [...entry.values]
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([nick, value]) => `    '${entry.gtype}.${nick}': ${value},`),
+  );
+
+  const deprecated = enums.flatMap((entry) =>
+    [...entry.deprecated].sort().map((nick) => `${entry.gtype}.${nick}`),
+  );
+
+  const unreadable = enums.flatMap((entry) =>
+    [...entry.unreadable]
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([nick, raw]) => `    '${entry.gtype}.${nick}': ${quote(raw)},`),
+  );
 
   const slots = all
     .filter((widget) => widget.slotCandidates.size > 0)
@@ -105,6 +135,40 @@ export const DECLS = ${record(decls)};
 export const CHILD_HOLDERS = ${list(surface.childHolders.map((holder) => holder.gtype))};
 
 export const ENUM_NICKS = ${record(nicks)};
+
+// The number behind each of those nicks, read from GIR's own \`value\` attribute.
+//
+// It ships because position in \`ENUM_NICKS\` is not the value and a consumer with no
+// typelib has no other way to learn it: a surface without GI still has to hand GObject an
+// integer. The alternative a consumer reaches for first is counting, and counting is wrong
+// on 6 of the 129 enums a GTK 4 vocabulary carries -- \`GtkResponseType\` runs -1 down to
+// -11, \`GtkTextWindowType\` starts at 1, and \`GtkConstraintStrength.required\` is
+// 1001001000 where counting answers 0.
+//
+// Same provenance as the nicks above, which is the point: a consumer that reads the numbers
+// from an INSTALLED library instead gets two provenances for one table, and a member the
+// vocabulary describes but the host predates then looks like a missing number rather than a
+// version gap.
+export const ENUM_VALUES = ${record(values)};
+
+// The nicks GIR marks \`deprecated="1"\`.
+//
+// Two members of one enum may share a value -- that is how GObject spells an alias, and
+// \`GTK_ALIGN_BASELINE\` and \`GTK_ALIGN_BASELINE_FILL\` are both 4. \`ENUM_VALUES\` keeps
+// both names, so nothing is lost, and this is what says which of the two a number should be
+// spelled back as. Stated rather than derived: the pairing is visible in the values, the
+// DIRECTION is not.
+export const ENUM_DEPRECATED = ${list(deprecated)};
+
+// The declared remainder: nicks whose GIR \`value\` is not a number this can carry.
+//
+// Every nick in \`ENUM_NICKS\` is in \`ENUM_VALUES\` or here -- a nick in neither would be a
+// silent drop. GIR carries two shapes no integer holds: a symbolic or absent value (Vala
+// writes \`(null)\`, a char enum writes a letter) and an integer past
+// \`Number.MAX_SAFE_INTEGER\`. The value kept here is the raw attribute, so the entry says
+// WHAT was unreadable rather than only that something was. Measured over the 718 GIRs in
+// ts-for-gir's \`girs/\`: 32 of 34096 registered-enum members, none in Gtk, Adw, GLib or Gio.
+export const ENUM_VALUES_UNREADABLE = ${record(unreadable)};
 
 export const SLOT_CANDIDATES = ${record(slots)};
 

--- a/packages/generator-typescript/src/vocabulary/emit-data.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-data.ts
@@ -26,11 +26,25 @@ const list = (items: readonly string[]): string =>
  * A single-quoted literal for text that is NOT an identifier.
  *
  * `list` above quotes nicks and GTypes, which GObject constrains to
- * `[A-Za-z0-9_-]`. The raw GIR `value` of a member no number could be read from is
- * arbitrary text -- Vala writes `(null)`, a char enum writes a letter -- so it is the
- * one thing emitted here that has to survive a quote of its own.
+ * `[A-Za-z0-9_-]` (measured: no nick or GType in the 718 GIRs leaves that set). The raw
+ * GIR `value` of a member no number could be read from is arbitrary text -- Vala writes
+ * `(null)`, a char enum writes a letter -- so it is the one thing emitted here that has to
+ * survive a quote of its own.
+ *
+ * Line terminators are in the list beside the quote and the backslash because they fail
+ * DIFFERENTLY and worse: a stray quote emits a wrong string, a raw newline emits an
+ * unterminated one and the whole module stops parsing -- every export in it, not just this
+ * entry. The parser does not apply XML attribute-value normalisation, so a newline written
+ * into a `value` reaches here as a newline.
  */
-const quote = (text: string): string => `'${text.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+const quote = (text: string): string =>
+  `'${text
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")}'`;
 
 export function emitVocabularyData(surface: WidgetVocabulary): string {
   // `OWN_PROPS` and `OWN_SIGNALS` are keyed by DECLARATION, not by creatable widget, and
@@ -75,6 +89,22 @@ export function emitVocabularyData(surface: WidgetVocabulary): string {
 
   const deprecated = enums.flatMap((entry) =>
     [...entry.deprecated].sort().map((nick) => `${entry.gtype}.${nick}`),
+  );
+
+  // Same two shapes as the enum tables above, over the bitfields — see `WidgetVocabulary.flags`
+  // for why they are carried at all and why they are their own table.
+  const bitfields = [...surface.flags.values()].sort((a, b) => (a.gtype < b.gtype ? -1 : 1));
+
+  const flagValues = bitfields.flatMap((entry) =>
+    [...entry.values]
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([nick, value]) => `    '${entry.gtype}.${nick}': ${value},`),
+  );
+
+  const flagUnreadable = bitfields.flatMap((entry) =>
+    [...entry.unreadable]
+      .sort(([a], [b]) => (a < b ? -1 : 1))
+      .map(([nick, raw]) => `    '${entry.gtype}.${nick}': ${quote(raw)},`),
   );
 
   const unreadable = enums.flatMap((entry) =>
@@ -141,7 +171,8 @@ export const ENUM_NICKS = ${record(nicks)};
 // It ships because position in \`ENUM_NICKS\` is not the value and a consumer with no
 // typelib has no other way to learn it: a surface without GI still has to hand GObject an
 // integer. The alternative a consumer reaches for first is counting, and counting is wrong
-// on 6 of the 129 enums a GTK 4 vocabulary carries -- \`GtkResponseType\` runs -1 down to
+// on 6 of the 129 enums a GTK 4 vocabulary carries (104 in Gtk-4.0, 25 in Adw-1) --
+// \`GtkResponseType\` runs -1 down to
 // -11, \`GtkTextWindowType\` starts at 1, and \`GtkConstraintStrength.required\` is
 // 1001001000 where counting answers 0.
 //
@@ -158,6 +189,10 @@ export const ENUM_VALUES = ${record(values)};
 // both names, so nothing is lost, and this is what says which of the two a number should be
 // spelled back as. Stated rather than derived: the pairing is visible in the values, the
 // DIRECTION is not.
+//
+// Read it as evidence, not as a negative: 4 registered-enum members in the 718 GIRs carry
+// the attribute at all, and 179 of the 182 value-sharing pairs carry it on neither half.
+// A nick missing from here is a nick GIR says nothing about, not a nick GIR calls current.
 export const ENUM_DEPRECATED = ${list(deprecated)};
 
 // The declared remainder: nicks whose GIR \`value\` is not a number this can carry.
@@ -169,6 +204,24 @@ export const ENUM_DEPRECATED = ${list(deprecated)};
 // WHAT was unreadable rather than only that something was. Measured over the 718 GIRs in
 // ts-for-gir's \`girs/\`: 32 of 34096 registered-enum members, none in Gtk, Adw, GLib or Gio.
 export const ENUM_VALUES_UNREADABLE = ${record(unreadable)};
+
+// The number behind each member of a registered BITFIELD, keyed the same way.
+//
+// \`ENUM_NICKS\` refuses a bitfield because GObject cannot resolve a nick SET, and that
+// reason says nothing about one member's number. 21 writable widget properties in Gtk-4.0
+// and Adw-1 are bitfield-typed -- \`GtkEntry:input-hints\`, \`GtkPopoverMenu:flags\`,
+// \`AdwTabView:shortcuts\`, ... -- and they are typed bare \`number\`, so a host without GI
+// has nothing to compute one from. Counting is worst exactly here: 95 of 121 Gtk-4.0
+// bitfield members disagree with their position, against 29 of 685 enumeration members.
+//
+// A table of its own rather than more rows in \`ENUM_VALUES\`, so that "every nick in
+// \`ENUM_NICKS\` has a number or a declared reason" stays a claim about one set.
+export const FLAG_VALUES = ${record(flagValues)};
+
+// The same declared remainder for the bitfields. Every one of the 13 members in ts-for-gir's
+// \`girs/\` whose value is past \`Number.MAX_SAFE_INTEGER\` is a bitfield member (Fwupd, Qmi),
+// so this is the table that shape actually reaches.
+export const FLAG_VALUES_UNREADABLE = ${record(flagUnreadable)};
 
 export const SLOT_CANDIDATES = ${record(slots)};
 

--- a/packages/generator-typescript/src/vocabulary/emit-types.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-types.ts
@@ -299,6 +299,40 @@ export const CHILD_HOLDERS: readonly string[];
 /** Enum GType -> the nicks this surface offers. */
 export const ENUM_NICKS: Readonly<Record<string, readonly string[]>>;
 
+/**
+ * \`<enum GType>.<nick>\` -> the integer GObject registers for it, from GIR's \`value\`.
+ *
+ * Position in \`ENUM_NICKS\` is NOT this number. Counting is wrong on 6 of the 129 enums a
+ * GTK 4 vocabulary carries: \`GtkResponseType\` runs -1 to -11, \`GtkTextWindowType\` starts
+ * at 1, \`GtkOrdering\` and \`GtkConstraintRelation\` are -1/0/1, \`GtkAlign\` has two names
+ * on one value, and \`GtkConstraintStrength.required\` is 1001001000 where counting says 0.
+ *
+ * Read from the same GIR as the nicks, deliberately. A consumer reading the numbers off an
+ * installed typelib instead has two provenances for one table, and then cannot tell a
+ * missing number from a host older than the vocabulary.
+ */
+export const ENUM_VALUES: Readonly<Record<string, number>>;
+
+/**
+ * The \`<enum GType>.<nick>\` entries GIR marks \`deprecated="1"\`.
+ *
+ * Two names on one value is how GObject spells an alias -- \`GTK_ALIGN_BASELINE\` and
+ * \`GTK_ALIGN_BASELINE_FILL\` are both 4, and both keep a \`ENUM_VALUES\` entry. The pairing
+ * is visible in the numbers; which name is the old one is not, and this is that fact.
+ */
+export const ENUM_DEPRECATED: readonly string[];
+
+/**
+ * \`<enum GType>.<nick>\` -> the raw GIR \`value\` no number could be read from.
+ *
+ * The declared remainder, so that every nick in \`ENUM_NICKS\` is in \`ENUM_VALUES\` or in
+ * here and a drop cannot be silent. Two shapes reach it: a symbolic or absent value (Vala
+ * writes \`(null)\`, a char enum writes a letter) and an integer past
+ * \`Number.MAX_SAFE_INTEGER\`, where a literal would lose precision and stop being the
+ * GIR's number. Empty for Gtk, Adw, GLib and Gio.
+ */
+export const ENUM_VALUES_UNREADABLE: Readonly<Record<string, string>>;
+
 /** Widget GType -> slot name -> the method that may adopt a child there. */
 export const SLOT_CANDIDATES: Readonly<Record<string, Readonly<Record<string, string>>>>;
 

--- a/packages/generator-typescript/src/vocabulary/emit-types.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-types.ts
@@ -303,7 +303,7 @@ export const ENUM_NICKS: Readonly<Record<string, readonly string[]>>;
  * \`<enum GType>.<nick>\` -> the integer GObject registers for it, from GIR's \`value\`.
  *
  * Position in \`ENUM_NICKS\` is NOT this number. Counting is wrong on 6 of the 129 enums a
- * GTK 4 vocabulary carries: \`GtkResponseType\` runs -1 to -11, \`GtkTextWindowType\` starts
+ * GTK 4 vocabulary carries -- 104 in Gtk-4.0 and 25 in Adw-1: \`GtkResponseType\` runs -1 to -11, \`GtkTextWindowType\` starts
  * at 1, \`GtkOrdering\` and \`GtkConstraintRelation\` are -1/0/1, \`GtkAlign\` has two names
  * on one value, and \`GtkConstraintStrength.required\` is 1001001000 where counting says 0.
  *
@@ -318,7 +318,10 @@ export const ENUM_VALUES: Readonly<Record<string, number>>;
  *
  * Two names on one value is how GObject spells an alias -- \`GTK_ALIGN_BASELINE\` and
  * \`GTK_ALIGN_BASELINE_FILL\` are both 4, and both keep a \`ENUM_VALUES\` entry. The pairing
- * is visible in the numbers; which name is the old one is not, and this is that fact.
+ * is visible in the numbers; which name is the old one is not, and this is that fact --
+ * where GIR states it. It usually does not: 4 registered-enum members across the 718 GIRs
+ * carry the attribute, and 179 of the 182 value-sharing pairs carry it on neither half, so
+ * absence from this list means GIR is silent, not that the nick is the current one.
  */
 export const ENUM_DEPRECATED: readonly string[];
 
@@ -332,6 +335,24 @@ export const ENUM_DEPRECATED: readonly string[];
  * GIR's number. Empty for Gtk, Adw, GLib and Gio.
  */
 export const ENUM_VALUES_UNREADABLE: Readonly<Record<string, string>>;
+
+/**
+ * \`<bitfield GType>.<nick>\` -> the integer GObject registers for that one member.
+ *
+ * \`ENUM_NICKS\` carries no bitfield, because GObject cannot resolve a nick SET; that says
+ * nothing about a single member's number, and the number is what a host without GI needs.
+ * 21 writable widget properties in Gtk-4.0 and Adw-1 are bitfield-typed and are declared
+ * bare \`number\` -- \`GtkEntry:input-hints\`, \`GtkPopoverMenu:flags\`, \`AdwTabView:shortcuts\`
+ * among them. Counting is worst here: 95 of 121 Gtk-4.0 bitfield members disagree with their
+ * position, against 29 of 685 enumeration members.
+ *
+ * Combine with \`|\` as GObject does. There is no nick table to pair this with, so a name
+ * here is resolvable and a SET still is not.
+ */
+export const FLAG_VALUES: Readonly<Record<string, number>>;
+
+/** \`<bitfield GType>.<nick>\` -> the raw GIR \`value\` no number could be read from. */
+export const FLAG_VALUES_UNREADABLE: Readonly<Record<string, string>>;
 
 /** Widget GType -> slot name -> the method that may adopt a child there. */
 export const SLOT_CANDIDATES: Readonly<Record<string, Readonly<Record<string, string>>>>;

--- a/packages/generator-typescript/src/vocabulary/model.ts
+++ b/packages/generator-typescript/src/vocabulary/model.ts
@@ -164,6 +164,49 @@ export interface VocabularyEnum {
   /** `Gtk.Orientation` as the surface spells it. */
   readonly reference: string;
   readonly nicks: readonly string[];
+  /**
+   * Nick -> the integer GObject registers for it, straight from GIR's `value`.
+   *
+   * Position in `nicks` is NOT this number and never was. Counting is wrong on 6 of the
+   * 129 enums a GTK 4 vocabulary carries, and `GtkConstraintStrength.required` is why
+   * "off by one" is the wrong mental model for it: counting answers 0 where the library
+   * means 1001001000.
+   */
+  readonly values: ReadonlyMap<string, number>;
+  /** The nicks GIR marks `deprecated="1"` — an alias always is the deprecated half. */
+  readonly deprecated: readonly string[];
+  /** Nick -> the raw GIR `value` for the members no number could be read from. */
+  readonly unreadable: ReadonlyMap<string, string>;
+}
+
+/**
+ * One registered, non-flag enum as the vocabulary carries it.
+ *
+ * Both callers below build the same entry from the same members, so they build it here:
+ * the runtime table and the nick union describe one enum, and two constructions of it
+ * would be two answers with nothing comparing them.
+ */
+function vocabularyEnumOf(
+  gtype: string,
+  reference: string,
+  enumeration: IntrospectedEnum,
+): VocabularyEnum {
+  const members = [...enumeration.members.values()];
+  const values = new Map<string, number>();
+  const unreadable = new Map<string, string>();
+  for (const member of members) {
+    const value = member.numericValue;
+    if (value === null) unreadable.set(member.nick, member.value);
+    else values.set(member.nick, value);
+  }
+  return {
+    gtype,
+    reference,
+    nicks: members.map((member) => member.nick),
+    values,
+    deprecated: members.filter((member) => member.deprecated).map((member) => member.nick),
+    unreadable,
+  };
 }
 
 /** Where a vocabulary came from, in a shape a check can read. */
@@ -448,8 +491,7 @@ function printPropType(
         if (!gtype) return `${resolved.namespace}.${resolved.name}`;
         namespaces.add(resolved.namespace);
         const reference = `${resolved.namespace}.${resolved.name}`;
-        const nicks = [...enumeration.members.values()].map((m) => m.nick);
-        enums.set(gtype, { gtype, reference, nicks });
+        enums.set(gtype, vocabularyEnumOf(gtype, reference, enumeration));
         return `${nickAliasOf(gtype)} | ${reference}`;
       }
       namespaces.add(resolved.namespace);
@@ -838,11 +880,14 @@ export function buildWidgetVocabulary(
       // Flags stay `number` everywhere, so a nick union for one would type something
       // every host has to reject; an unregistered enum has no nicks GObject knows.
       if (candidate.flags || !candidate.glibTypeName) continue;
-      enums.set(candidate.glibTypeName, {
-        gtype: candidate.glibTypeName,
-        reference: `${module.namespace}.${candidate.name}`,
-        nicks: [...candidate.members.values()].map((m) => m.nick),
-      });
+      enums.set(
+        candidate.glibTypeName,
+        vocabularyEnumOf(
+          candidate.glibTypeName,
+          `${module.namespace}.${candidate.name}`,
+          candidate,
+        ),
+      );
     }
   }
 

--- a/packages/generator-typescript/src/vocabulary/model.ts
+++ b/packages/generator-typescript/src/vocabulary/model.ts
@@ -168,12 +168,22 @@ export interface VocabularyEnum {
    * Nick -> the integer GObject registers for it, straight from GIR's `value`.
    *
    * Position in `nicks` is NOT this number and never was. Counting is wrong on 6 of the
-   * 129 enums a GTK 4 vocabulary carries, and `GtkConstraintStrength.required` is why
+   * 129 enums a GTK 4 vocabulary carries -- 104 in Gtk-4.0 and 25 in Adw-1 -- and
+   * `GtkConstraintStrength.required` is why
    * "off by one" is the wrong mental model for it: counting answers 0 where the library
    * means 1001001000.
    */
   readonly values: ReadonlyMap<string, number>;
-  /** The nicks GIR marks `deprecated="1"` — an alias always is the deprecated half. */
+  /**
+   * The nicks GIR marks `deprecated="1"`.
+   *
+   * NOT "the alias halves": the flag and the alias are independent, and measured over the
+   * 718 GIRs they barely meet. Four registered-enum members carry the flag at all --
+   * `GtkAlign.baseline`, `GstValidateActionReturn.interlaced`, `NotifyClosedReason.undefiend`
+   * and `FolksIndividualAggregatorError.no-writeable-store`, the last of which shares its
+   * value with nothing -- while 179 of the 182 value-sharing pairs carry it on NEITHER half.
+   * So an absent entry means "GIR does not say", never "this is the current name".
+   */
   readonly deprecated: readonly string[];
   /** Nick -> the raw GIR `value` for the members no number could be read from. */
   readonly unreadable: ReadonlyMap<string, string>;
@@ -247,6 +257,20 @@ export interface WidgetVocabulary {
   readonly declarations: ReadonlyMap<string, VocabularyDecl>;
   /** Nick unions this surface must emit itself, by enum GType. */
   readonly enums: ReadonlyMap<string, VocabularyEnum>;
+  /**
+   * Registered BITFIELDS this namespace declares, by GType — values only, no nicks.
+   *
+   * A separate table from `enums` and not a widening of it, because the two answer
+   * different questions and one of them has to stay narrow. `ENUM_NICKS` refuses a
+   * bitfield on purpose: GObject cannot resolve a nick SET, so a union of nicks would
+   * type something every host rejects. That reason says nothing about a single member's
+   * NUMBER, and the number is what a host without GI needs — 21 writable widget
+   * properties in Gtk-4.0 and Adw-1 are bitfield-typed (`GtkEntry:input-hints`,
+   * `GtkPopoverMenu:flags`, `AdwTabView:shortcuts`, …), typed bare `number` with nothing
+   * to compute one from. Counting is worst exactly here: 95 of 121 Gtk-4.0 bitfield
+   * members disagree with their position, against 29 of 685 enumeration members.
+   */
+  readonly flags: ReadonlyMap<string, VocabularyEnum>;
   /** GIR namespace -> the import this surface needs for its VALUE types. */
   readonly namespaceImports: ReadonlyMap<string, string>;
   /** `@girs/<pkg>/vocabulary` -> the names imported from another namespace's vocabulary. */
@@ -738,6 +762,7 @@ export function buildWidgetVocabulary(
 
   const namespaceImports = new Map<string, string>();
   const enums = new Map<string, VocabularyEnum>();
+  const flags = new Map<string, VocabularyEnum>();
   const surfaceImports = new Map<string, Set<string>>();
   const importFromVocabulary = (owner: GirModule, name: string) => {
     const subpath = `${owner.importPath}/vocabulary`;
@@ -877,9 +902,23 @@ export function buildWidgetVocabulary(
   for (const member of module.members.values()) {
     for (const candidate of Array.isArray(member) ? member : [member]) {
       if (!(candidate instanceof IntrospectedEnum)) continue;
+      // An unregistered enum has no GType and no nicks GObject knows, so neither table
+      // can key it.
+      if (!candidate.glibTypeName) continue;
       // Flags stay `number` everywhere, so a nick union for one would type something
-      // every host has to reject; an unregistered enum has no nicks GObject knows.
-      if (candidate.flags || !candidate.glibTypeName) continue;
+      // every host has to reject — but their MEMBERS still have numbers, and `flags`
+      // above says why those are carried anyway.
+      if (candidate.flags) {
+        flags.set(
+          candidate.glibTypeName,
+          vocabularyEnumOf(
+            candidate.glibTypeName,
+            `${module.namespace}.${candidate.name}`,
+            candidate,
+          ),
+        );
+        continue;
+      }
       enums.set(
         candidate.glibTypeName,
         vocabularyEnumOf(
@@ -982,6 +1021,7 @@ export function buildWidgetVocabulary(
     childHolders,
     declarations: withBases,
     enums,
+    flags,
     namespaceImports,
     surfaceImports: new Map([...surfaceImports].map(([k, v]) => [k, [...v].sort()])),
     omissions: computeOmissions(withBases),

--- a/packages/lib/src/gir/enum-member.ts
+++ b/packages/lib/src/gir/enum-member.ts
@@ -46,6 +46,11 @@ export class GirEnumMember extends IntrospectedBase<IntrospectedEnum> {
 	 * ENUM rather than about its documentation. Two members sharing a value is how GObject
 	 * spells an alias -- `GTK_ALIGN_BASELINE` and `GTK_ALIGN_BASELINE_FILL` are both 4 --
 	 * and the flag is the only thing that says which of the two names is the old one.
+	 *
+	 * How often it says so is worth carrying with the rule, because it is not "usually":
+	 * four registered-enum members in the 718 GIRs have the attribute, and 179 of the 182
+	 * value-sharing pairs have it on neither half. The flag is therefore evidence when
+	 * present and silence when absent -- never the negative claim.
 	 */
 	deprecated: boolean;
 
@@ -85,6 +90,16 @@ export class GirEnumMember extends IntrospectedBase<IntrospectedEnum> {
 	 * `Number.MAX_SAFE_INTEGER`, where the literal loses precision and the emitted number
 	 * is not the GIR's. Measured over the 718 GIRs in `girs/`: 32 of 34096 registered-enum
 	 * members, none of them in Gtk, Adw, GLib or Gio.
+	 *
+	 * WHAT NULL COSTS at the `.d.ts` emitter, because the two emitters diverge here and
+	 * only here. It emits no initialiser, so TypeScript falls back to the PREVIOUS member's
+	 * value plus one -- not the member's index, and not the GIR's number: `Mini.Odd` in
+	 * `tests/widget-vocabulary` has `HUGE` follow `ZERO = 0` and become 1 where GIR says
+	 * 9007199254740993. So `./vocabulary` names the member in `ENUM_VALUES_UNREADABLE`
+	 * while the enum beside it quietly asserts a number. It stays that way because
+	 * TypeScript has no enum initialiser meaning "unknown": the alternatives are a literal
+	 * that is not the GIR's, or dropping the member out of the enum and breaking every
+	 * reference to it. A consumer that needs the true number reads the vocabulary.
 	 */
 	get numericValue(): number | null {
 		const trimmed = this.value?.trim();

--- a/packages/lib/src/gir/enum-member.ts
+++ b/packages/lib/src/gir/enum-member.ts
@@ -2,6 +2,7 @@ import type { FormatGenerator } from "../generators/generator.ts";
 import type { GirMemberElement } from "../index.ts";
 import type { OptionsLoad } from "../types/index.ts";
 import { parseDoc, parseMetadata } from "../utils/gir-parsing.ts";
+import { isDeprecated } from "../utils/girs.ts";
 import type { GirVisitor } from "../visitor.ts";
 import type { IntrospectedEnum } from "./enum.ts";
 import { IntrospectedBase } from "./introspected-base.ts";
@@ -37,11 +38,59 @@ export class GirEnumMember extends IntrospectedBase<IntrospectedEnum> {
 	 */
 	nick: string;
 
-	constructor(name: string, value: string, parent: IntrospectedEnum, c_identifier: string, nick: string) {
+	/**
+	 * GIR's `deprecated="1"` on the member itself.
+	 *
+	 * A first-class field and not `metadata.deprecated`, for the same reason `nick` is
+	 * one: `parseMetadata` only runs when docs are loaded, and this is a fact about the
+	 * ENUM rather than about its documentation. Two members sharing a value is how GObject
+	 * spells an alias -- `GTK_ALIGN_BASELINE` and `GTK_ALIGN_BASELINE_FILL` are both 4 --
+	 * and the flag is the only thing that says which of the two names is the old one.
+	 */
+	deprecated: boolean;
+
+	constructor(
+		name: string,
+		value: string,
+		parent: IntrospectedEnum,
+		c_identifier: string,
+		nick: string,
+		deprecated = false,
+	) {
 		super(name, parent);
 		this.value = value;
 		this.c_identifier = c_identifier;
 		this.nick = nick;
+		this.deprecated = deprecated;
+	}
+
+	/**
+	 * The GIR's `value` as a number, or null where it is not one this can carry.
+	 *
+	 * THE INCIDENT. Without it the numbers were simply wrong, and since TS 5.0 made
+	 * numeric enums literal unions, wrong in a way the compiler enforces:
+	 * `Gtk.ResponseType.OK` is -5 upstream and was emitted as 4, so `response === -5`
+	 * failed to compile against the very enum that defines it. Bitfields are worse than
+	 * off-by-one -- `Gtk.StateFlags` declares 0,1,2,4,8,16 and got 0,1,2,3,4,5, so
+	 * `SELECTED | INSENSITIVE` computed 7 where GTK means 12. Measured: 124 of 806 members
+	 * in Gtk-4.0 and 424 of 751 in GLib had a value that is not their position.
+	 *
+	 * ONE RULE, TWO EMITTERS. The `.d.ts` enum initialiser and the `./vocabulary` runtime
+	 * table both ask this. They used to be one rule and one caller; a second copy of
+	 * "which GIR values TypeScript can carry" is the thing that would drift apart, and
+	 * nothing would say so because both would still emit something.
+	 *
+	 * Null covers the two shapes GIR writes that no initialiser can hold: a symbolic or
+	 * absent value (Vala emits `(null)`, and a char enum emits `'a'`), and an integer past
+	 * `Number.MAX_SAFE_INTEGER`, where the literal loses precision and the emitted number
+	 * is not the GIR's. Measured over the 718 GIRs in `girs/`: 32 of 34096 registered-enum
+	 * members, none of them in Gtk, Adw, GLib or Gio.
+	 */
+	get numericValue(): number | null {
+		const trimmed = this.value?.trim();
+		if (trimmed === undefined || !/^-?\d+$/.test(trimmed)) return null;
+		const parsed = Number(trimmed);
+		return Number.isSafeInteger(parsed) ? parsed : null;
 	}
 
 	get namespace() {
@@ -54,9 +103,16 @@ export class GirEnumMember extends IntrospectedBase<IntrospectedEnum> {
 	}
 
 	copy(): GirEnumMember {
-		const { value, name, parent, c_identifier, nick } = this;
+		const { value, name, parent, c_identifier, nick, deprecated } = this;
 
-		return new GirEnumMember(name, value, parent, c_identifier, nick)._copyBaseProperties(this);
+		return new GirEnumMember(
+			name,
+			value,
+			parent,
+			c_identifier,
+			nick,
+			deprecated,
+		)._copyBaseProperties(this);
 	}
 
 	static fromXML(element: GirMemberElement, parent: IntrospectedEnum, options: OptionsLoad): GirEnumMember {
@@ -67,7 +123,14 @@ export class GirEnumMember extends IntrospectedBase<IntrospectedEnum> {
 		// case, because a nick never differs from its name by case -- see `nick` above.
 		const nick = element.$["glib:nick"] ?? element.$.name.replace(/_/g, "-");
 
-		const enumMember = new GirEnumMember(upper, element.$.value, parent, c_identifier, nick);
+		const enumMember = new GirEnumMember(
+			upper,
+			element.$.value,
+			parent,
+			c_identifier,
+			nick,
+			isDeprecated(element),
+		);
 
 		if (options.loadDocs) {
 			enumMember.doc = parseDoc(element);

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -239,7 +239,7 @@ if (data.ENUM_NICKS?.GtkStateFlags) {
 // A suite that only checked `GtkOrientation` would pass either way: its values ARE its
 // positions. `GtkOdd.below` is -1 at position 0, so counting answers 0 and reading answers
 // -1, and only one of those can pass. That is the shape the real corpus has -- 6 of the 129
-// enums in a GTK 4 vocabulary disagree with counting, `GtkConstraintStrength.required`
+// enums in a GTK 4 vocabulary (104 in Gtk-4.0, 25 in Adw-1) disagree with counting, `GtkConstraintStrength.required`
 // by 1001001000.
 if (data.ENUM_VALUES?.["GtkOdd.below"] !== -1) {
   fail(
@@ -274,6 +274,17 @@ if (data.ENUM_VALUES_UNREADABLE?.["GtkOdd.symbolic"] !== "(null)") {
 if (data.ENUM_VALUES_UNREADABLE?.["GtkOdd.huge"] !== "9007199254740993") {
   fail("an integer past Number.MAX_SAFE_INTEGER was carried as a number instead of declared");
 }
+// The raw value is the one string the vocabulary emits that is not an identifier, and this
+// is the only member that makes its quoting do anything -- every real unreadable value in
+// `girs/` is `(null)` or a single letter, so a suite without a hostile one passes just as
+// well with the escaping deleted. Checked by ROUND TRIP: the `import()` above already had
+// to parse the module (an unescaped newline makes it a SyntaxError and takes every other
+// export with it), and the characters have to come back unchanged.
+if (data.ENUM_VALUES_UNREADABLE?.["GtkOdd.hostile"] !== "it's a \\ and a\nnewline") {
+  fail(
+    `the raw value did not survive quoting: ${JSON.stringify(data.ENUM_VALUES_UNREADABLE?.["GtkOdd.hostile"])}`,
+  );
+}
 // And the invariant the remainder exists for: nothing falls between the two tables.
 for (const [gtype, nicks] of Object.entries(data.ENUM_NICKS ?? {})) {
   for (const nick of nicks) {
@@ -289,8 +300,40 @@ for (const [gtype, nicks] of Object.entries(data.ENUM_NICKS ?? {})) {
 for (const key of Object.keys(data.ENUM_VALUES ?? {})) {
   if (key.startsWith("GtkStateFlags.")) fail(`ENUM_VALUES carries a bitfield member: ${key}`);
 }
+// THE BITFIELDS, which `ENUM_NICKS` refuses and which still have numbers.
+//
+// `GtkStateFlags.insensitive` is 8 at position 2, so this separates read from counted the
+// way `GtkOdd.below` does for the enums -- and it is the shape that matters most: 95 of 121
+// Gtk-4.0 bitfield members disagree with their position, against 29 of 685 enumeration
+// members.
+if (data.FLAG_VALUES?.["GtkStateFlags.insensitive"] !== 8) {
+  fail(`FLAG_VALUES lost the GIR value: GtkStateFlags.insensitive is ${data.FLAG_VALUES?.["GtkStateFlags.insensitive"]}, GIR says 8`);
+}
+if (data.FLAG_VALUES?.["GtkStateFlags.active"] !== 1 || data.FLAG_VALUES?.["GtkStateFlags.focused"] !== 2) {
+  fail(`FLAG_VALUES is ${JSON.stringify(data.FLAG_VALUES)}`);
+}
+if (data.FLAG_VALUES?.["GtkStateFlags.insensitive"] === 2) {
+  fail("FLAG_VALUES agrees with counting on a power-of-two member");
+}
+// The remainder reaches this table and not the enum one: every value past
+// Number.MAX_SAFE_INTEGER in ts-for-gir's `girs/` is a bitfield member.
+if (data.FLAG_VALUES_UNREADABLE?.["GtkStateFlags.beyond"] !== "9007199254740993") {
+  fail(`FLAG_VALUES_UNREADABLE is ${JSON.stringify(data.FLAG_VALUES_UNREADABLE)}`);
+}
+if ("GtkStateFlags.beyond" in (data.FLAG_VALUES ?? {})) {
+  fail("an integer past Number.MAX_SAFE_INTEGER was carried as a number instead of declared");
+}
+// And the line stays where `ENUM_NICKS` drew it: a bitfield has numbers here and no nicks
+// there, so neither table has quietly taken the other's subject.
+if (data.ENUM_NICKS?.GtkStateFlags) fail("ENUM_NICKS took a bitfield after all");
+for (const key of Object.keys(data.FLAG_VALUES ?? {})) {
+  if (key.startsWith("GtkOrientation.") || key.startsWith("GtkOdd.")) {
+    fail(`FLAG_VALUES carries a plain enum member: ${key}`);
+  }
+}
+
 // The TYPE half declares all three, or the two halves have stopped describing one surface.
-for (const name of ["ENUM_VALUES", "ENUM_DEPRECATED", "ENUM_VALUES_UNREADABLE"]) {
+for (const name of ["ENUM_VALUES", "ENUM_DEPRECATED", "ENUM_VALUES_UNREADABLE", "FLAG_VALUES", "FLAG_VALUES_UNREADABLE"]) {
   if (!new RegExp(`export const ${name}\\s*:`).test(types)) {
     fail(`the .d.ts half does not declare ${name}`);
   }
@@ -629,7 +672,7 @@ if (existsSync(brokenSurface)) fail("the broken fixture wrote a surface file bef
 // ----------------------------------------------------------------------------------
 
 if (failures.length > 0) {
-  console.error("widget-surface assertion failures:");
+  console.error("widget-vocabulary assertion failures:");
   for (const failure of failures) console.error(`  - ${failure}`);
   process.exit(1);
 }
@@ -638,7 +681,8 @@ console.log(
   `OK: ${rowGTypes.size - holders.size} widget row(s), ${holders.size} child holder(s), ` +
     `${Object.keys(data.OWN_PROPS).length} declaration(s) with props, ` +
     `${Object.keys(data.ENUM_NICKS).length} nick union(s), ` +
-    `${Object.keys(data.ENUM_VALUES).length} enum value(s) with ${Object.keys(data.ENUM_VALUES_UNREADABLE).length} declared unreadable; ` +
+    `${Object.keys(data.ENUM_VALUES).length} enum value(s) with ${Object.keys(data.ENUM_VALUES_UNREADABLE).length} declared unreadable, ` +
+    `${Object.keys(data.FLAG_VALUES).length} flag value(s) with ${Object.keys(data.FLAG_VALUES_UNREADABLE).length} declared unreadable; ` +
     `flag-off control clean; ` +
     `broken fixture rejected with exit ${brokenExit}`,
 );

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -234,6 +234,68 @@ if (!data.ENUM_NICKS?.GtkUnreferenced) {
 if (data.ENUM_NICKS?.GtkStateFlags) {
   fail("ENUM_NICKS carries a bitfield; a nick SET is not something GObject can resolve");
 }
+// THE NUMBERS BEHIND THE NICKS, and the control that separates "read" from "counted".
+//
+// A suite that only checked `GtkOrientation` would pass either way: its values ARE its
+// positions. `GtkOdd.below` is -1 at position 0, so counting answers 0 and reading answers
+// -1, and only one of those can pass. That is the shape the real corpus has -- 6 of the 129
+// enums in a GTK 4 vocabulary disagree with counting, `GtkConstraintStrength.required`
+// by 1001001000.
+if (data.ENUM_VALUES?.["GtkOdd.below"] !== -1) {
+  fail(
+    `ENUM_VALUES lost the GIR value: GtkOdd.below is ${data.ENUM_VALUES?.["GtkOdd.below"]}, GIR says -1`,
+  );
+}
+if (data.ENUM_VALUES?.["GtkOdd.below"] === data.ENUM_NICKS?.GtkOdd?.indexOf("below")) {
+  fail("ENUM_VALUES agrees with counting on the one enum where counting is wrong");
+}
+// An alias: two names, one number. Both keep an entry -- dropping either would make a
+// number un-spellable in one direction or the other -- and only `ENUM_DEPRECATED` says
+// which name is the old one.
+if (
+  data.ENUM_VALUES?.["GtkAlign.baseline"] !== 4 ||
+  data.ENUM_VALUES?.["GtkAlign.baseline-fill"] !== 4
+) {
+  fail(
+    `an alias lost one of its two names: ${JSON.stringify({
+      baseline: data.ENUM_VALUES?.["GtkAlign.baseline"],
+      "baseline-fill": data.ENUM_VALUES?.["GtkAlign.baseline-fill"],
+    })}`,
+  );
+}
+if (JSON.stringify(data.ENUM_DEPRECATED) !== JSON.stringify(["GtkAlign.baseline"])) {
+  fail(`ENUM_DEPRECATED is ${JSON.stringify(data.ENUM_DEPRECATED)}, expected the alias half only`);
+}
+// The declared remainder, with the raw attribute kept: an entry that said only "no number"
+// would leave a reader unable to tell a Vala `(null)` from an integer too large to carry.
+if (data.ENUM_VALUES_UNREADABLE?.["GtkOdd.symbolic"] !== "(null)") {
+  fail(`ENUM_VALUES_UNREADABLE lost the raw value: ${JSON.stringify(data.ENUM_VALUES_UNREADABLE)}`);
+}
+if (data.ENUM_VALUES_UNREADABLE?.["GtkOdd.huge"] !== "9007199254740993") {
+  fail("an integer past Number.MAX_SAFE_INTEGER was carried as a number instead of declared");
+}
+// And the invariant the remainder exists for: nothing falls between the two tables.
+for (const [gtype, nicks] of Object.entries(data.ENUM_NICKS ?? {})) {
+  for (const nick of nicks) {
+    const key = `${gtype}.${nick}`;
+    if (key in (data.ENUM_VALUES ?? {})) continue;
+    if (key in (data.ENUM_VALUES_UNREADABLE ?? {})) continue;
+    fail(`${key} has a nick and neither a number nor a declared reason — a silent drop`);
+  }
+}
+// Same subject as the nicks, so a bitfield is out of both: ENUM_NICKS refuses one because
+// GObject cannot resolve a nick SET, and a values table that covered more than the nicks
+// would make the invariant above a claim about an overlap instead of about one set.
+for (const key of Object.keys(data.ENUM_VALUES ?? {})) {
+  if (key.startsWith("GtkStateFlags.")) fail(`ENUM_VALUES carries a bitfield member: ${key}`);
+}
+// The TYPE half declares all three, or the two halves have stopped describing one surface.
+for (const name of ["ENUM_VALUES", "ENUM_DEPRECATED", "ENUM_VALUES_UNREADABLE"]) {
+  if (!new RegExp(`export const ${name}\\s*:`).test(types)) {
+    fail(`the .d.ts half does not declare ${name}`);
+  }
+}
+
 if (data.SINCE?.["GtkOrientable.orientation"] !== "1.2") {
   fail(`SINCE lost the GIR version attribute: ${JSON.stringify(data.SINCE)}`);
 }
@@ -575,6 +637,8 @@ if (failures.length > 0) {
 console.log(
   `OK: ${rowGTypes.size - holders.size} widget row(s), ${holders.size} child holder(s), ` +
     `${Object.keys(data.OWN_PROPS).length} declaration(s) with props, ` +
-    `${Object.keys(data.ENUM_NICKS).length} nick union(s); flag-off control clean; ` +
+    `${Object.keys(data.ENUM_NICKS).length} nick union(s), ` +
+    `${Object.keys(data.ENUM_VALUES).length} enum value(s) with ${Object.keys(data.ENUM_VALUES_UNREADABLE).length} declared unreadable; ` +
+    `flag-off control clean; ` +
     `broken fixture rejected with exit ${brokenExit}`,
 );

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -27,6 +27,23 @@
          `GtkSourceView.text-window-type` reaches `Gtk.TextWindowType`, which no Gtk-4.0
          widget property uses, and the emit-what-you-reference version left
          `@girs/gtksource-5/surface` importing a name `@girs/gtk-4.0/surface` did not have). -->
+    <!-- Two names on one value, the second deprecated: GObject's own spelling of an alias,
+         copied from GtkAlign where GTK 4.12 deprecated BASELINE into BASELINE_FILL. -->
+    <enumeration name="Align" c:type="GtkAlign" glib:type-name="GtkAlign" glib:get-type="gtk_align_get_type">
+      <member name="fill" value="0" c:identifier="GTK_ALIGN_FILL" glib:nick="fill"/>
+      <member name="start" value="1" c:identifier="GTK_ALIGN_START" glib:nick="start"/>
+      <member name="baseline_fill" value="4" c:identifier="GTK_ALIGN_BASELINE_FILL" glib:nick="baseline-fill"/>
+      <member name="baseline" value="4" c:identifier="GTK_ALIGN_BASELINE" glib:nick="baseline" deprecated="1" deprecated-version="4.12"/>
+    </enumeration>
+    <!-- The shapes counting gets wrong and the two GIR writes that no integer holds. Every
+         member here is real somewhere in `girs/`: negatives are GtkOrdering, the symbolic
+         value is Vala's `(null)`, and the letter is Gitg's char enum. -->
+    <enumeration name="Odd" c:type="GtkOdd" glib:type-name="GtkOdd" glib:get-type="gtk_odd_get_type">
+      <member name="below" value="-1" c:identifier="GTK_ODD_BELOW" glib:nick="below"/>
+      <member name="zero" value="0" c:identifier="GTK_ODD_ZERO" glib:nick="zero"/>
+      <member name="huge" value="9007199254740993" c:identifier="GTK_ODD_HUGE" glib:nick="huge"/>
+      <member name="symbolic" value="(null)" c:identifier="GTK_ODD_SYMBOLIC" glib:nick="symbolic"/>
+    </enumeration>
     <enumeration name="Unreferenced" c:type="GtkUnreferenced" glib:type-name="GtkUnreferenced" glib:get-type="gtk_unreferenced_get_type">
       <member name="one" value="0" c:identifier="GTK_UNREFERENCED_ONE" glib:nick="one"/>
       <member name="two" value="1" c:identifier="GTK_UNREFERENCED_TWO" glib:nick="two"/>

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -43,6 +43,15 @@
       <member name="zero" value="0" c:identifier="GTK_ODD_ZERO" glib:nick="zero"/>
       <member name="huge" value="9007199254740993" c:identifier="GTK_ODD_HUGE" glib:nick="huge"/>
       <member name="symbolic" value="(null)" c:identifier="GTK_ODD_SYMBOLIC" glib:nick="symbolic"/>
+      <!-- The raw value is the one string the vocabulary emits that is not an
+           identifier, so it is the one that has to survive quoting -- and the only member
+           here that makes `quote` do anything: every real unreadable value in `girs/` is
+           `(null)` or a single letter, so without this the escaping could be deleted whole
+           and the suite would still pass. The newline is deliberate and is the worst of
+           the three: a stray quote emits a wrong string, an unescaped newline emits an
+           unterminated one and every export in the module stops parsing with it. -->
+      <member name="hostile" value="it&apos;s a \ and a
+newline" c:identifier="GTK_ODD_HOSTILE" glib:nick="hostile"/>
     </enumeration>
     <enumeration name="Unreferenced" c:type="GtkUnreferenced" glib:type-name="GtkUnreferenced" glib:get-type="gtk_unreferenced_get_type">
       <member name="one" value="0" c:identifier="GTK_UNREFERENCED_ONE" glib:nick="one"/>
@@ -53,6 +62,11 @@
     <bitfield name="StateFlags" c:type="GtkStateFlags" glib:type-name="GtkStateFlags" glib:get-type="gtk_state_flags_get_type">
       <member name="active" value="1" c:identifier="GTK_STATE_FLAG_ACTIVE" glib:nick="active"/>
       <member name="focused" value="2" c:identifier="GTK_STATE_FLAG_FOCUSED" glib:nick="focused"/>
+      <!-- A power of two three positions in: counting answers 2, GObject means 8. This is
+           the shape 95 of 121 Gtk-4.0 bitfield members have. -->
+      <member name="insensitive" value="8" c:identifier="GTK_STATE_FLAG_INSENSITIVE" glib:nick="insensitive"/>
+      <!-- Every value past Number.MAX_SAFE_INTEGER in `girs/` is a bitfield member. -->
+      <member name="beyond" value="9007199254740993" c:identifier="GTK_STATE_FLAG_BEYOND" glib:nick="beyond"/>
     </bitfield>
 
     <!-- The interface that carries `orientation`. GObject installs interface properties on


### PR DESCRIPTION
`@girs/<ns>/vocabulary` gave `ENUM_NICKS` — the names GObject registers, in declaration order
— and no numbers. A consumer with no typelib still has to hand GObject an integer, so the
derivation it reaches for is counting, and **counting is wrong on 6 of the 129 enums a GTK 4
vocabulary carries** (104 of them in Gtk-4.0, the other 25 in Adw-1):

| enum | GIR says | counting says |
|---|---|---|
| `GtkResponseType.none` … `.help` | -1 … -11 | 0 … 10 |
| `GtkTextWindowType.widget` | 1 (position 0 is not a member) | 0 |
| `GtkOrdering` / `GtkConstraintRelation` | -1 / 0 / 1 | 0 / 1 / 2 |
| `GtkAlign.baseline` | 4, sharing it with `baseline-fill` | 5 |
| `GtkConstraintStrength.required` | 1001001000 | 0 |

The last one is why "off by one" is the wrong mental model.

The downstream that measured this (`gjsify`'s `gtk-host`) reads the numbers off an **installed
typelib** instead, which gives one table two provenances — nicks from the GIR the vocabulary
was generated against, values from whatever GTK the maintainer had. A member the vocabulary
describes but the host predates then looks like a missing number rather than a version gap.
Its generator header says where the numbers belong: *"`@girs/<ns>/vocabulary` is where they
BELONG, and it does not have them."*

## What the vocabulary now emits

Read from the same GIR as the nicks.

- **`ENUM_VALUES`** — `'<GType>.<nick>'` to the integer, the same key grammar `SINCE` already
  uses for a member, so a consumer reading both needs one key parser.
- **`ENUM_DEPRECATED`** — the nicks GIR marks `deprecated="1"`. Two members sharing a value is
  how GObject spells an alias; both keep an `ENUM_VALUES` entry, so nothing is lost. Evidence
  when present, **silence when absent**: only 4 registered-enum members across the 718 GIRs
  carry the flag, one of which shares its value with nothing, and 179 of the 182 value-sharing
  pairs carry it on neither half.
- **`ENUM_VALUES_UNREADABLE`** — the declared remainder, carrying the raw attribute, so a nick
  in neither table fails instead of dropping silently. **32 of 34096** registered-enum members
  over the 718 GIRs, none in Gtk, Adw, GLib or Gio.
- **`FLAG_VALUES`** and **`FLAG_VALUES_UNREADABLE`** — the same for registered bitfields.
  `ENUM_NICKS` refuses a bitfield because GObject cannot resolve a nick *set*; that reason says
  nothing about one member's number, and **21 writable widget properties** in Gtk-4.0 and Adw-1
  are bitfield-typed (`GtkEntry:input-hints`, `GtkPopoverMenu:flags`, `AdwTabView:shortcuts`, …),
  declared bare `number` with nothing to compute one from. Counting is worst exactly there:
  **95 of 121** Gtk-4.0 bitfield members disagree with their position, against 29 of 685
  enumeration members. Their own tables rather than more rows in the enum ones, so *"every nick
  in `ENUM_NICKS` has a number or a declared reason"* stays a claim about one set.

## One rule, two emitters

"Which GIR values TypeScript can carry" was a private function in the `.d.ts` emitter, added by
#455. Both emitters now ask it, so it moves to `GirEnumMember.numericValue` — a second copy is
what would drift apart while both still emitted something. Verified exhaustively: over all 1641
distinct `value` strings in `girs/`, the old function and the new getter emit byte-identical
initialisers.

**The refactor changes no generated type.** Gtk-4.0 generated against `origin/main` and against
this branch, diffed directory against directory: **0 of 22 files differ.**

`GirEnumMember` also gains `deprecated` as a first-class field rather than reading
`metadata.deprecated`, for the same reason `nick` is one: `parseMetadata` only runs when docs
are loaded, and this is a fact about the enum rather than about its documentation.

## The gate

`Mini-1.0.gir` gains an alias pair (`GtkAlign`, `baseline` and `baseline-fill` both 4, the first
deprecated), `GtkOdd` with a negative value and both unreadable shapes, a member whose value
carries a quote, a backslash and a raw newline, and a bitfield member at 8 in position 2.

The control that matters separates *read* from *counted*: a suite testing only `GtkOrientation`
would pass either way, because its values **are** its positions. `GtkOdd.below` is -1 at
position 0 and `GtkStateFlags.insensitive` is 8 at position 2, so counting and reading cannot
both pass. Replacing `numericValue` with the position turns it red on four assertions.

## What an independent review changed

- **A quoting defect that broke the whole module.** `quote()` escaped a backslash and a quote
  and no line terminator; the parser applies no XML attribute-value normalisation, so a newline
  in a `value` arrived as a newline and the emitted `.js` failed to parse — taking every export
  with it, not just that entry.
- **And the gate could not see it.** The fixture's unreadable values were `(null)` and a digit
  string, so removing `quote()`'s escaping whole was exit 0. The one hostile-input helper had
  zero coverage. Now it has a member built to break it and a round-trip assertion.
- **Four claims measurement contradicted**: 129 was the union of two files; *"an alias always is
  the deprecated half"* is false for 1 of the 4 flagged members and says nothing about 179 of
  182 aliases; the `.d.ts` fallback for an unreadable value is *previous + 1*, not the index
  (`GtkOdd.HUGE` gets 1 where GIR says 9007199254740993), and that consequence had been deleted
  along with the function that documented it; AGENTS.md pointed at `src/surface/` and
  `tests/widget-surface`, neither of which exists — the latter resolving to an untracked
  leftover directory with no test in it.
- **The bitfield gap**, which the first version justified by testability rather than need. The
  review measured the need; `FLAG_VALUES` is the answer.

`gjsify run check:app` and `gjsify run test:tests` pass.

## Not in this PR

No example. AGENTS.md asks for one per type-generation PR; this emits no type a GJS app can
exercise — the surface's own gate is `tests/widget-vocabulary`, and no example consumes
`./vocabulary`. Saying so rather than skipping it quietly.

No regenerated types: `types-dev` / `types-release` are written by the release flow, and the
`.d.ts` half is proved unchanged above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAGzf2HfFRVGeAv3u3tr9J
