### PR TITLE
feat: say which enum a property is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,9 @@ behind each of those nicks from `value` (plus each nick GIR marks deprecated —
 for the registered BITFIELDS — which get no nick union, because GObject cannot resolve a nick
 SET, and whose members still carry numbers 21 bitfield-typed widget properties need — the
 declaration-keyed join saying WHICH enum or bitfield a settable property is (without it the
-numbers are half an answer: nothing else says `orientation` is a `GtkOrientation`), a
+numbers are half an answer: nothing else says `orientation` is a `GtkOrientation`; every GType
+it names has numbers in SOME vocabulary — a referenced bitfield whose owner emits none is
+inlined, which `GtkGLArea:allowed-apis` needed and 4 more rows in the corpus with it), a
 GType-keyed `Widgets` map, and the same facts again as runtime data in the sibling `.js` —
 because types are erased and the only check that can go red for a real reason is a consumer asking the
 INSTALLED library whether every name is real. Code:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,9 @@ declaration, the construct-only name union, enum nick unions from `glib:nick`, t
 behind each of those nicks from `value` (plus each nick GIR marks deprecated — evidence only,
 4 members in 718 GIRs carry it, so absence is silence not currency), the same numbers again
 for the registered BITFIELDS — which get no nick union, because GObject cannot resolve a nick
-SET, and whose members still carry numbers 21 bitfield-typed widget properties need — a
+SET, and whose members still carry numbers 21 bitfield-typed widget properties need — the
+declaration-keyed join saying WHICH enum or bitfield a settable property is (without it the
+numbers are half an answer: nothing else says `orientation` is a `GtkOrientation`), a
 GType-keyed `Widgets` map, and the same facts again as runtime data in the sibling `.js` —
 because types are erased and the only check that can go red for a real reason is a consumer asking the
 INSTALLED library whether every name is real. Code:

--- a/packages/generator-typescript/src/vocabulary/emit-data.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-data.ts
@@ -60,6 +60,16 @@ export function emitVocabularyData(surface: WidgetVocabulary): string {
     .filter((decl) => decl.props.length > 0)
     .map((decl) => `    ${decl.gtype}: ${list(decl.props.map((prop) => prop.girName))},`);
 
+  // The join `ENUM_VALUES` needs and nothing else in the vocabulary carries: which enum or
+  // bitfield a settable property IS. Keyed by DECLARATION, like `OWN_PROPS` beside it, so a
+  // consumer walks a `DECLS` chain and reads all three at every link — `orientation` is
+  // registered on `GtkOrientable`, not on the `GtkBox` a caller starts from.
+  const propEnums = byGType.flatMap((decl) =>
+    decl.props
+      .filter((prop) => prop.enumType !== undefined)
+      .map((prop) => `    '${decl.gtype}.${prop.girName}': '${prop.enumType}',`),
+  );
+
   const ownSignals = byGType
     .filter((decl) => decl.signals.length > 0)
     .map((decl) => `    ${decl.gtype}: ${list(decl.signals)},`);
@@ -222,6 +232,18 @@ export const FLAG_VALUES = ${record(flagValues)};
 // \`girs/\` whose value is past \`Number.MAX_SAFE_INTEGER\` is a bitfield member (Fwupd, Qmi),
 // so this is the table that shape actually reaches.
 export const FLAG_VALUES_UNREADABLE = ${record(flagUnreadable)};
+
+// Declaration GType + property name -> the GType of that property's enum or bitfield.
+//
+// Without it the value tables above are half an answer. A host with no GI knows it must set
+// \`orientation\` to the number behind the nick \`vertical\`; \`ENUM_VALUES\` is keyed
+// \`GtkOrientation.vertical\`, and nothing else says that \`orientation\` is a
+// \`GtkOrientation\`. Deriving it is not available: \`never\` is a member of several Gtk enums,
+// and choosing between them produces a wrong number rather than a missing one.
+//
+// Only where the property's OWN type is the enum. An array of them and a union that mentions
+// one are both entries a consumer would resolve wrongly, so neither is written.
+export const PROP_ENUMS = ${record(propEnums)};
 
 export const SLOT_CANDIDATES = ${record(slots)};
 

--- a/packages/generator-typescript/src/vocabulary/emit-data.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-data.ts
@@ -243,6 +243,10 @@ export const FLAG_VALUES_UNREADABLE = ${record(flagUnreadable)};
 //
 // Only where the property's OWN type is the enum. An array of them and a union that mentions
 // one are both entries a consumer would resolve wrongly, so neither is written.
+//
+// A GType named here has numbers in SOME vocabulary, not necessarily this one: the namespace
+// that OWNS an enum publishes it, so 57 of the 438 entries a full run emits want the owner's
+// vocabulary loaded too. Owners that emit none (Gdk, Pango) are inlined into the tables above.
 export const PROP_ENUMS = ${record(propEnums)};
 
 export const SLOT_CANDIDATES = ${record(slots)};

--- a/packages/generator-typescript/src/vocabulary/emit-types.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-types.ts
@@ -365,6 +365,13 @@ export const FLAG_VALUES_UNREADABLE: Readonly<Record<string, string>>;
  *
  * Present only where the property's OWN type is the enum: an array of them, or a union that
  * merely mentions one, would be an entry a consumer resolves wrongly.
+ *
+ * The GType named here is not always one THIS module gives numbers for. A nick vocabulary is
+ * emitted once, by the namespace that owns the enum, so \`AdwComboRow.search-match-mode\` names
+ * \`GtkStringFilterMatchMode\` and its rows are in \`@girs/gtk-4.0/vocabulary\` — 57 of the 438
+ * entries in a full run resolve only with the owner's vocabulary loaded beside this one. An
+ * owner with no vocabulary of its own (Gdk, Pango) is inlined here instead, so every entry
+ * resolves against SOME module.
  */
 export const PROP_ENUMS: Readonly<Record<string, string>>;
 

--- a/packages/generator-typescript/src/vocabulary/emit-types.ts
+++ b/packages/generator-typescript/src/vocabulary/emit-types.ts
@@ -354,6 +354,20 @@ export const FLAG_VALUES: Readonly<Record<string, number>>;
 /** \`<bitfield GType>.<nick>\` -> the raw GIR \`value\` no number could be read from. */
 export const FLAG_VALUES_UNREADABLE: Readonly<Record<string, string>>;
 
+/**
+ * \`<declaration GType>.<property>\` -> the GType of that property's enum or bitfield.
+ *
+ * The join the value tables need and nothing else here carries. A host with no GI has a
+ * property name and a nick and needs a number; \`ENUM_VALUES\` is keyed by ENUM GType, and
+ * only this says which enum a property is. Keyed by DECLARATION like \`OWN_PROPS\`, so it is
+ * read at every link of a \`DECLS\` chain — \`orientation\` belongs to \`GtkOrientable\`, not
+ * to the \`GtkBox\` a caller starts from.
+ *
+ * Present only where the property's OWN type is the enum: an array of them, or a union that
+ * merely mentions one, would be an entry a consumer resolves wrongly.
+ */
+export const PROP_ENUMS: Readonly<Record<string, string>>;
+
 /** Widget GType -> slot name -> the method that may adopt a child there. */
 export const SLOT_CANDIDATES: Readonly<Record<string, Readonly<Record<string, string>>>>;
 

--- a/packages/generator-typescript/src/vocabulary/model.ts
+++ b/packages/generator-typescript/src/vocabulary/model.ts
@@ -470,6 +470,16 @@ interface PrintedType {
   /** Enums whose nick alias the text references. */
   readonly enums: readonly VocabularyEnum[];
   /**
+   * Registered bitfields the text references, which get no nick alias and still need numbers.
+   *
+   * A bitfield prints as bare `number`, so nothing about the TEXT asks for it — `PROP_ENUMS`
+   * does. Naming a bitfield no table gives numbers for is a join into nothing, and it is not
+   * hypothetical: `GtkGLArea:allowed-apis` is a `GdkGLAPI`, Gdk declares no widget and so
+   * emits no vocabulary, and 5 rows in the 142-vocabulary corpus pointed at a GType no
+   * vocabulary carried.
+   */
+  readonly flags: readonly VocabularyEnum[];
+  /**
    * The GType of the property's OWN type, when that type is a registered enum or bitfield.
    *
    * Recorded at depth 0 only, which is what makes it a fact rather than a guess: an array of
@@ -501,6 +511,7 @@ function printPropType(
 ): PrintedType {
   const namespaces = new Set<string>();
   const enums = new Map<string, VocabularyEnum>();
+  const flags = new Map<string, VocabularyEnum>();
   /** Set only from depth 0 — see `PrintedType.ownEnumType`. */
   let ownEnumType: string | undefined;
 
@@ -528,19 +539,25 @@ function printPropType(
       if (enumeration) {
         // A bitfield's GType is recorded even though its TEXT is `number`: the reason
         // `ENUM_NICKS` refuses one is that GObject cannot resolve a nick SET, and that says
-        // nothing about a single member's number. 21 writable widget properties in Gtk-4.0
-        // and Adw-1 are bitfield-typed, and this is the only thing that says which bitfield.
+        // nothing about a single member's number. 10 of the 104 properties this table keys
+        // in Gtk-4.0 and Adw-1 are bitfield-typed (8 + 2), and nothing else says which
+        // bitfield. The 21 counted for `FLAG_VALUES` is a different set: it covers every
+        // Gtk/Adw class, and 11 of those 21 sit on declarations no widget chain reaches.
         if (depth === 0 && enumeration.glibTypeName) ownEnumType = enumeration.glibTypeName;
+        const gtype = enumeration.glibTypeName;
+        const reference = `${resolved.namespace}.${resolved.name}`;
         // Flags stay `number` in both positions, mirroring the runtime: GObject
         // exposes no way to resolve a nick SET ("horizontal|vertical"), so a union
-        // of nicks would type something every host has to reject.
-        if (enumeration.flags) return "number";
-        const gtype = enumeration.glibTypeName;
+        // of nicks would type something every host has to reject. The MEMBERS are
+        // collected anyway — see `PrintedType.flags` for the join that needs them.
+        if (enumeration.flags) {
+          if (gtype) flags.set(gtype, vocabularyEnumOf(gtype, reference, enumeration));
+          return "number";
+        }
         // An unregistered enum has no GType, therefore no nicks GObject knows,
         // therefore nothing a string could be checked against.
-        if (!gtype) return `${resolved.namespace}.${resolved.name}`;
+        if (!gtype) return reference;
         namespaces.add(resolved.namespace);
-        const reference = `${resolved.namespace}.${resolved.name}`;
         enums.set(gtype, vocabularyEnumOf(gtype, reference, enumeration));
         return `${nickAliasOf(gtype)} | ${reference}`;
       }
@@ -559,6 +576,7 @@ function printPropType(
     text,
     namespaces: [...namespaces],
     enums: [...enums.values()],
+    flags: [...flags.values()],
     ...(ownEnumType === undefined ? {} : { ownEnumType }),
   };
 }
@@ -824,6 +842,17 @@ export function buildWidgetVocabulary(
         continue;
       }
       enums.set(enumeration.gtype, enumeration);
+    }
+    for (const bitfield of printed.flags) {
+      const owner = module.getInstalledImport(
+        bitfield.reference.slice(0, bitfield.reference.indexOf(".")),
+      );
+      // Same division as the enums above, minus the import: a bitfield gets no nick union,
+      // so there is no NAME to bring over, only numbers. They live in the owner's own
+      // vocabulary when it has one and here when it does not — which is the case
+      // `PROP_ENUMS` broke, Gdk owning `GdkGLAPI` and declaring no widget to emit it.
+      if (owner && owner !== module && declaresWidgets(owner)) continue;
+      flags.set(bitfield.gtype, bitfield);
     }
   };
 

--- a/packages/generator-typescript/src/vocabulary/model.ts
+++ b/packages/generator-typescript/src/vocabulary/model.ts
@@ -88,6 +88,16 @@ const acceptsNothing = (ts: string): boolean => /\bnever\b/.test(ts);
 export interface VocabularyProp {
   /** The name GObject registered — `icon-name`, dashed. */
   readonly girName: string;
+  /**
+   * The GType of this property's enum or bitfield type, where it has one.
+   *
+   * The join a host without GI cannot make for itself: it knows a property name and a nick
+   * and needs a number, `ENUM_VALUES` is keyed by ENUM GType, and nothing else says which
+   * enum a property is. Deriving it by searching the nick lists is not available — `never`
+   * is a member of several Gtk enums, and picking between them is a wrong number rather than
+   * a missing one.
+   */
+  readonly enumType?: string;
   readonly ts: string;
   readonly constructOnly: boolean;
   readonly since?: string;
@@ -459,6 +469,15 @@ interface PrintedType {
   readonly namespaces: readonly string[];
   /** Enums whose nick alias the text references. */
   readonly enums: readonly VocabularyEnum[];
+  /**
+   * The GType of the property's OWN type, when that type is a registered enum or bitfield.
+   *
+   * Recorded at depth 0 only, which is what makes it a fact rather than a guess: an array of
+   * enums and a union that mentions one both reference an enum without BEING one, and a
+   * consumer resolving a nick against them would be resolving the wrong thing. `enums` above
+   * stays the set the TEXT references, which is a different question with a different answer.
+   */
+  readonly ownEnumType?: string;
 }
 
 /**
@@ -482,6 +501,8 @@ function printPropType(
 ): PrintedType {
   const namespaces = new Set<string>();
   const enums = new Map<string, VocabularyEnum>();
+  /** Set only from depth 0 — see `PrintedType.ownEnumType`. */
+  let ownEnumType: string | undefined;
 
   const walk = (node: TypeExpression, depth: number): string => {
     if (depth > 8) throw new VocabularyError(`${where}: type nests deeper than 8 levels`);
@@ -505,6 +526,11 @@ function printPropType(
         throw new VocabularyError(`${where}: namespace ${resolved.namespace} is not installed`);
       const enumeration = owner.getEnum(resolved.name);
       if (enumeration) {
+        // A bitfield's GType is recorded even though its TEXT is `number`: the reason
+        // `ENUM_NICKS` refuses one is that GObject cannot resolve a nick SET, and that says
+        // nothing about a single member's number. 21 writable widget properties in Gtk-4.0
+        // and Adw-1 are bitfield-typed, and this is the only thing that says which bitfield.
+        if (depth === 0 && enumeration.glibTypeName) ownEnumType = enumeration.glibTypeName;
         // Flags stay `number` in both positions, mirroring the runtime: GObject
         // exposes no way to resolve a nick SET ("horizontal|vertical"), so a union
         // of nicks would type something every host has to reject.
@@ -528,7 +554,13 @@ function printPropType(
     throw new VocabularyError(`${where}: unsupported type expression ${node.constructor.name}`);
   };
 
-  return { text: walk(type, 0), namespaces: [...namespaces], enums: [...enums.values()] };
+  const text = walk(type, 0);
+  return {
+    text,
+    namespaces: [...namespaces],
+    enums: [...enums.values()],
+    ...(ownEnumType === undefined ? {} : { ownEnumType }),
+  };
 }
 
 /**
@@ -576,6 +608,7 @@ function ownProps(
     collect(printed);
     byName.set(girName, {
       girName,
+      ...(printed.ownEnumType === undefined ? {} : { enumType: printed.ownEnumType }),
       ts: printed.text,
       constructOnly: prop.constructOnly,
       since: prop.metadata?.introducedVersion,

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -321,14 +321,52 @@ if ("GtkWidget.axes" in (data.PROP_ENUMS ?? {})) {
 }
 // And a property with no enum type at all has no entry.
 if ("GtkBox.spacing" in (data.PROP_ENUMS ?? {})) fail("PROP_ENUMS claims a plain int property");
+// A bitfield from a namespace that emits NO vocabulary of its own, which is the case the
+// join silently broke: `printPropType` returned `number` for a bitfield before collecting
+// it, so `FLAG_VALUES` only ever carried the ones this namespace DECLARES. `PROP_ENUMS`
+// then named `GdkGLAPI` for `GtkGLArea:allowed-apis` with no table anywhere holding its
+// numbers -- 5 such rows in the 142 generated vocabularies, every one of them a bitfield.
+if (data.PROP_ENUMS?.["GtkWidget.binding-flags"] !== "GBindingFlags") {
+  fail(`PROP_ENUMS omits the foreign bitfield: ${JSON.stringify(data.PROP_ENUMS)}`);
+}
+// The invariant that makes the join a join, and the same one `ENUM_NICKS` is held to above:
+// a GType named here has numbers to be resolved against.
+const numbered = new Set(
+  [
+    ...Object.keys(data.ENUM_VALUES ?? {}),
+    ...Object.keys(data.FLAG_VALUES ?? {}),
+    ...Object.keys(data.ENUM_VALUES_UNREADABLE ?? {}),
+    ...Object.keys(data.FLAG_VALUES_UNREADABLE ?? {}),
+  ].map((key) => key.slice(0, key.lastIndexOf("."))),
+);
+for (const [key, gtype] of Object.entries(data.PROP_ENUMS ?? {})) {
+  if (numbered.has(gtype)) continue;
+  fail(
+    `PROP_ENUMS says ${key} is a ${gtype}, and no value table carries one — a join into nothing`,
+  );
+}
+// The other half of the same containment `OWN_PROPS` is held to above: a key here names a
+// declaration and a property that declaration actually offers. A table keyed by anything
+// else — the concrete widget, the underscored spelling — is one a `DECLS` walk cannot hit.
+for (const key of Object.keys(data.PROP_ENUMS ?? {})) {
+  const gtype = key.slice(0, key.indexOf("."));
+  const prop = key.slice(key.indexOf(".") + 1);
+  if ((data.OWN_PROPS?.[gtype] ?? []).includes(prop)) continue;
+  fail(`PROP_ENUMS keys ${key}, which OWN_PROPS[${gtype}] does not offer`);
+}
 // End to end, the way a consumer actually walks it: widget -> DECLS chain -> PROP_ENUMS ->
 // ENUM_VALUES. If this stops working the three tables have stopped being one answer.
 {
   const chain = data.DECLS?.GtkBox ?? [];
   const owner = chain.find((gtype) => `${gtype}.orientation` in (data.PROP_ENUMS ?? {}));
-  const resolved = owner === undefined ? undefined : data.ENUM_VALUES?.[`${data.PROP_ENUMS[`${owner}.orientation`]}.vertical`];
+  const resolved =
+    owner === undefined
+      ? undefined
+      : data.ENUM_VALUES?.[`${data.PROP_ENUMS[`${owner}.orientation`]}.vertical`];
   if (resolved !== 1) {
-    fail(`walking GtkBox -> DECLS -> PROP_ENUMS -> ENUM_VALUES for \`vertical\` gave ${resolved}, expected 1`);
+    fail(
+      `walking GtkBox -> DECLS -> PROP_ENUMS -> ENUM_VALUES for \`vertical\` gave ${resolved}, expected 1`,
+    );
   }
 }
 
@@ -365,7 +403,14 @@ for (const key of Object.keys(data.FLAG_VALUES ?? {})) {
 }
 
 // The TYPE half declares all three, or the two halves have stopped describing one surface.
-for (const name of ["ENUM_VALUES", "ENUM_DEPRECATED", "ENUM_VALUES_UNREADABLE", "FLAG_VALUES", "FLAG_VALUES_UNREADABLE", "PROP_ENUMS"]) {
+for (const name of [
+  "ENUM_VALUES",
+  "ENUM_DEPRECATED",
+  "ENUM_VALUES_UNREADABLE",
+  "FLAG_VALUES",
+  "FLAG_VALUES_UNREADABLE",
+  "PROP_ENUMS",
+]) {
   if (!new RegExp(`export const ${name}\\s*:`).test(types)) {
     fail(`the .d.ts half does not declare ${name}`);
   }
@@ -714,7 +759,8 @@ console.log(
     `${Object.keys(data.OWN_PROPS).length} declaration(s) with props, ` +
     `${Object.keys(data.ENUM_NICKS).length} nick union(s), ` +
     `${Object.keys(data.ENUM_VALUES).length} enum value(s) with ${Object.keys(data.ENUM_VALUES_UNREADABLE).length} declared unreadable, ` +
-    `${Object.keys(data.FLAG_VALUES).length} flag value(s) with ${Object.keys(data.FLAG_VALUES_UNREADABLE).length} declared unreadable; ` +
+    `${Object.keys(data.FLAG_VALUES).length} flag value(s) with ${Object.keys(data.FLAG_VALUES_UNREADABLE).length} declared unreadable, ` +
+    `${Object.keys(data.PROP_ENUMS).length} property/enum join(s); ` +
     `flag-off control clean; ` +
     `broken fixture rejected with exit ${brokenExit}`,
 );

--- a/tests/widget-vocabulary/assert.mjs
+++ b/tests/widget-vocabulary/assert.mjs
@@ -300,6 +300,38 @@ for (const [gtype, nicks] of Object.entries(data.ENUM_NICKS ?? {})) {
 for (const key of Object.keys(data.ENUM_VALUES ?? {})) {
   if (key.startsWith("GtkStateFlags.")) fail(`ENUM_VALUES carries a bitfield member: ${key}`);
 }
+// THE JOIN, without which the value tables are half an answer.
+//
+// A host with no GI has a property name and a nick and needs a number. `ENUM_VALUES` is keyed
+// by ENUM GType, and only `PROP_ENUMS` says which enum a property is. Keyed by DECLARATION:
+// `orientation` is registered on the `GtkOrientable` INTERFACE, so a consumer that looked it
+// up under `GtkBox` would find nothing.
+if (data.PROP_ENUMS?.["GtkOrientable.orientation"] !== "GtkOrientation") {
+  fail(`PROP_ENUMS lost the interface-declared property: ${JSON.stringify(data.PROP_ENUMS)}`);
+}
+// A bitfield gets an entry even though `ENUM_NICKS` refuses it — the refusal is about a nick
+// SET, and this is about one member's number.
+if (data.PROP_ENUMS?.["GtkWidget.state-flags"] !== "GtkStateFlags") {
+  fail(`PROP_ENUMS omits the bitfield-typed property: ${JSON.stringify(data.PROP_ENUMS)}`);
+}
+// The control for the depth-0 rule: an ARRAY of a registered enum references one without
+// being one. An entry here would be a nick resolved against the wrong thing.
+if ("GtkWidget.axes" in (data.PROP_ENUMS ?? {})) {
+  fail("PROP_ENUMS claims an array-of-enum property, which no consumer can resolve a nick against");
+}
+// And a property with no enum type at all has no entry.
+if ("GtkBox.spacing" in (data.PROP_ENUMS ?? {})) fail("PROP_ENUMS claims a plain int property");
+// End to end, the way a consumer actually walks it: widget -> DECLS chain -> PROP_ENUMS ->
+// ENUM_VALUES. If this stops working the three tables have stopped being one answer.
+{
+  const chain = data.DECLS?.GtkBox ?? [];
+  const owner = chain.find((gtype) => `${gtype}.orientation` in (data.PROP_ENUMS ?? {}));
+  const resolved = owner === undefined ? undefined : data.ENUM_VALUES?.[`${data.PROP_ENUMS[`${owner}.orientation`]}.vertical`];
+  if (resolved !== 1) {
+    fail(`walking GtkBox -> DECLS -> PROP_ENUMS -> ENUM_VALUES for \`vertical\` gave ${resolved}, expected 1`);
+  }
+}
+
 // THE BITFIELDS, which `ENUM_NICKS` refuses and which still have numbers.
 //
 // `GtkStateFlags.insensitive` is 8 at position 2, so this separates read from counted the
@@ -333,7 +365,7 @@ for (const key of Object.keys(data.FLAG_VALUES ?? {})) {
 }
 
 // The TYPE half declares all three, or the two halves have stopped describing one surface.
-for (const name of ["ENUM_VALUES", "ENUM_DEPRECATED", "ENUM_VALUES_UNREADABLE", "FLAG_VALUES", "FLAG_VALUES_UNREADABLE"]) {
+for (const name of ["ENUM_VALUES", "ENUM_DEPRECATED", "ENUM_VALUES_UNREADABLE", "FLAG_VALUES", "FLAG_VALUES_UNREADABLE", "PROP_ENUMS"]) {
   if (!new RegExp(`export const ${name}\\s*:`).test(types)) {
     fail(`the .d.ts half does not declare ${name}`);
   }

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -153,6 +153,13 @@ newline" c:identifier="GTK_ODD_HOSTILE" glib:nick="hostile"/>
       <property name="state-flags" writable="1" transfer-ownership="none">
         <type name="StateFlags" c:type="GtkStateFlags"/>
       </property>
+      <!-- A bitfield owned by a namespace that declares no widget and therefore emits no
+           vocabulary. `PROP_ENUMS` names its GType, so some table has to carry its numbers,
+           and before the fix none did: the real instance is `GtkGLArea:allowed-apis`, a
+           `GdkGLAPI`, one of 5 rows in the corpus pointing at a GType no vocabulary held. -->
+      <property name="binding-flags" writable="1" transfer-ownership="none">
+        <type name="GObject.BindingFlags" c:type="GBindingFlags"/>
+      </property>
       <!-- READ-ONLY. `ConstructorProps` offers this as settable; writing it is exit 0. -->
       <property name="parent" readable="1" writable="0" transfer-ownership="none">
         <type name="Widget" c:type="GtkWidget*"/>

--- a/tests/widget-vocabulary/fixtures/Mini-1.0.gir
+++ b/tests/widget-vocabulary/fixtures/Mini-1.0.gir
@@ -142,6 +142,14 @@ newline" c:identifier="GTK_ODD_HOSTILE" glib:nick="hostile"/>
           <type name="utf8" c:type="gchar*"/>
         </array>
       </property>
+      <!-- An ARRAY of a registered enum: references one without BEING one, so PROP_ENUMS
+           must NOT claim it — a consumer resolving a nick against it resolves the wrong
+           thing. This is the control for the depth-0 rule. -->
+      <property name="axes" writable="1" transfer-ownership="none">
+        <array>
+          <type name="Orientation" c:type="GtkOrientation"/>
+        </array>
+      </property>
       <property name="state-flags" writable="1" transfer-ownership="none">
         <type name="StateFlags" c:type="GtkStateFlags"/>
       </property>


### PR DESCRIPTION
v4.8.0 gave the vocabulary the numbers behind every nick. A consumer measured what that is worth
on its own, and the answer is: half an answer.

## The measured case

gjsify's in-repo Blueprint parser emits GtkBuilder XML and must write
`<property name="orientation">1</property>` where the source says `orientation: vertical`. It
has the nick and the property name.

- `ENUM_VALUES` is keyed `GtkOrientation.vertical` → `1`. ✅ shipped in #465.
- Nothing in the runtime half says that `orientation` **is** a `GtkOrientation`. `OWN_PROPS`
  carries names, `ENUM_NICKS` is keyed by enum GType, and the `.d.ts` types the property in a
  form that is erased exactly where an emitter needs it.

**Eleven of that repo's thirty-seven corpus files sit in a divergence ledger for this one
missing join.** Deriving it is not available, and that is the point: `never` is a member of
several Gtk enums, so searching the nick lists produces a *wrong* number rather than a missing
one.

## What lands

**`PROP_ENUMS`** — `'<declaration GType>.<property>'` → the enum or bitfield GType.

- **Keyed by declaration**, like `OWN_PROPS` beside it, so it is read at every link of a
  `DECLS` chain. `orientation` is registered on the `GtkOrientable` *interface*; a consumer
  that looked it up under `GtkBox` would find nothing.
- **Bitfields get an entry too.** `ENUM_NICKS` refuses one because GObject cannot resolve a
  nick *set*; that says nothing about a single member's number, and `FLAG_VALUES` (also #465)
  holds those numbers.
- **Depth 0 only.** An array of enums and a union that merely mentions one both reference an
  enum without *being* one, and an entry for either is a nick resolved against the wrong thing.

## The gate

The fixture gains an array-of-enum property as the control for the depth rule: removing the
depth check turns it red with *"PROP_ENUMS claims an array-of-enum property, which no consumer
can resolve a nick against"*. Asserted alongside: the interface-declared property, the
bitfield-typed one, and that a plain `int` property gets no entry.

And the suite now walks it the way a consumer does — `GtkBox` → `DECLS` chain → `PROP_ENUMS` →
`ENUM_VALUES` → `1` — so the three tables are held to being *one* answer rather than three that
happen to exist side by side.

`gjsify run check:app` and `gjsify run test:tests` pass.

## What the review changed

**A join into nothing, and the flagship namespace had one.** Measured over all 719 GIRs (142
vocabularies): 5 of the 438 entries pointed at a GType no vocabulary anywhere gives numbers for,
including `PROP_ENUMS['GtkGLArea.allowed-apis'] = 'GdkGLAPI'` — while Gtk-4.0's `FLAG_VALUES`
holds twenty flag GTypes, every one of them `Gtk*`.

The cause is a line older than this PR: `printPropType` returns `"number"` for a bitfield
*before* the line that collects a referenced enum, so `surface.flags` was only ever filled from
the bitfields a namespace **declares**. Referenced enums were collected all along — that is why
Gtk-4.0 publishes `PangoEllipsizeMode` — and referenced bitfields never were. Nothing pointed at
them before, so it was invisible. All four dangling GTypes are Gdk bitfields, and Gdk declares no
widget, so it emits no vocabulary at all.

Registered bitfields now follow the same owner rule the enums already use. Resolvable nowhere:
**5 → 0**. Gtk-4.0 grows 46 bytes.

The invariant is asserted now — every GType `PROP_ENUMS` names has a row in some value table —
with a fixture control typed `GObject.BindingFlags`, a bitfield owned by a namespace with no
vocabulary. On this PR as submitted that emitted `'GtkWidget.binding-flags': 'GBindingFlags'`
with no `GBindingFlags` anywhere and the suite stayed green.

**62 of 438 entries need a sibling vocabulary loaded.** `AdwComboRow.search-match-mode` is a
`GtkStringFilterMatchMode` and Adw-1 carries none of it: walking Adw-1 alone resolves 31 of 43,
with `gtk-4.0` loaded 43 of 43. That follows the existing owner convention, so it is documented
where a consumer reads it rather than changed.

**One measured number was wrong.** A comment claimed 21 bitfield-typed widget properties;
`PROP_ENUMS` keys 10. The 21 counts all Gtk/Adw classes, 11 of which no widget chain reaches.

## What the review verified

- **The depth-0 rule is lossless.** Static scan of 31,051 writable properties across 719 GIRs:
  zero nullable-enum, zero aliased-enum, zero array-of-enum properties. Then an in-pipeline
  probe over the whole 142-vocabulary run: 15,373 property printings, **0** where a deep enum
  was seen without a depth-0 own type.
- **Keying is complete on Gtk-4.0 + Adw-1**: 104 enum-typed writable properties, 104 keyed, 0
  in `OWN_PROPS` without an entry, 0 entries without GIR backing, 0 duplicate keys across all
  142 vocabularies.
- **End to end**: Gtk-4.0 resolves 527 of 527 (widget, declaration, property) walks to a number
  after the fix.
- **Cost**: 3,530 B of Gtk-4.0's 85,206 B module (4.1%). Nesting by declaration would be
  *larger* — 4,218 B — because 67 entries over 48 declarations averages 1.4 props each and the
  braces cost more than the repeated GType.
- **The main `.d.ts` is byte-identical** to the pre-PR baseline for both Gtk-4.0 and Adw-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAGzf2HfFRVGeAv3u3tr9J
