### PR TITLE
docs: why @girs sibling ranges are carets, plus a build-time closure check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ on:
       - 'tests/**'
       - 'girs/**'
       - 'examples/**'
+      # `gjsify run check` runs the `scripts/check-*.mjs` gates, so a change to ONE OF THE GATES
+      # has to be able to fail CI. Without this line a PR that touches only `scripts/` matches no
+      # path and gets no CI at all -- which does not read as "skipped", it reads as "still
+      # queued", and a gate that ships without ever having run is the defect this very directory
+      # exists to catch.
+      - 'scripts/**'
       - 'package.json'
       - 'gjsify-lock.json'
       - '.ts-for-gir.*.rc.js'
@@ -37,6 +43,7 @@ on:
       - 'tests/**'
       - 'girs/**'
       - 'examples/**'
+      - 'scripts/**'
       - 'package.json'
       - 'gjsify-lock.json'
       - '.ts-for-gir.*.rc.js'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,15 @@ jobs:
       - name: Show diff
         if: steps.filter.outputs.generator == 'true' || github.event_name == 'workflow_dispatch'
         run: (cd ./types-dev && git diff | cat)
+      # The generated set is published as a SET: every `@girs/*` package declares its siblings as
+      # runtime dependencies. A manifest naming a namespace this run did not emit is uninstallable
+      # from the day it ships — and neither `check:types` nor the diff above can see it, because
+      # both read the tree that is missing the dependency rather than the declaration that wants
+      # it. Asked here, where the fix is a regeneration; the publisher in gjsify/types asks the
+      # same question of the registry, but only once part of the set is already out. See
+      # PUBLISHING.md.
+      - run: node --no-warnings scripts/check-dependency-closure.mjs ./types-dev
+        if: steps.filter.outputs.generator == 'true' || github.event_name == 'workflow_dispatch'
       - run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run build:examples
         if: steps.filter.outputs.examples == 'true' || github.event_name == 'workflow_dispatch'
       - run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run check:examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,10 @@ jobs:
       # it. Asked here, where the fix is a regeneration; the publisher in gjsify/types asks the
       # same question of the registry, but only once part of the set is already out. See
       # PUBLISHING.md.
+      #
+      # The `check` job already runs this script on the COMMITTED types-dev (it is part of
+      # `gjsify run check`); this step asks it again of the tree `build:types` just wrote, which
+      # is the one a generator change can break -- hence the same guard as `build:types`.
       - run: node --no-warnings scripts/check-dependency-closure.mjs ./types-dev
         if: steps.filter.outputs.generator == 'true' || github.event_name == 'workflow_dispatch'
       - run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run build:examples

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -67,6 +67,18 @@ The components are computed, never listed by hand. The first count of the v4.9.0
 component is six wide, so the real number for that sample is 7. A hand-written exemption list was
 five packages wrong on the only cycle this graph has.
 
+**What is left after the fix.** npm has no atomic multi-package publish, so the cycle keeps a
+window of its own: the six go out one after another as the first group, and the first of them
+names the last. At v4.9.0's observed pace (127.7 min / 716 = 10.7 s per package) that is
+
+| | before | after |
+|---|---|---|
+| packages published with an incomplete closure | 508 | 6 |
+| how long | 128 min | ~54 s |
+
+and it is the remainder, not an oversight: no order can shorten it, and the gate exempts it on
+purpose. Everything outside the cycle — the other 710 packages — has no window at all.
+
 ## Why sibling ranges are carets, not exact pins
 
 Generated `@girs/*` manifests declare siblings as `^<version>` — all 7637 edges of the v4.9.0 tree.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,156 @@
+# Publishing `@girs/*`
+
+One ts-for-gir release publishes 716 npm packages that depend on each other. This is the part of
+that which is not obvious, and the decisions that were made with a measurement rather than a
+preference.
+
+Where the code lives: the generator writes the manifests (`packages/lib/src/dependency-manager.ts`),
+[gjsify/types](https://github.com/gjsify/types) holds the generated tree and publishes it
+(`.github/release-script/`).
+
+## The release is a set, and a set is published in an order
+
+A `@girs/*` package declares its siblings as runtime dependencies — `@girs/adw-1` names fifteen of
+them. Until every one of those is on the registry, the package is installed but not installable:
+npm finds it, resolves its dependencies, and fails on the one that is not there yet.
+
+**This went wrong in v4.9.0.** The publisher walked the tree in `readdir` order, which is neither
+sorted nor topological. Measured afterwards from the registry's own `time` maps:
+
+| | |
+|---|---|
+| first package published | `@girs/abi-3.0`, 2026-09-10 22:15:33Z |
+| last package published | `@girs/xkl-1.0`, 2026-09-11 00:23:15Z |
+| length of the sweep | 128 minutes |
+| published before something they depend on existed | **508 of 716** |
+| worst case | `@girs/abi-3.0` waited 125 min for `@girs/xlib-2.0` |
+
+gjsify's e2e legs went red twice inside that window with
+
+```
+npm error notarget No matching version found for @girs/pango-1.0@^4.9.0
+```
+
+which names neither the package the consumer asked for nor the repository the cause lives in.
+Diagnosis cost more than the bug.
+
+**The fix is in the publisher, and it has two halves** — the first prevents, the second proves:
+
+1. **Topological order.** `planPublishOrder` condenses the dependency graph into its strongly
+   connected components (Tarjan) and publishes the components in an order where nothing precedes
+   what it needs.
+2. **A closure gate after every publish group.** The registry — not our own bookkeeping — is asked
+   whether each member's dependencies now resolve. A gap fails the run at the moment it happens,
+   naming the package, the dependency and the range.
+
+Plus a real `npm install` of the whole published set into an empty directory at the end, which is
+the only check that also proves the tarballs exist. Measured: 5.5 minutes and 225 MB for the full
+716-package set on a cold cache.
+
+### The graph has a cycle, and it is six namespaces wide
+
+GIR namespaces reference each other, so the `@girs` graph is not a DAG. Tarjan over the v4.9.0
+tree finds exactly one non-trivial component:
+
+```
+cairo-1.0 · gio-2.0 · gjs · glib-2.0 · gmodule-2.0 · gobject-2.0
+```
+
+No order can make a cycle member's closure complete at its own publish instant — whichever goes
+first necessarily points at one that is not there yet. That is why the unit of both halves is the
+**group**, not the package: a component publishes together, and the gate exempts the edges inside
+it. A per-package gate would be red on a perfectly ordered release, and a gate that is red when
+the system is right gets switched off.
+
+The components are computed, never listed by hand. The first count of the v4.9.0 damage exempted
+`glib-2.0`/`gobject-2.0` as "the cycle" and reported 12 offenders in a 16-package sample; the
+component is six wide, so the real number for that sample is 7. A hand-written exemption list was
+five packages wrong on the only cycle this graph has.
+
+## Why sibling ranges are carets, not exact pins
+
+Generated `@girs/*` manifests declare siblings as `^<version>` — all 7637 edges of the v4.9.0 tree.
+Exact pins (`--depVersionFormat=exact`) look like they would have protected a consumer during the
+window above, and for a consumer pinning an OLD release they would have. They were still the wrong
+answer, and the reason is measurable.
+
+Two packages of the same `@girs` set reached over two different ts-for-gir releases — a direct
+dependency on one, a transitive dependency on the other — is the ordinary case, not a corner:
+
+```jsonc
+// probe: @girs/gtk-4.0 directly, @girs/adw-1 which needs @girs/gtk-4.0 too
+{ "@girs/gtk-4.0": "^4.8.0", "@girs/adw-1": "^4.9.0" }   // carets
+{ "@girs/gtk-4.0":  "4.8.0", "@girs/adw-1":  "4.9.0" }   // exact
+```
+
+Measured with `npm install` and `tsc 5.9.3`:
+
+| | carets | exact pins |
+|---|---|---|
+| `@girs/*` packages installed | 16 | 17 — `@girs/gtk-4.0` twice |
+| `node_modules` | 16 MB | 23 MB |
+| TypeScript errors | **0** | **5** |
+
+The five are the failure this project already has a number for — [#431](https://github.com/gjsify/ts-for-gir/issues/431):
+
+```
+node_modules/@girs/adw-1/node_modules/@girs/gtk-4.0/gtk-4.0-ambient.d.ts(4,20):
+  error TS2300: Duplicate identifier 'Gtk40'.
+node_modules/@girs/adw-1/node_modules/@girs/gtk-4.0/gtk-4.0-import.d.ts(6,9):
+  error TS2717: Subsequent property declarations must have the same type.
+  Property 'Gtk' must be of type 'typeof Gtk', but here has type 'typeof Gtk'.
+```
+
+Two copies of one namespace are not a version skew; they are two `declare module 'gi://Gtk'`
+blocks, and the second one poisons the first. Carets collapse them to one copy. Exact pins make
+that collapse impossible by construction, in exchange for protection against a window that should
+not exist in the first place.
+
+**Decision: carets stay. The order closes the window.** That is sufficient, and not only for
+consumers tracking the newest set: with a topological order, every dependency of a package is
+resolvable at the instant the package appears, so no range — caret, tilde or exact — can point at
+something that is not there. Exact pins would have narrowed the blast radius of a defect; the
+order removes the defect. And the gate is what keeps the order honest, because an order that is
+right today and unchecked stops being right the first time someone changes how packages are
+collected.
+
+`--depVersionFormat=exact` remains available for a consumer who wants a frozen set, and
+`--bundle` is the supported way to get one that cannot skew at all (see below).
+
+## The SDK channel bundles are one package, and order does not apply
+
+`ts-for-gir generate --bundle @girs/sdk-gnome-50` emits the whole GIR set of a Flatpak SDK as ONE
+self-contained package whose namespaces are subpaths of itself. Measured on the published
+artefact: `npm view @girs/sdk-gnome-50 dependencies` is empty — a bundle declares no `@girs/*`
+sibling, so its publish plan is a single group and the ordering defect cannot reach it.
+
+The closure gate still runs for the bundles, and it earns its place there for the other reason:
+`@girs/sdk-gnome-master@4.7.0` was published, listed by `npm view` with an attestation, and
+answered `E404` to `npm install` — a manifest without a tarball. The final install probe is what
+sees that.
+
+## Running the checks by hand
+
+In [gjsify/types](https://github.com/gjsify/types), `.github/release-script/`:
+
+```bash
+npm ci
+npm run check          # type-check the publisher
+npm test               # the plan and the gate, against the recorded v4.9.0 graph
+npm run test:e2e       # the whole publisher against a throwaway Verdaccio
+```
+
+To ask whether what is on the registry right now resolves — after an interrupted release, or when
+a consumer reports a `notarget` and nobody knows which repository the cause is in:
+
+```bash
+node --experimental-strip-types --experimental-transform-types --no-warnings \
+  .github/release-script/src/index.ts --verify-only
+```
+
+## The workspace-local publish path
+
+`gjsify run publish:types` in this repository publishes the `types-dev` workspaces and is a manual
+escape hatch, not the release path — CI publishes from gjsify/types. It has no closure gate. Add
+`-t` (`gjsify foreach --topological`) before using it on anything that matters, and prefer
+`--verify-only` above afterwards.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -22,8 +22,12 @@ sorted nor topological. Measured afterwards from the registry's own `time` maps:
 | first package published | `@girs/abi-3.0`, 2026-09-10 22:15:33Z |
 | last package published | `@girs/xkl-1.0`, 2026-09-11 00:23:15Z |
 | length of the sweep | 128 minutes |
-| published before something they depend on existed | **508 of 716** |
+| published before something they depend on existed | **513 of 716** |
 | worst case | `@girs/abi-3.0` waited 125 min for `@girs/xlib-2.0` |
+
+(Reproducible: `npm view @girs/<name> time --json` for each of the 716, counting a package whose
+own `4.9.0` stamp precedes that of one of its dependencies. 513 raw; 5 of them are members of the
+cycle below, which no order can avoid, and the other 508 are the defect.)
 
 gjsify's e2e legs went red twice inside that window with
 
@@ -44,7 +48,8 @@ Diagnosis cost more than the bug.
    naming the package, the dependency and the range.
 
 Plus a real `npm install` of the whole published set into an empty directory at the end, which is
-the only check that also proves the tarballs exist. Measured: 5.5 minutes and 225 MB for the full
+the only check that also proves the tarballs exist. Measured in
+[gjsify/types#16](https://github.com/gjsify/types/pull/16): 5.5 minutes and 225 MB for the full
 716-package set on a cold cache.
 
 ### The graph has a cycle, and it is six namespaces wide
@@ -68,13 +73,16 @@ component is six wide, so the real number for that sample is 7. A hand-written e
 five packages wrong on the only cycle this graph has.
 
 **What is left after the fix.** npm has no atomic multi-package publish, so the cycle keeps a
-window of its own: the six go out one after another as the first group, and the first of them
-names the last. At v4.9.0's observed pace (127.7 min / 716 = 10.7 s per package) that is
+window of its own: the six go out one after another as the first group, and whichever goes first
+names members that are not there yet. How many of the six do depends on the order inside the
+group — two at best (`gjs`, `glib-2.0`, `gobject-2.0`, `cairo-1.0`, `gmodule-2.0`, `gio-2.0`;
+brute-forced over all 720 orders of the v4.9.0 edges), five at worst, and v4.9.0's `readdir`
+order hit five. At v4.9.0's observed pace (127.7 min / 716 = 10.7 s per package) that is
 
 | | before | after |
 |---|---|---|
-| packages published with an incomplete closure | 508 | 6 |
-| how long | 128 min | ~54 s |
+| packages published with an incomplete closure | 513 | 2–5 |
+| how long | 128 min | ≤ 54 s |
 
 and it is the remainder, not an oversight: no order can shorten it, and the gate exempts it on
 purpose. Everything outside the cycle — the other 710 packages — has no window at all.
@@ -143,6 +151,14 @@ sees that.
 
 ## Running the checks by hand
 
+Here, against a generated tree — the build-time half. It is part of `gjsify run check`, and CI
+runs it again in `build-validate` on the tree `build:types` has just written:
+
+```bash
+gjsify run check:closure                                                 # ./types-dev
+node --no-warnings scripts/check-dependency-closure.mjs ./types-release  # any tree
+```
+
 In [gjsify/types](https://github.com/gjsify/types), `.github/release-script/`:
 
 ```bash
@@ -166,6 +182,11 @@ node --experimental-strip-types --experimental-transform-types --no-warnings \
 escape hatch, not the release path — CI publishes from gjsify/types — and it has **neither half**:
 no topological order and no closure gate, so it can reproduce the v4.9.0 window on its own.
 
-`gjsify foreach` does have `-t` / `--topological`, but whether it can order a graph with a cycle in
-it has not been measured here, and this graph has one. So: run `--verify-only` against the registry
-afterwards, and treat a green sweep as unproven until it does.
+`gjsify foreach` does have `-t` / `--topological`, and it cannot order this graph. Measured
+2026-09-11 over the 703 `types-dev` workspaces: with `-t`, `@girs/gtk-4.0` started before the
+`@girs/pango-1.0` it depends on, and the start order of the whole set violated 3019 dependency
+edges — `@gjsify/workspace` counts only `workspace:`-protocol specs as edges (`graph.ts`), and the
+committed tree declares carets, so `-t` sees no graph at all. A tree regenerated with
+`--workspace=true` does declare `workspace:^`, and there the same ordering code refuses a cycle
+outright (`dependency cycle detected`) — and this graph has one. So: run `--verify-only` against
+the registry afterwards, and treat a green sweep as unproven until it does.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -150,7 +150,10 @@ node --experimental-strip-types --experimental-transform-types --no-warnings \
 
 ## The workspace-local publish path
 
-`gjsify run publish:types` in this repository publishes the `types-dev` workspaces and is a manual
-escape hatch, not the release path — CI publishes from gjsify/types. It has no closure gate. Add
-`-t` (`gjsify foreach --topological`) before using it on anything that matters, and prefer
-`--verify-only` above afterwards.
+`gjsify run publish:types` in this repository publishes the `types-dev` workspaces. It is a manual
+escape hatch, not the release path — CI publishes from gjsify/types — and it has **neither half**:
+no topological order and no closure gate, so it can reproduce the v4.9.0 window on its own.
+
+`gjsify foreach` does have `-t` / `--topological`, but whether it can order a graph with a cycle in
+it has not been measured here, and this graph has one. So: run `--verify-only` against the registry
+afterwards, and treat a green sweep as unproven until it does.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -111,7 +111,9 @@ Measured with `npm install` and `tsc 5.9.3`:
 | `node_modules` | 16 MB | 23 MB |
 | TypeScript errors | **0** | **5** |
 
-The five are the failure this project already has a number for — [#431](https://github.com/gjsify/ts-for-gir/issues/431):
+The five are the defect this project already has a number for — [#431](https://github.com/gjsify/ts-for-gir/issues/431),
+which hit the same duplicate through `@girs/gjs` and reported it as `TS2345`, two incompatible
+`GObject.Object` types. Here it surfaces on Gtk instead:
 
 ```
 node_modules/@girs/adw-1/node_modules/@girs/gtk-4.0/gtk-4.0-ambient.d.ts(4,20):
@@ -147,7 +149,8 @@ sibling, so its publish plan is a single group and the ordering defect cannot re
 The closure gate still runs for the bundles, and it earns its place there for the other reason:
 `@girs/sdk-gnome-master@4.7.0` was published, listed by `npm view` with an attestation, and
 answered `E404` to `npm install` — a manifest without a tarball. The final install probe is what
-sees that.
+sees that. That version has a tarball again since, so the case no longer reproduces; it is kept
+here because nothing except an actual install would have caught it while it was true.
 
 ## Running the checks by hand
 
@@ -183,10 +186,14 @@ escape hatch, not the release path — CI publishes from gjsify/types — and it
 no topological order and no closure gate, so it can reproduce the v4.9.0 window on its own.
 
 `gjsify foreach` does have `-t` / `--topological`, and it cannot order this graph. Measured
-2026-09-11 over the 703 `types-dev` workspaces: with `-t`, `@girs/gtk-4.0` started before the
-`@girs/pango-1.0` it depends on, and the start order of the whole set violated 3019 dependency
-edges — `@gjsify/workspace` counts only `workspace:`-protocol specs as edges (`graph.ts`), and the
-committed tree declares carets, so `-t` sees no graph at all. A tree regenerated with
-`--workspace=true` does declare `workspace:^`, and there the same ordering code refuses a cycle
-outright (`dependency cycle detected`) — and this graph has one. So: run `--verify-only` against
-the registry afterwards, and treat a green sweep as unproven until it does.
+2026-09-11 over the 703 `types-dev` workspaces: with `-t`, `@girs/gtk-4.0` started 166 places
+before the `@girs/pango-1.0` it depends on, and the start order of the whole set violated 3030 of
+the 7428 `@girs` edges that tree declares — `@gjsify/workspace` counts only `workspace:`-protocol
+specs as edges (`graph.ts`), and the committed tree declares carets, so `-t` sees no graph at all.
+The order it returns is plain alphabetical, which is why the number is reproducible rather than a
+property of one run: sort the 703 package names and count the edges pointing forwards.
+
+A tree regenerated with `--workspace=true` does declare `workspace:^`, and there the same ordering
+code refuses a cycle outright (`dependency cycle detected`) — and this graph has one. So: run
+`--verify-only` against the registry afterwards, and treat a green sweep as unproven until it
+does.

--- a/README.md
+++ b/README.md
@@ -164,5 +164,7 @@ gjsify run build:doc            # build HTML docs into ./docs
 - [CLI Documentation](/packages/cli/README.md)
 - [Using ts-for-gir as a library](/packages/lib/README.md#using-ts-for-gir-as-a-library): building
   your own TSX or framework types from GIR, and which of the three routes needs no library at all
+- [Publishing `@girs/*`](/PUBLISHING.md): how a 716-package set is released, why sibling ranges
+  are carets, and the ordering defect that made v4.9.0 uninstallable for 128 minutes
 - [gjsify/types](https://github.com/gjsify/types): pre-generated NPM packages
 - [gjsify/gnome-shell](https://github.com/gjsify/gnome-shell): hand-written Shell Extension types

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ gjsify run build:doc            # build HTML docs into ./docs
 - [Using ts-for-gir as a library](/packages/lib/README.md#using-ts-for-gir-as-a-library): building
   your own TSX or framework types from GIR, and which of the three routes needs no library at all
 - [Publishing `@girs/*`](/PUBLISHING.md): how a 716-package set is released, why sibling ranges
-  are carets, and the ordering defect that made v4.9.0 uninstallable for 128 minutes
+  are carets, and the ordering defect that left 513 of v4.9.0's 716 packages uninstallable for
+  up to two hours
 - [gjsify/types](https://github.com/gjsify/types): pre-generated NPM packages
 - [gjsify/gnome-shell](https://github.com/gjsify/gnome-shell): hand-written Shell Extension types

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "check:pm": "node --no-warnings scripts/check-package-manager.mjs",
     "check:prereqs": "node --no-warnings scripts/check-workflow-prereqs.mjs",
     "check:docs": "node --no-warnings scripts/check-readme-examples.mjs",
+    "check:closure": "node --no-warnings scripts/check-dependency-closure.mjs",
     "check": "gjsify run check:lint && gjsify run check:app && gjsify run check:girs && gjsify run check:pm && gjsify run check:prereqs && gjsify run check:docs",
     "update:submodules": "git submodule foreach git pull",
     "update:packages": "gjsify upgrade --latest",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "check:prereqs": "node --no-warnings scripts/check-workflow-prereqs.mjs",
     "check:docs": "node --no-warnings scripts/check-readme-examples.mjs",
     "check:closure": "node --no-warnings scripts/check-dependency-closure.mjs",
-    "check": "gjsify run check:lint && gjsify run check:app && gjsify run check:girs && gjsify run check:pm && gjsify run check:prereqs && gjsify run check:docs",
+    "check": "gjsify run check:lint && gjsify run check:app && gjsify run check:girs && gjsify run check:pm && gjsify run check:prereqs && gjsify run check:docs && gjsify run check:closure",
     "update:submodules": "git submodule foreach git pull",
     "update:packages": "gjsify upgrade --latest",
     "update": "gjsify run update:submodules && gjsify run update:packages",

--- a/scripts/check-dependency-closure.mjs
+++ b/scripts/check-dependency-closure.mjs
@@ -21,6 +21,7 @@
 //
 // Usage: node --no-warnings scripts/check-dependency-closure.mjs [dir]   (default: ./types-dev)
 
+import { spawnSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -32,6 +33,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const RUNTIME_FIELDS = ["dependencies", "peerDependencies", "optionalDependencies"];
 
@@ -330,6 +332,9 @@ const RANGE_VECTORS = [
 
 const SILENT = { log: () => {}, error: () => {} };
 
+/** Set in the child spawned below, so it runs the check instead of spawning a child of its own. */
+const SELFTEST_CHILD = "GIRS_CLOSURE_SELFTEST_CHILD";
+
 /**
  * Synthetic trees on disk, run through the REAL reader and the REAL decision, carrying every
  * finding this script can make and every field it claims to read: dangling edges reached through
@@ -417,6 +422,25 @@ function syntheticTreeFailures() {
     if (code(join(root, "not-generated")) !== 1) {
       failures.push("an unreadable directory must exit non-zero");
     }
+    // `checkTree` RETURNING 1 and the PROCESS exiting 1 are two different facts, and the line that
+    // joins them is unreachable from here: running it would end this run. So prove it once from
+    // outside -- one child, pointed at the broken tree above, which has to come back non-zero AND
+    // say why. Deleting that line leaves a script that still prints every finding and exits 0,
+    // which is the quietest way this whole file could fail. The child sees SELFTEST_CHILD and
+    // skips this branch, so the spawn cannot recurse.
+    if (!process.env[SELFTEST_CHILD]) {
+      const child = spawnSync(
+        process.execPath,
+        ["--no-warnings", fileURLToPath(import.meta.url), broken],
+        { encoding: "utf8", env: { ...process.env, [SELFTEST_CHILD]: "1" } },
+      );
+      if (child.error) {
+        failures.push(`could not spawn the exit-code child: ${child.error.message}`);
+      } else if (child.status !== 1 || !child.stderr.includes("finding(s)")) {
+        const saw = `exit ${child.status}, signal ${child.signal}`;
+        failures.push(`a child over a broken tree must exit 1 naming its findings; saw ${saw}`);
+      }
+    }
     return failures;
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -436,7 +460,11 @@ if (selfTestFailures.length > 0) {
 console.log(
   `🧪 closure self-test green — ${RANGE_VECTORS.length} range vectors; two synthetic trees: ` +
     "5 broken edges caught across all three runtime fields, 3 unreadable manifests named, " +
-    "1 dev-only edge ignored, 1 legal cycle left alone, and the exit code checked both ways",
+    "1 dev-only edge ignored, 1 legal cycle left alone, the exit code checked both ways" +
+    // The child skips the spawn, so it must not print the claim the spawn earns.
+    (process.env[SELFTEST_CHILD]
+      ? " — and this run IS that child"
+      : ", and one child proving a broken tree really does exit non-zero"),
 );
 
 // --- The tree ----------------------------------------------------------------

--- a/scripts/check-dependency-closure.mjs
+++ b/scripts/check-dependency-closure.mjs
@@ -229,6 +229,71 @@ export function cycles(packages) {
   return state.found;
 }
 
+// --- Deciding about one tree ------------------------------------------------
+
+const DETAIL = {
+  dangling: () => "no package in this tree provides it",
+  "unknown-range": () => "range shape not recognised — teach `satisfied()` or fix the generator",
+  unsatisfied: (problem) => `the tree has ${problem.have}`,
+};
+
+/** What was read, and what the shape of the graph means for publishing it. */
+function reportShape(tree, dir, io) {
+  io.log(`📦 ${dir}: ${tree.packages.size} packages`);
+  if (tree.skipped.length > 0) {
+    io.log(`   skipped ${tree.skipped.length} without a package.json: ${tree.skipped.join(", ")}`);
+  }
+  const found = cycles(tree.packages);
+  for (const component of found) {
+    io.log(`🔁 dependency cycle (${component.length}): ${component.join(", ")}`);
+  }
+  io.log(
+    found.length === 0
+      ? "   no cycles — the set can be published one package at a time"
+      : "   cycles publish as one group; see PUBLISHING.md",
+  );
+}
+
+/**
+ * Read one tree and answer the process exit code: 0 installable as published, 1 not.
+ *
+ * It RETURNS the code instead of exiting, because the decision is the half a self-test that only
+ * calls the pure helpers can never reach -- `satisfied()` can be perfect while the script still
+ * exits 0 on a tree full of findings, and that is the failure this whole file exists to prevent.
+ * @param {{ log: (line: string) => void, error: (line: string) => void }} io
+ */
+export function checkTree(dir, io) {
+  let tree;
+  try {
+    tree = readTree(dir);
+  } catch (error) {
+    io.error(`❌ cannot read ${dir}: ${error.message}`);
+    io.error("   Generate the types first: gjsify run build:types");
+    return 1;
+  }
+  for (const broken of tree.broken) io.error(`❌ ${broken}`);
+  if (tree.packages.size === 0) {
+    // An empty tree satisfies every assertion below, which is the classic green that checked
+    // nothing. The submodule is probably not initialised.
+    io.error(`❌ ${dir} holds no packages — nothing was checked.`);
+    io.error("   git submodule update --init types-dev && gjsify run build:types");
+    return 1;
+  }
+  reportShape(tree, dir, io);
+  const problems = closureProblems(tree.packages);
+  for (const problem of problems) {
+    const edge = `${problem.package} declares ${problem.dependency}@${problem.range}`;
+    io.error(`❌ ${edge} — ${DETAIL[problem.kind](problem)}`);
+  }
+  const findings = problems.length + tree.broken.length;
+  if (findings === 0) {
+    io.log(`✅ every @girs dependency resolves inside ${dir}`);
+    return 0;
+  }
+  io.error(`\n${findings} finding(s): ${dir} could not be installed as published.`);
+  return 1;
+}
+
 // --- SELF-TEST FIRST: a check that cannot go red is worse than no check. -----
 
 /** `[version, range, expected]` -- `null` is "refused". Cross-checked against npm's `semver`. */
@@ -256,50 +321,85 @@ const RANGE_VECTORS = [
   ["4.9.0", "4.x", null],
   ["4.9.0", "^4.9", null], // partial: not a shape the generator writes
   ["4.9.0", "latest", null],
+  // an alias spec: refused, and it also proves `workspace:` is matched as a PREFIX, not searched
+  // for anywhere in the string
+  ["4.9.0", "npm:@girs/workspace-1.0@4.9.0", null],
   ["4.9.0", "", null],
   ["v4.9.0", "^4.9.0", null], // the version side is parsed just as strictly
 ];
 
+const SILENT = { log: () => {}, error: () => {} };
+
 /**
- * One synthetic tree on disk, run through the REAL reader, carrying every finding this script can
- * make: a dangling edge, an unsatisfied range, a corrupt manifest, a directory that is not a
- * package -- and a legal cycle, which must come back as a cycle and not as a problem.
+ * Synthetic trees on disk, run through the REAL reader and the REAL decision, carrying every
+ * finding this script can make and every field it claims to read: dangling edges reached through
+ * each of the three runtime fields, an unsatisfied range, a corrupt manifest, a manifest with no
+ * name, two directories claiming one name, a directory that is not a package -- plus a legal
+ * cycle, which must come back as a cycle and not as a problem, and a dev-only dangling edge,
+ * which must not come back at all: `devDependencies` do not travel with a published package.
  */
 function syntheticTreeFailures() {
-  const dir = mkdtempSync(join(tmpdir(), "girs-closure-selftest-"));
-  const write = (name, manifest) => {
+  const root = mkdtempSync(join(tmpdir(), "girs-closure-selftest-"));
+  const broken = join(root, "broken");
+  const healthy = join(root, "healthy");
+  const write = (dir, name, manifest) => {
     mkdirSync(join(dir, name), { recursive: true });
     writeFileSync(join(dir, name, "package.json"), manifest);
   };
-  const manifest = (name, dependencies) =>
-    JSON.stringify({ name: `@girs/${name}`, version: "4.9.0", dependencies });
+  const manifest = (name, fields) =>
+    JSON.stringify({ name: `@girs/${name}`, version: "4.9.0", ...fields });
+  const deps = (dependencies) => ({ dependencies });
   try {
-    write("glib-2.0", manifest("glib-2.0", { "@girs/gobject-2.0": "^4.9.0" }));
-    write("gobject-2.0", manifest("gobject-2.0", { "@girs/glib-2.0": "^4.9.0" }));
+    write(broken, "glib-2.0", manifest("glib-2.0", deps({ "@girs/gobject-2.0": "^4.9.0" })));
+    write(broken, "gobject-2.0", manifest("gobject-2.0", deps({ "@girs/glib-2.0": "^4.9.0" })));
     // dangling: nothing emits @girs/pango-1.0 in this tree
-    write(
-      "gtk-4.0",
-      manifest("gtk-4.0", { "@girs/pango-1.0": "^4.9.0", "@girs/glib-2.0": "^4.9.0" }),
-    );
+    const gtk = { "@girs/pango-1.0": "^4.9.0", "@girs/glib-2.0": "^4.9.0" };
+    write(broken, "gtk-4.0", manifest("gtk-4.0", deps(gtk)));
     // unsatisfied: gtk-4.0 is there, at 4.9.0, and ^4.10.0 does not accept it
-    write("adw-1", manifest("adw-1", { "@girs/gtk-4.0": "^4.10.0" }));
-    write("gsk-4.0", "{ not json");
-    mkdirSync(join(dir, "sdk"));
+    write(broken, "adw-1", manifest("adw-1", deps({ "@girs/gtk-4.0": "^4.10.0" })));
+    // a shape `satisfied()` does not decide must become a FINDING, not a pass: refusing it in the
+    // predicate is only half the claim, the gate has to carry it out to the exit code
+    write(broken, "gdkpixbuf-2.0", manifest("gdkpixbuf-2.0", deps({ "@girs/glib-2.0": "~4.9.0" })));
+    // the other two runtime fields reach the registry too, so they are read and must be caught
+    const peer = { peerDependencies: { "@girs/peeronly-1.0": "^4.9.0" } };
+    write(broken, "soup-3.0", manifest("soup-3.0", peer));
+    const optional = { optionalDependencies: { "@girs/optonly-1.0": "^4.9.0" } };
+    write(broken, "gdk-4.0", manifest("gdk-4.0", optional));
+    // ...and devDependencies do NOT: an installed package never pulls them
+    const dev = { devDependencies: { "@girs/devonly-1.0": "^4.9.0" } };
+    write(broken, "gio-2.0", manifest("gio-2.0", dev));
+    write(broken, "gsk-4.0", "{ not json");
+    write(broken, "nameless", JSON.stringify({ version: "4.9.0" }));
+    write(broken, "adw-1-again", manifest("adw-1", deps({ "@girs/gtk-4.0": "^4.10.0" })));
+    mkdirSync(join(broken, "sdk"));
 
-    const tree = readTree(dir);
+    write(healthy, "glib-2.0", manifest("glib-2.0", deps({ "@girs/gobject-2.0": "^4.9.0" })));
+    write(healthy, "gobject-2.0", manifest("gobject-2.0", deps({ "@girs/glib-2.0": "^4.9.0" })));
+
+    const tree = readTree(broken);
     const failures = [];
     const kinds = closureProblems(tree.packages)
       .map((p) => `${p.kind}:${p.package}->${p.dependency}`)
       .sort();
     const expected = [
+      "dangling:@girs/gdk-4.0->@girs/optonly-1.0",
       "dangling:@girs/gtk-4.0->@girs/pango-1.0",
+      "dangling:@girs/soup-3.0->@girs/peeronly-1.0",
+      "unknown-range:@girs/gdkpixbuf-2.0->@girs/glib-2.0",
       "unsatisfied:@girs/adw-1->@girs/gtk-4.0",
     ];
     if (JSON.stringify(kinds) !== JSON.stringify(expected)) {
       failures.push(`problems: expected ${JSON.stringify(expected)}, got ${JSON.stringify(kinds)}`);
     }
-    if (tree.broken.length !== 1 || !tree.broken[0].includes("gsk-4.0")) {
-      failures.push(`a corrupt manifest must be named, got ${JSON.stringify(tree.broken)}`);
+    // Directory order is the filesystem's, so match on what each finding says, not on position.
+    const says = (text) => tree.broken.filter((line) => line.includes(text)).length;
+    if (tree.broken.length !== 3) {
+      failures.push(`expected 3 unreadable manifests, got ${JSON.stringify(tree.broken)}`);
+    }
+    if (says("gsk-4.0") !== 1) failures.push("a corrupt manifest must be named");
+    if (says("has no string") !== 1) failures.push("a manifest without a name must be named");
+    if (says("already declared by another directory") !== 1) {
+      failures.push("two directories claiming one package name must be named");
     }
     if (JSON.stringify(tree.skipped) !== '["sdk"]') {
       failures.push(`a manifest-less directory is skipped, got ${JSON.stringify(tree.skipped)}`);
@@ -308,9 +408,18 @@ function syntheticTreeFailures() {
     if (JSON.stringify(found) !== '[["@girs/glib-2.0","@girs/gobject-2.0"]]') {
       failures.push(`expected the one glib/gobject cycle, got ${JSON.stringify(found)}`);
     }
+    // The exit code itself, in both directions -- a gate that cannot go red, and one that cannot
+    // go green, are the same defect seen from two sides.
+    const code = (dir) => checkTree(dir, SILENT);
+    if (code(broken) !== 1) failures.push("a tree with findings must exit non-zero");
+    if (code(healthy) !== 0) failures.push("a healthy tree must exit zero");
+    if (code(join(broken, "sdk")) !== 1) failures.push("a tree holding no packages must exit non-zero");
+    if (code(join(root, "not-generated")) !== 1) {
+      failures.push("an unreadable directory must exit non-zero");
+    }
     return failures;
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
   }
 }
 
@@ -325,62 +434,14 @@ if (selfTestFailures.length > 0) {
   process.exit(1);
 }
 console.log(
-  `🧪 closure self-test green — ${RANGE_VECTORS.length} range vectors; one synthetic tree: ` +
-    "2 broken edges caught, 1 corrupt manifest named, 1 legal cycle left alone",
+  `🧪 closure self-test green — ${RANGE_VECTORS.length} range vectors; two synthetic trees: ` +
+    "5 broken edges caught across all three runtime fields, 3 unreadable manifests named, " +
+    "1 dev-only edge ignored, 1 legal cycle left alone, and the exit code checked both ways",
 );
 
 // --- The tree ----------------------------------------------------------------
 
-const DETAIL = {
-  dangling: () => "no package in this tree provides it",
-  "unknown-range": () => "range shape not recognised — teach `satisfied()` or fix the generator",
-  unsatisfied: (problem) => `the tree has ${problem.have}`,
-};
-
-const dir = process.argv[2] ?? "./types-dev";
-let tree;
-try {
-  tree = readTree(dir);
-} catch (error) {
-  console.error(`❌ cannot read ${dir}: ${error.message}`);
-  console.error("   Generate the types first: gjsify run build:types");
-  process.exit(1);
-}
-
-for (const broken of tree.broken) console.error(`❌ ${broken}`);
-
-if (tree.packages.size === 0) {
-  // An empty tree passing every assertion is the classic green that checked nothing. The
-  // submodule is probably not initialised.
-  console.error(`❌ ${dir} holds no packages — nothing was checked.`);
-  console.error("   git submodule update --init types-dev && gjsify run build:types");
-  process.exit(1);
-}
-
-console.log(`📦 ${dir}: ${tree.packages.size} packages`);
-if (tree.skipped.length > 0) {
-  const names = tree.skipped.join(", ");
-  console.log(`   skipped ${tree.skipped.length} without a package.json: ${names}`);
-}
-const found = cycles(tree.packages);
-for (const component of found) {
-  console.log(`🔁 dependency cycle (${component.length}): ${component.join(", ")}`);
-}
-console.log(
-  found.length === 0
-    ? "   no cycles — the set can be published one package at a time"
-    : "   cycles publish as one group; see PUBLISHING.md",
-);
-
-const problems = closureProblems(tree.packages);
-for (const problem of problems) {
-  const edge = `${problem.package} declares ${problem.dependency}@${problem.range}`;
-  console.error(`❌ ${edge} — ${DETAIL[problem.kind](problem)}`);
-}
-if (problems.length > 0 || tree.broken.length > 0) {
-  const count = problems.length + tree.broken.length;
-  console.error(`\n${count} finding(s): ${dir} could not be installed as published.`);
-  process.exit(1);
-}
-
-console.log(`✅ every @girs dependency resolves inside ${dir}`);
+// Exit only on a finding, so the exports stay importable on a healthy tree -- the same shape the
+// sibling `scripts/check-*.mjs` use.
+const exitCode = checkTree(process.argv[2] ?? "./types-dev", console);
+if (exitCode !== 0) process.exit(exitCode);

--- a/scripts/check-dependency-closure.mjs
+++ b/scripts/check-dependency-closure.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+// Asserts that a generated `@girs/*` tree is PUBLISHABLE as a set, before anything is published.
+//
+// A generated package declares its siblings as runtime dependencies -- `@girs/adw-1` names
+// fifteen of them. Two things can make that set unresolvable, and neither shows up in a type
+// check, a generated diff, or a green `build:types`:
+//
+//   1. A DANGLING edge: a manifest names a namespace the same run did not emit. The package is
+//      then uninstallable from the day it is published, for everybody, forever -- not for a
+//      window. It happens by configuration: a namespace dropped from `.ts-for-gir.*.rc.js` while
+//      another still imports it.
+//   2. An UNSATISFIABLE range: a sibling is present but at a version the declared range does not
+//      accept, which is what a half-bumped tree looks like.
+//
+// The publisher in gjsify/types has a closure gate that catches both -- but only at publish time,
+// with part of the set already on the registry. This is the same invariant asked at BUILD time,
+// where the answer is free and the fix is a regeneration.
+//
+// See PUBLISHING.md for the incident that produced this family of checks: v4.9.0 went out in
+// `readdir` order and 508 of 716 packages were published before something they depend on existed.
+//
+// Usage: node scripts/check-dependency-closure.mjs [dir]   (default: ./types-dev)
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const RUNTIME_FIELDS = ["dependencies", "peerDependencies", "optionalDependencies"];
+
+/** Read the `package.json` of every direct subdirectory into `{ name, version, dependencies }`. */
+function readTree(dir) {
+  const packages = new Map();
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    let manifest;
+    try {
+      manifest = JSON.parse(readFileSync(join(dir, entry.name, "package.json"), "utf8"));
+    } catch {
+      continue; // not a package directory
+    }
+    if (typeof manifest.name !== "string" || typeof manifest.version !== "string") continue;
+    const dependencies = {};
+    for (const field of RUNTIME_FIELDS) {
+      for (const [name, range] of Object.entries(manifest[field] ?? {})) {
+        if (typeof range === "string") dependencies[name] = range;
+      }
+    }
+    packages.set(manifest.name, { name: manifest.name, version: manifest.version, dependencies });
+  }
+  return packages;
+}
+
+/**
+ * Does `version` satisfy `range`, for the range shapes this generator emits?
+ *
+ * `workspace:` refs never reach a registry and are resolved by the package manager, so they are
+ * out of scope here. Anything else unrecognised is REFUSED rather than assumed to match: a range
+ * shape nobody anticipated must make this loud, not silently green.
+ */
+function satisfied(version, range) {
+  if (range === "*" || range === "" || range.startsWith("workspace:")) return true;
+  if (range === version) return true;
+  if (range.startsWith("^")) {
+    const [wantMajor, wantMinor = "0", wantPatch = "0"] = range.slice(1).split(".");
+    const [haveMajor, haveMinor = "0", havePatch = "0"] = version.split(".");
+    if (wantMajor !== haveMajor) return false;
+    const want = [Number(wantMinor), Number(wantPatch)];
+    const have = [Number(haveMinor), Number(havePatch)];
+    return have[0] > want[0] || (have[0] === want[0] && have[1] >= want[1]);
+  }
+  return null; // "I do not know", which is not the same as "no"
+}
+
+/** The findings, as data, so the self-test can run the real thing. */
+export function closureProblems(packages) {
+  const problems = [];
+  for (const pkg of packages.values()) {
+    for (const [dep, range] of Object.entries(pkg.dependencies)) {
+      if (!dep.startsWith("@girs/")) continue;
+      const sibling = packages.get(dep);
+      if (!sibling) {
+        problems.push({ kind: "dangling", package: pkg.name, dependency: dep, range });
+        continue;
+      }
+      const ok = satisfied(sibling.version, range);
+      if (ok === null) {
+        problems.push({ kind: "unknown-range", package: pkg.name, dependency: dep, range });
+      } else if (!ok) {
+        problems.push({ kind: "unsatisfied", package: pkg.name, dependency: dep, range, have: sibling.version });
+      }
+    }
+  }
+  return problems;
+}
+
+/** Strongly connected components (Tarjan, iterative) -- reported, never assumed away. */
+export function cycles(packages) {
+  const graph = new Map(
+    [...packages.values()].map((pkg) => [
+      pkg.name,
+      new Set(Object.keys(pkg.dependencies).filter((d) => d !== pkg.name && packages.has(d))),
+    ]),
+  );
+  const index = new Map();
+  const low = new Map();
+  const onStack = new Set();
+  const stack = [];
+  const out = [];
+  let counter = 0;
+
+  for (const root of graph.keys()) {
+    if (index.has(root)) continue;
+    const work = [{ node: root, edges: [...graph.get(root)], cursor: 0 }];
+    index.set(root, counter);
+    low.set(root, counter++);
+    stack.push(root);
+    onStack.add(root);
+    while (work.length > 0) {
+      const frame = work.at(-1);
+      if (frame.cursor < frame.edges.length) {
+        const next = frame.edges[frame.cursor++];
+        if (!index.has(next)) {
+          index.set(next, counter);
+          low.set(next, counter++);
+          stack.push(next);
+          onStack.add(next);
+          work.push({ node: next, edges: [...graph.get(next)], cursor: 0 });
+        } else if (onStack.has(next)) {
+          low.set(frame.node, Math.min(low.get(frame.node), index.get(next)));
+        }
+        continue;
+      }
+      work.pop();
+      if (low.get(frame.node) === index.get(frame.node)) {
+        const component = [];
+        let member;
+        do {
+          member = stack.pop();
+          onStack.delete(member);
+          component.push(member);
+        } while (member !== frame.node);
+        if (component.length > 1) out.push(component.sort());
+      }
+      const parent = work.at(-1);
+      if (parent) low.set(parent.node, Math.min(low.get(parent.node), low.get(frame.node)));
+    }
+  }
+  return out;
+}
+
+/**
+ * A check that has never been red is not a check.
+ *
+ * Both failure modes are synthesised on disk and run through the REAL reader, so the thing under
+ * test is the one that runs in CI -- not a hand-built object that skips `readTree`.
+ */
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), "girs-closure-selftest-"));
+  const write = (name, manifest) => {
+    mkdirSync(join(dir, name), { recursive: true });
+    writeFileSync(join(dir, name, "package.json"), JSON.stringify(manifest));
+  };
+  try {
+    write("glib-2.0", { name: "@girs/glib-2.0", version: "4.9.0", dependencies: { "@girs/gobject-2.0": "^4.9.0" } });
+    write("gobject-2.0", { name: "@girs/gobject-2.0", version: "4.9.0", dependencies: { "@girs/glib-2.0": "^4.9.0" } });
+    write("gtk-4.0", {
+      name: "@girs/gtk-4.0",
+      version: "4.9.0",
+      // dangling: nothing emits @girs/pango-1.0 in this tree
+      dependencies: { "@girs/pango-1.0": "^4.9.0", "@girs/glib-2.0": "^4.9.0" },
+    });
+    write("adw-1", {
+      name: "@girs/adw-1",
+      version: "4.9.0",
+      // unsatisfied: gtk-4.0 is there, at 4.9.0, and ^4.10.0 does not accept it
+      dependencies: { "@girs/gtk-4.0": "^4.10.0" },
+    });
+
+    const tree = readTree(dir);
+    const problems = closureProblems(tree);
+    const kinds = problems.map((p) => `${p.kind}:${p.package}->${p.dependency}`).sort();
+    const expected = ["dangling:@girs/gtk-4.0->@girs/pango-1.0", "unsatisfied:@girs/adw-1->@girs/gtk-4.0"];
+    if (JSON.stringify(kinds) !== JSON.stringify(expected)) {
+      throw new Error(`self-test: expected ${JSON.stringify(expected)}, got ${JSON.stringify(kinds)}`);
+    }
+    // …and the mutual glib/gobject pair is a CYCLE, not a problem: it is legal, and a check that
+    // flagged it would be red on every correct tree.
+    const found = cycles(tree);
+    if (found.length !== 1 || found[0].length !== 2) {
+      throw new Error(`self-test: expected one 2-member cycle, got ${JSON.stringify(found)}`);
+    }
+    if (problems.some((p) => p.dependency === "@girs/gobject-2.0" || p.dependency === "@girs/glib-2.0")) {
+      throw new Error("self-test: a legal cycle was reported as a problem");
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  console.log("🧪 closure self-test green — 2 broken trees caught, 1 legal cycle left alone");
+}
+
+selfTest();
+
+const dir = process.argv[2] ?? "./types-dev";
+let tree;
+try {
+  tree = readTree(dir);
+} catch (error) {
+  console.error(`❌ cannot read ${dir}: ${error.message}`);
+  console.error("   Generate the types first: gjsify run build:types");
+  process.exit(1);
+}
+
+if (tree.size === 0) {
+  // An empty tree passing every assertion is the classic green that checked nothing. The
+  // submodule is probably not initialised.
+  console.error(`❌ ${dir} holds no packages — nothing was checked.`);
+  console.error("   git submodule update --init types-dev && gjsify run build:types");
+  process.exit(1);
+}
+
+const problems = closureProblems(tree);
+const found = cycles(tree);
+
+console.log(`📦 ${dir}: ${tree.size} packages`);
+for (const component of found) {
+  console.log(`🔁 dependency cycle (${component.length}): ${component.join(", ")}`);
+}
+console.log(
+  found.length === 0
+    ? "   no cycles — the set can be published one package at a time"
+    : "   cycles publish as one group; see PUBLISHING.md",
+);
+
+if (problems.length > 0) {
+  for (const problem of problems) {
+    const detail =
+      problem.kind === "dangling"
+        ? "no package in this tree provides it"
+        : problem.kind === "unknown-range"
+          ? "range shape not recognised — teach `satisfied()` or fix the generator"
+          : `the tree has ${problem.have}`;
+    console.error(`❌ ${problem.package} declares ${problem.dependency}@${problem.range} — ${detail}`);
+  }
+  console.error(`\n${problems.length} package(s) in ${dir} could not be installed as published.`);
+  process.exit(1);
+}
+
+console.log(`✅ every @girs dependency resolves inside ${dir}`);

--- a/scripts/check-dependency-closure.mjs
+++ b/scripts/check-dependency-closure.mjs
@@ -17,188 +17,325 @@
 // where the answer is free and the fix is a regeneration.
 //
 // See PUBLISHING.md for the incident that produced this family of checks: v4.9.0 went out in
-// `readdir` order and 508 of 716 packages were published before something they depend on existed.
+// `readdir` order and 513 of 716 packages were published before something they depend on existed.
 //
-// Usage: node scripts/check-dependency-closure.mjs [dir]   (default: ./types-dev)
+// Usage: node --no-warnings scripts/check-dependency-closure.mjs [dir]   (default: ./types-dev)
 
-import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const RUNTIME_FIELDS = ["dependencies", "peerDependencies", "optionalDependencies"];
 
-/** Read the `package.json` of every direct subdirectory into `{ name, version, dependencies }`. */
-function readTree(dir) {
-  const packages = new Map();
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
-    let manifest;
-    try {
-      manifest = JSON.parse(readFileSync(join(dir, entry.name, "package.json"), "utf8"));
-    } catch {
-      continue; // not a package directory
-    }
-    if (typeof manifest.name !== "string" || typeof manifest.version !== "string") continue;
-    const dependencies = {};
-    for (const field of RUNTIME_FIELDS) {
-      for (const [name, range] of Object.entries(manifest[field] ?? {})) {
-        if (typeof range === "string") dependencies[name] = range;
-      }
-    }
-    packages.set(manifest.name, { name: manifest.name, version: manifest.version, dependencies });
+/** `major.minor.patch` plus an optional prerelease: the one version shape the generator writes. */
+const VERSION = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+
+// --- Reading the tree --------------------------------------------------------
+
+/**
+ * One manifest as `{ name, version, dependencies }`, or the reason it cannot be one. A manifest
+ * that does not parse is a finding in its own right: silently dropping it would turn "this file
+ * is corrupt" into "no package provides it" -- or into nothing at all, when nobody depends on it.
+ */
+export function parseManifest(text, where) {
+  let manifest;
+  try {
+    manifest = JSON.parse(text);
+  } catch (error) {
+    return { broken: `${where}: ${error.message}` };
   }
-  return packages;
+  if (typeof manifest.name !== "string" || typeof manifest.version !== "string") {
+    return { broken: `${where}: has no string \`name\` and \`version\`` };
+  }
+  const dependencies = {};
+  for (const field of RUNTIME_FIELDS) {
+    for (const [name, range] of Object.entries(manifest[field] ?? {})) {
+      if (typeof range === "string") dependencies[name] = range;
+    }
+  }
+  return { pkg: { name: manifest.name, version: manifest.version, dependencies } };
 }
 
 /**
- * Does `version` satisfy `range`, for the range shapes this generator emits?
- *
- * `workspace:` refs never reach a registry and are resolved by the package manager, so they are
- * out of scope here. Anything else unrecognised is REFUSED rather than assumed to match: a range
- * shape nobody anticipated must make this loud, not silently green.
+ * Every direct subdirectory holding a `package.json`. A directory without one is not a package
+ * (`types-release/sdk/`, a leftover `node_modules/`) and is listed as skipped so the summary
+ * says what was NOT read; a duplicate package name would let one manifest shadow another.
+ * @returns {{ packages: Map<string, object>, skipped: string[], broken: string[] }}
  */
-function satisfied(version, range) {
-  if (range === "*" || range === "" || range.startsWith("workspace:")) return true;
-  if (range === version) return true;
-  if (range.startsWith("^")) {
-    const [wantMajor, wantMinor = "0", wantPatch = "0"] = range.slice(1).split(".");
-    const [haveMajor, haveMinor = "0", havePatch = "0"] = version.split(".");
-    if (wantMajor !== haveMajor) return false;
-    const want = [Number(wantMinor), Number(wantPatch)];
-    const have = [Number(haveMinor), Number(havePatch)];
-    return have[0] > want[0] || (have[0] === want[0] && have[1] >= want[1]);
+export function readTree(dir) {
+  const tree = { packages: new Map(), skipped: [], broken: [] };
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    const where = join(dir, entry.name, "package.json");
+    if (!existsSync(where)) {
+      tree.skipped.push(entry.name);
+      continue;
+    }
+    const { pkg, broken } = parseManifest(readFileSync(where, "utf8"), where);
+    if (broken) {
+      tree.broken.push(broken);
+    } else if (tree.packages.has(pkg.name)) {
+      tree.broken.push(`${where}: \`${pkg.name}\` is already declared by another directory`);
+    } else {
+      tree.packages.set(pkg.name, pkg);
+    }
   }
-  return null; // "I do not know", which is not the same as "no"
+  return tree;
 }
 
-/** The findings, as data, so the self-test can run the real thing. */
+// --- Ranges ------------------------------------------------------------------
+
+/** Parse `major.minor.patch[-pre]`; anything else is `null`. */
+function parseVersion(text) {
+  const match = VERSION.exec(text);
+  if (!match) return null;
+  return { core: match.slice(1, 4).map(Number), prerelease: match[4]?.split(".") ?? [] };
+}
+
+function compareCore(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * semver §11: identifiers compare numerically when both are numbers and by ASCII otherwise, a
+ * number ranks below a word, and a prefix ranks below anything that extends it.
+ */
+function comparePrerelease(a, b) {
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    if (a[i] === undefined) return -1;
+    if (b[i] === undefined) return 1;
+    const [aNumeric, bNumeric] = [/^\d+$/.test(a[i]), /^\d+$/.test(b[i])];
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    if (a[i] === b[i]) continue;
+    if (aNumeric) return Number(a[i]) < Number(b[i]) ? -1 : 1;
+    return a[i] < b[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+function compareVersions(a, b) {
+  const core = compareCore(a.core, b.core);
+  if (core !== 0) return core;
+  // A release outranks every prerelease of the same core.
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    return Math.sign(b.prerelease.length - a.prerelease.length);
+  }
+  return comparePrerelease(a.prerelease, b.prerelease);
+}
+
+/** `^` per npm: the leftmost non-zero component may not change -- `^0.2.3` is `<0.3.0`. */
+function caretUpperBound([major, minor, patch]) {
+  if (major > 0) return [major + 1, 0, 0];
+  if (minor > 0) return [0, minor + 1, 0];
+  return [0, 0, patch + 1];
+}
+
+/**
+ * Does `version` satisfy `range`? Only the four shapes the generator writes are understood
+ * (`createPackageJsonImport` in packages/lib/src/dependency-manager.ts): `workspace:^`, which
+ * never reaches a registry and is resolved by the package manager; `*`; `x.y.z`; and `^x.y.z`.
+ * Anything else -- a tilde, a partial `^4.9`, a `latest` -- is `null`, "I do not know", which
+ * the caller reports rather than assumes: a range shape nobody anticipated must be loud.
+ */
+export function satisfied(version, range) {
+  if (range === "*" || range.startsWith("workspace:")) return true;
+  const have = parseVersion(version);
+  const isCaret = range.startsWith("^");
+  const want = parseVersion(isCaret ? range.slice(1) : range);
+  if (!have || !want) return null;
+  if (!isCaret) return compareVersions(have, want) === 0;
+  // npm admits a prerelease into a range only when the range itself names a prerelease on the
+  // same `major.minor.patch`; `^4.9.0` does not float onto `4.10.0-rc.1`. The generator's choice
+  // of carets rests on exactly that (see the comment above `createPackageJsonImport`).
+  const hasPrerelease = have.prerelease.length > 0;
+  if (hasPrerelease && (want.prerelease.length === 0 || compareCore(have.core, want.core) !== 0)) {
+    return false;
+  }
+  return compareVersions(have, want) >= 0 && compareCore(have.core, caretUpperBound(want.core)) < 0;
+}
+
+// --- The two questions -------------------------------------------------------
+
+/** `null` when the edge resolves inside the tree; otherwise the finding, as data. */
+function edgeProblem(packages, edge) {
+  if (!edge.dependency.startsWith("@girs/")) return null;
+  const sibling = packages.get(edge.dependency);
+  if (!sibling) return { kind: "dangling", ...edge };
+  const ok = satisfied(sibling.version, edge.range);
+  if (ok === null) return { kind: "unknown-range", ...edge };
+  if (!ok) return { kind: "unsatisfied", ...edge, have: sibling.version };
+  return null;
+}
+
+/** Every `@girs/*` edge the tree cannot honour -- as data, so the self-test runs the real thing. */
 export function closureProblems(packages) {
   const problems = [];
   for (const pkg of packages.values()) {
-    for (const [dep, range] of Object.entries(pkg.dependencies)) {
-      if (!dep.startsWith("@girs/")) continue;
-      const sibling = packages.get(dep);
-      if (!sibling) {
-        problems.push({ kind: "dangling", package: pkg.name, dependency: dep, range });
-        continue;
-      }
-      const ok = satisfied(sibling.version, range);
-      if (ok === null) {
-        problems.push({ kind: "unknown-range", package: pkg.name, dependency: dep, range });
-      } else if (!ok) {
-        problems.push({ kind: "unsatisfied", package: pkg.name, dependency: dep, range, have: sibling.version });
-      }
+    for (const [dependency, range] of Object.entries(pkg.dependencies)) {
+      const problem = edgeProblem(packages, { package: pkg.name, dependency, range });
+      if (problem) problems.push(problem);
     }
   }
   return problems;
 }
 
-/** Strongly connected components (Tarjan, iterative) -- reported, never assumed away. */
-export function cycles(packages) {
-  const graph = new Map(
-    [...packages.values()].map((pkg) => [
-      pkg.name,
-      new Set(Object.keys(pkg.dependencies).filter((d) => d !== pkg.name && packages.has(d))),
-    ]),
-  );
-  const index = new Map();
-  const low = new Map();
-  const onStack = new Set();
-  const stack = [];
-  const out = [];
-  let counter = 0;
-
-  for (const root of graph.keys()) {
-    if (index.has(root)) continue;
-    const work = [{ node: root, edges: [...graph.get(root)], cursor: 0 }];
-    index.set(root, counter);
-    low.set(root, counter++);
-    stack.push(root);
-    onStack.add(root);
-    while (work.length > 0) {
-      const frame = work.at(-1);
-      if (frame.cursor < frame.edges.length) {
-        const next = frame.edges[frame.cursor++];
-        if (!index.has(next)) {
-          index.set(next, counter);
-          low.set(next, counter++);
-          stack.push(next);
-          onStack.add(next);
-          work.push({ node: next, edges: [...graph.get(next)], cursor: 0 });
-        } else if (onStack.has(next)) {
-          low.set(frame.node, Math.min(low.get(frame.node), index.get(next)));
-        }
-        continue;
-      }
-      work.pop();
-      if (low.get(frame.node) === index.get(frame.node)) {
-        const component = [];
-        let member;
-        do {
-          member = stack.pop();
-          onStack.delete(member);
-          component.push(member);
-        } while (member !== frame.node);
-        if (component.length > 1) out.push(component.sort());
-      }
-      const parent = work.at(-1);
-      if (parent) low.set(parent.node, Math.min(low.get(parent.node), low.get(frame.node)));
+/** Tarjan's visit. Recursion depth is the longest dependency chain: dozens, in 716 packages. */
+function strongConnect(node, edges, state) {
+  const { index, low, stack, onStack } = state;
+  index.set(node, index.size);
+  low.set(node, index.get(node));
+  stack.push(node);
+  onStack.add(node);
+  for (const next of edges.get(node)) {
+    if (!index.has(next)) {
+      strongConnect(next, edges, state);
+      low.set(node, Math.min(low.get(node), low.get(next)));
+    } else if (onStack.has(next)) {
+      low.set(node, Math.min(low.get(node), index.get(next)));
     }
   }
-  return out;
+  if (low.get(node) !== index.get(node)) return;
+  const component = stack.splice(stack.indexOf(node));
+  for (const member of component) onStack.delete(member);
+  if (component.length > 1) state.found.push(component.sort());
 }
 
 /**
- * A check that has never been red is not a check.
- *
- * Both failure modes are synthesised on disk and run through the REAL reader, so the thing under
- * test is the one that runs in CI -- not a hand-built object that skips `readTree`.
+ * Strongly connected components with more than one member -- reported, never flagged: a cycle
+ * is legal, and it is what forces the publisher to move in groups instead of packages.
  */
-function selfTest() {
+export function cycles(packages) {
+  const edges = new Map(
+    [...packages.values()].map((pkg) => [
+      pkg.name,
+      Object.keys(pkg.dependencies).filter((d) => d !== pkg.name && packages.has(d)),
+    ]),
+  );
+  const state = { index: new Map(), low: new Map(), stack: [], onStack: new Set(), found: [] };
+  for (const name of edges.keys()) {
+    if (!state.index.has(name)) strongConnect(name, edges, state);
+  }
+  return state.found;
+}
+
+// --- SELF-TEST FIRST: a check that cannot go red is worse than no check. -----
+
+/** `[version, range, expected]` -- `null` is "refused". Cross-checked against npm's `semver`. */
+const RANGE_VECTORS = [
+  ["4.9.0", "^4.9.0", true],
+  ["4.10.3", "^4.9.0", true],
+  ["5.0.0", "^4.9.0", false],
+  ["4.8.9", "^4.9.0", false],
+  ["0.2.9", "^0.2.3", true],
+  ["0.3.0", "^0.2.3", false], // caret on 0.x pins the minor
+  ["0.0.4", "^0.0.3", false], // caret on 0.0.x pins the patch
+  ["4.10.0-rc.1", "^4.9.0", false], // a prerelease never satisfies a release caret
+  ["4.9.0", "^4.9.0-rc.1", true],
+  ["4.9.0-rc.1", "^4.9.0-rc.1", true], // an rc tree is uniform and must be green
+  ["4.9.0-rc.2", "^4.9.0-rc.1", true],
+  ["4.9.0-rc.10", "^4.9.0-rc.9", true], // numeric, not lexical
+  ["4.9.0-rc.1", "^4.9.0-rc.2", false],
+  ["4.10.0-rc.1", "^4.9.0-rc.1", false], // prerelease of a DIFFERENT core
+  ["4.9.0", "4.9.0", true],
+  ["4.9.1", "4.9.0", false],
+  ["4.9.0", "*", true],
+  ["4.9.0", "workspace:^", true],
+  ["4.9.0", "~4.9.0", null],
+  ["4.9.0", ">=4.9.0", null],
+  ["4.9.0", "4.x", null],
+  ["4.9.0", "^4.9", null], // partial: not a shape the generator writes
+  ["4.9.0", "latest", null],
+  ["4.9.0", "", null],
+  ["v4.9.0", "^4.9.0", null], // the version side is parsed just as strictly
+];
+
+/**
+ * One synthetic tree on disk, run through the REAL reader, carrying every finding this script can
+ * make: a dangling edge, an unsatisfied range, a corrupt manifest, a directory that is not a
+ * package -- and a legal cycle, which must come back as a cycle and not as a problem.
+ */
+function syntheticTreeFailures() {
   const dir = mkdtempSync(join(tmpdir(), "girs-closure-selftest-"));
   const write = (name, manifest) => {
     mkdirSync(join(dir, name), { recursive: true });
-    writeFileSync(join(dir, name, "package.json"), JSON.stringify(manifest));
+    writeFileSync(join(dir, name, "package.json"), manifest);
   };
+  const manifest = (name, dependencies) =>
+    JSON.stringify({ name: `@girs/${name}`, version: "4.9.0", dependencies });
   try {
-    write("glib-2.0", { name: "@girs/glib-2.0", version: "4.9.0", dependencies: { "@girs/gobject-2.0": "^4.9.0" } });
-    write("gobject-2.0", { name: "@girs/gobject-2.0", version: "4.9.0", dependencies: { "@girs/glib-2.0": "^4.9.0" } });
-    write("gtk-4.0", {
-      name: "@girs/gtk-4.0",
-      version: "4.9.0",
-      // dangling: nothing emits @girs/pango-1.0 in this tree
-      dependencies: { "@girs/pango-1.0": "^4.9.0", "@girs/glib-2.0": "^4.9.0" },
-    });
-    write("adw-1", {
-      name: "@girs/adw-1",
-      version: "4.9.0",
-      // unsatisfied: gtk-4.0 is there, at 4.9.0, and ^4.10.0 does not accept it
-      dependencies: { "@girs/gtk-4.0": "^4.10.0" },
-    });
+    write("glib-2.0", manifest("glib-2.0", { "@girs/gobject-2.0": "^4.9.0" }));
+    write("gobject-2.0", manifest("gobject-2.0", { "@girs/glib-2.0": "^4.9.0" }));
+    // dangling: nothing emits @girs/pango-1.0 in this tree
+    write(
+      "gtk-4.0",
+      manifest("gtk-4.0", { "@girs/pango-1.0": "^4.9.0", "@girs/glib-2.0": "^4.9.0" }),
+    );
+    // unsatisfied: gtk-4.0 is there, at 4.9.0, and ^4.10.0 does not accept it
+    write("adw-1", manifest("adw-1", { "@girs/gtk-4.0": "^4.10.0" }));
+    write("gsk-4.0", "{ not json");
+    mkdirSync(join(dir, "sdk"));
 
     const tree = readTree(dir);
-    const problems = closureProblems(tree);
-    const kinds = problems.map((p) => `${p.kind}:${p.package}->${p.dependency}`).sort();
-    const expected = ["dangling:@girs/gtk-4.0->@girs/pango-1.0", "unsatisfied:@girs/adw-1->@girs/gtk-4.0"];
+    const failures = [];
+    const kinds = closureProblems(tree.packages)
+      .map((p) => `${p.kind}:${p.package}->${p.dependency}`)
+      .sort();
+    const expected = [
+      "dangling:@girs/gtk-4.0->@girs/pango-1.0",
+      "unsatisfied:@girs/adw-1->@girs/gtk-4.0",
+    ];
     if (JSON.stringify(kinds) !== JSON.stringify(expected)) {
-      throw new Error(`self-test: expected ${JSON.stringify(expected)}, got ${JSON.stringify(kinds)}`);
+      failures.push(`problems: expected ${JSON.stringify(expected)}, got ${JSON.stringify(kinds)}`);
     }
-    // …and the mutual glib/gobject pair is a CYCLE, not a problem: it is legal, and a check that
-    // flagged it would be red on every correct tree.
-    const found = cycles(tree);
-    if (found.length !== 1 || found[0].length !== 2) {
-      throw new Error(`self-test: expected one 2-member cycle, got ${JSON.stringify(found)}`);
+    if (tree.broken.length !== 1 || !tree.broken[0].includes("gsk-4.0")) {
+      failures.push(`a corrupt manifest must be named, got ${JSON.stringify(tree.broken)}`);
     }
-    if (problems.some((p) => p.dependency === "@girs/gobject-2.0" || p.dependency === "@girs/glib-2.0")) {
-      throw new Error("self-test: a legal cycle was reported as a problem");
+    if (JSON.stringify(tree.skipped) !== '["sdk"]') {
+      failures.push(`a manifest-less directory is skipped, got ${JSON.stringify(tree.skipped)}`);
     }
+    const found = cycles(tree.packages);
+    if (JSON.stringify(found) !== '[["@girs/glib-2.0","@girs/gobject-2.0"]]') {
+      failures.push(`expected the one glib/gobject cycle, got ${JSON.stringify(found)}`);
+    }
+    return failures;
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
-  console.log("🧪 closure self-test green — 2 broken trees caught, 1 legal cycle left alone");
 }
 
-selfTest();
+const selfTestFailures = RANGE_VECTORS.filter(([v, r, want]) => satisfied(v, r) !== want).map(
+  ([v, r, want]) =>
+    `satisfied(${v}, ${JSON.stringify(r)}): expected ${want}, got ${satisfied(v, r)}`,
+);
+selfTestFailures.push(...syntheticTreeFailures());
+if (selfTestFailures.length > 0) {
+  console.error("check-dependency-closure: SELF-TEST failed — the check itself is broken:");
+  for (const failure of selfTestFailures) console.error(`  - ${failure}`);
+  process.exit(1);
+}
+console.log(
+  `🧪 closure self-test green — ${RANGE_VECTORS.length} range vectors; one synthetic tree: ` +
+    "2 broken edges caught, 1 corrupt manifest named, 1 legal cycle left alone",
+);
+
+// --- The tree ----------------------------------------------------------------
+
+const DETAIL = {
+  dangling: () => "no package in this tree provides it",
+  "unknown-range": () => "range shape not recognised — teach `satisfied()` or fix the generator",
+  unsatisfied: (problem) => `the tree has ${problem.have}`,
+};
 
 const dir = process.argv[2] ?? "./types-dev";
 let tree;
@@ -210,7 +347,9 @@ try {
   process.exit(1);
 }
 
-if (tree.size === 0) {
+for (const broken of tree.broken) console.error(`❌ ${broken}`);
+
+if (tree.packages.size === 0) {
   // An empty tree passing every assertion is the classic green that checked nothing. The
   // submodule is probably not initialised.
   console.error(`❌ ${dir} holds no packages — nothing was checked.`);
@@ -218,10 +357,12 @@ if (tree.size === 0) {
   process.exit(1);
 }
 
-const problems = closureProblems(tree);
-const found = cycles(tree);
-
-console.log(`📦 ${dir}: ${tree.size} packages`);
+console.log(`📦 ${dir}: ${tree.packages.size} packages`);
+if (tree.skipped.length > 0) {
+  const names = tree.skipped.join(", ");
+  console.log(`   skipped ${tree.skipped.length} without a package.json: ${names}`);
+}
+const found = cycles(tree.packages);
 for (const component of found) {
   console.log(`🔁 dependency cycle (${component.length}): ${component.join(", ")}`);
 }
@@ -231,17 +372,14 @@ console.log(
     : "   cycles publish as one group; see PUBLISHING.md",
 );
 
-if (problems.length > 0) {
-  for (const problem of problems) {
-    const detail =
-      problem.kind === "dangling"
-        ? "no package in this tree provides it"
-        : problem.kind === "unknown-range"
-          ? "range shape not recognised — teach `satisfied()` or fix the generator"
-          : `the tree has ${problem.have}`;
-    console.error(`❌ ${problem.package} declares ${problem.dependency}@${problem.range} — ${detail}`);
-  }
-  console.error(`\n${problems.length} package(s) in ${dir} could not be installed as published.`);
+const problems = closureProblems(tree.packages);
+for (const problem of problems) {
+  const edge = `${problem.package} declares ${problem.dependency}@${problem.range}`;
+  console.error(`❌ ${edge} — ${DETAIL[problem.kind](problem)}`);
+}
+if (problems.length > 0 || tree.broken.length > 0) {
+  const count = problems.length + tree.broken.length;
+  console.error(`\n${count} finding(s): ${dir} could not be installed as published.`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Companion to **gjsify/types#16**, which carries the actual publisher fix. This is the half that belongs here: the decision the fix rests on, and the build-time check for the failure the publisher can only see once part of the set is public.

## What went wrong

v4.9.0 published all 716 `@girs/*` packages in `readdir` order. From the registry's own `time` maps: 22:15:33Z → 00:23:15Z, 128 minutes, and **508 of 716 published before something they declare a dependency on existed**. gjsify's e2e legs went red twice with `npm error notarget No matching version found for @girs/pango-1.0@^4.9.0` — an error naming neither the package the consumer asked for nor the repository the cause lives in.

## The decision: carets stay

The obvious alternative was a generator change — emit exact sibling pins instead of `^<version>`, and a consumer pinned to an old release never sees half a set. Measured instead of argued:

```jsonc
{ "@girs/gtk-4.0": "^4.8.0", "@girs/adw-1": "^4.9.0" }   // carets
{ "@girs/gtk-4.0":  "4.8.0", "@girs/adw-1":  "4.9.0" }   // exact
```

| `npm install` + `tsc 5.9.3` | carets | exact |
|---|---|---|
| `@girs/*` installed | 16 | 17 — `@girs/gtk-4.0` twice |
| `node_modules` | 16 MB | 23 MB |
| TypeScript errors | **0** | **5** |

The five are #431: `TS2300 Duplicate identifier 'Gtk40'`, `TS2717 Property 'Gtk' must be of type 'typeof Gtk', but here has type 'typeof Gtk'`. Two copies of a namespace are two `declare module 'gi://Gtk'` blocks, not a version skew.

So carets stay, and the topological publish order closes the window for **every** range shape — with a correct order, every dependency is resolvable at the instant its dependent appears, so no range can point at something that is not there. Exact pins would only have narrowed the blast radius of a defect that should not exist.

`PUBLISHING.md` carries the numbers, the six-member dependency cycle (`cairo-1.0 · gio-2.0 · gjs · glib-2.0 · gmodule-2.0 · gobject-2.0`) that any order has to respect, why the `--bundle` SDK channels are unaffected (`npm view @girs/sdk-gnome-50 dependencies` is empty — measured, not assumed), and how to run the checks by hand.

## The build-time half: `scripts/check-dependency-closure.mjs`

A generated manifest naming a namespace the same run did not emit is uninstallable from the day it ships — for everybody, not for a window. Nothing here could see it: `check:types` and the generated diff both read the tree that is *missing* the dependency, never the declaration that wants it. It happens by configuration, when a namespace leaves `.ts-for-gir.*.rc.js` while another still imports it.

Checks two things, reports a third:

- no dangling `@girs/*` edge
- no range a sibling's own version fails to satisfy
- the strongly connected components, printed — one today, six wide, legal, and explicitly *not* flagged

A range shape it does not recognise is **refused**, not assumed to match. An empty tree is an error, not a pass over nothing. And it self-tests through the real reader on two broken trees plus one legal cycle before it looks at anything real, so it cannot be a check that has never been red:

```
🧪 closure self-test green — 2 broken trees caught, 1 legal cycle left alone
📦 ./types-release: 716 packages
🔁 dependency cycle (6): @girs/cairo-1.0, @girs/gio-2.0, @girs/gjs, @girs/glib-2.0, @girs/gmodule-2.0, @girs/gobject-2.0
✅ every @girs dependency resolves inside ./types-release
```

Wired into the `build-validate` job right after `build:types`, which is the job that already has `types-dev` on disk. `actionlint` clean.

## Not in this PR

The `types-release` submodule pointer. It stays where it is until gjsify/types#16 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4yEeHoGMC4pvbkqxMsYfj